### PR TITLE
bug: Update Makefile.list with irc_filter.c/h

### DIFF
--- a/Makefile.list
+++ b/Makefile.list
@@ -48,6 +48,7 @@ CLIENT_C_FILES := \
 	hud_editor \
 	ignore \
 	image \
+	irc_filter \
 	irc \
 	keys \
 	logging \


### PR DESCRIPTION
When updating the other platform build files I missed the Makefile.list file. Spotted by localghost, ta!
