### PR TITLE
fix: Remove code that forces lowercase text in console

### DIFF
--- a/osx/sys_osx.m
+++ b/osx/sys_osx.m
@@ -971,7 +971,7 @@ void	Sys_DoEvents (NSEvent *myEvent, NSEventType myType)
             for (i = 0; i < myKeyboardBufferSize; i++)
             {
                 myCharacter = [myKeyboardBuffer characterAtIndex: i];
-				
+
                 if ((myCharacter & 0xFF00) ==  0xF700)
                 {
                     myCharacter -= 0xF700;
@@ -991,7 +991,7 @@ void	Sys_DoEvents (NSEvent *myEvent, NSEventType myType)
                     if (myFlags & NSNumericPadKeyMask)
                     {
                         myKeyPad = [myEvent keyCode];
-            
+
                         if (myKeyPad < 0x5D && gInNumPadKey[myKeyPad] != 0x00)
                         {
                             Key_Event (gInNumPadKey[myKeyPad], (myType == NSKeyDown));
@@ -1002,7 +1002,10 @@ void	Sys_DoEvents (NSEvent *myEvent, NSEventType myType)
                     {
                       if (Sys_CheckSpecialKeys (myCharacter) == 0)
                       {
-                        Key_Event (myCharacter, (myType == NSKeyDown));
+                        if (myCharacter >= 'A' && myCharacter <= 'Z')
+                          Key_EventEx (tolower(myCharacter), myCharacter, (myType == NSKeyDown));
+                        else
+                          Key_Event (myCharacter, (myType == NSKeyDown));
                       }
                     }
                 }


### PR DESCRIPTION
I was experiencing a strange issue in OSX ezQuake, where I wasn't able to SHOUT AT PEOPLE INGAME. IT WAS REALLY STRANGE.

I had a wee dig about in the code and found this line. From the looks of it it's deliberately converting the text to lowercase, but I can't see why.

Anyway, this works for me and I can't figure out any fallout, so I thought I'd share.

(Background: http://www.quakeworld.nu/forum/viewtopic.php?id=5569)
