### PR TITLE
OSX: Fix Server Browser Crash

### DIFF
--- a/EX_browser_net.c
+++ b/EX_browser_net.c
@@ -201,6 +201,7 @@ void Parse_Serverinfo(server_data *s, char *info)
         qbool spec;
         int id, frags, time, ping, slen;
         char name[100], skin[100], team[100];
+        char *nameptr = name;
         int top, bottom;
         int pos;
 
@@ -233,8 +234,8 @@ void Parse_Serverinfo(server_data *s, char *info)
             ping = -ping;
 
             if (name[0] == '\\' && name[1] == 's' && name[2] == '\\')
-                strlcpy(name, name+3, sizeof(name)); // strip \s\<name>
-            if (slen > 3 && name[slen-3] == '(' && name[slen-2] == 's' && name[slen-1] == ')')
+                nameptr = name+3; // strip \s\<name>
+            else if (slen > 3 && name[slen-3] == '(' && name[slen-2] == 's' && name[slen-1] == ')')
                 name[slen-3] = 0; // strip <name>(s) for old servers
         }
 
@@ -248,7 +249,7 @@ void Parse_Serverinfo(server_data *s, char *info)
         s->players[i]->top = Sbar_ColorForMap(top);
         s->players[i]->bottom = Sbar_ColorForMap(bottom);
 
-        strlcpy(s->players[i]->name, name, sizeof(s->players[0]->name));
+        strlcpy(s->players[i]->name, nameptr, sizeof(s->players[0]->name));
         strlcpy(s->players[i]->skin, skin, sizeof(s->players[0]->skin));
         strlcpy(s->players[i]->team, team, sizeof(s->players[0]->team));
 


### PR DESCRIPTION
Crash because strlcpy destination and source were the same. The copy is
unnecessary, we only need to keep a pointer to track the start of the name
and move the pointer, instead of moving all the bytes in the name.
## 

Process:         ezquake-darwin-x86_64 [13675]

Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000

Application Specific Information:
detected source and destination buffer overlap

Thread 9 Crashed:
0   libsystem_kernel.dylib          0x00007fff941af866 __pthread_kill + 10
1   libsystem_pthread.dylib         0x00007fff8c43935c pthread_kill + 92
2   libsystem_c.dylib               0x00007fff8b615bba abort + 125
3   libsystem_c.dylib               0x00007fff8b615d31 abort_report_np + 181
4   libsystem_c.dylib               0x00007fff8b6398c5 __chk_fail + 48
5   libsystem_c.dylib               0x00007fff8b6398d5 __chk_fail_overlap + 16
6   libsystem_c.dylib               0x00007fff8b6398f7 __chk_overlap + 34
7   libsystem_c.dylib               0x00007fff8b639973 __strlcpy_chk + 68
8   ezquake-darwin                  0x000000010ce328bf Parse_Serverinfo + 2479 (EX_browser_net.c:233)
9   ezquake-darwin                  0x000000010ce33639 GetServerInfosProc + 1401 (EX_browser_net.c:516)
10  ezquake-darwin                  0x000000010ce33932 GetServerPingsAndInfosProc + 146 (EX_browser_net.c:593)
11  libSDL2-2.0.0.dylib             0x0000000111ba9649 SDL_RunThread + 64
12  libSDL2-2.0.0.dylib             0x0000000111bdfd15 RunThread + 9
13  libsystem_pthread.dylib         0x00007fff8c438899 _pthread_body + 138
14  libsystem_pthread.dylib         0x00007fff8c43872a _pthread_start + 137
15  libsystem_pthread.dylib         0x00007fff8c43cfc9 thread_start + 13
