### PR TITLE
Fix SDL2 issue with keys getting stuck during vid_restart

### DIFF
--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -844,6 +844,9 @@ static void VID_Restart_f(void)
 
 	ReloadPaletteAndColormap();
 
+	// keys can get stuck because SDL2 doesn't send keyup event when the video system is down
+	Key_ClearStates();
+
 	VID_Init(host_basepal);
 
 	// force models to reload (just flush, no actual loading code here)
@@ -868,7 +871,6 @@ static void VID_Restart_f(void)
 
 	// window may be re-created, so caption need to be forced to update
 	CL_UpdateCaption(true);
-
 }
 
 void VID_RegisterCommands(void) 


### PR DESCRIPTION
When using menu "Apply video settings" or Alt-Enter, the keys will get stuck because up events are discarded during vid_restart.
