### PR TITLE
Bug: don't autoscreenshot if you've only joined

### DIFF
--- a/match_tools.c
+++ b/match_tools.c
@@ -799,6 +799,10 @@ void MT_TakeScreenshot(void) {
 	if (!matchcvars[matchstate.matchtype].autosshot)
 		return;
 
+  // don't bother screen-shotting if we've only just joined
+  if (cl.time < 10)
+    return;
+
 	//make sure there are actually some frags on the board, and somebody besides us
 	have_opponent = false;
 	for (i = 0; i < MAX_CLIENTS; i++) {


### PR DESCRIPTION
Add to the list of autoscreenshot prereqs. If  you've been on the server
less than 10 seconds, don't autoscreenshot.

Ticket:
https://sourceforge.net/tracker/?func=detail&aid=1697867&group_id=117445&atid=678559
