### PR TITLE
TF sbar placement hack that works for all tested versions

### DIFF
--- a/cl_parse.c
+++ b/cl_parse.c
@@ -3289,7 +3289,10 @@ void CL_ParseServerMessage (void)
 				// SCR_CenterPrint (MSG_ReadString ());
 				// Centerprint re-triggers
 				s = MSG_ReadString();
-				
+
+				if (cl.teamfortress && SCR_TF_Sbar(s))
+					break;
+
 				if (!cls.demoseeking)
 				{
 					if (!CL_SearchForReTriggers(s, RE_PRINT_CENTER))

--- a/screen.h
+++ b/screen.h
@@ -125,6 +125,7 @@ typedef struct ti_player_s {
 
 void Update_TeamInfo(void);
 char *SCR_GetWeaponShortNameByFlag (int flag);
+qbool SCR_TF_Sbar(const char *);
 
 // end - scr_teaminfo
 


### PR DESCRIPTION
Properly places the server side TeamFortress "sbar" that is aligned (poorly) using centerprint. Also removes flicker that other prints would cause.
