### PR TITLE
Make all SDL2 mouse input use relative coordinates

### DIFF
--- a/in_sdl2.c
+++ b/in_sdl2.c
@@ -99,8 +99,6 @@ void IN_MouseMove (usercmd_t *cmd)
 			cmd->forwardmove -= m_forward.value * mouse_y;
 		}
 	}
-
-	mx = my = 0; // clear for next update
 }
 
 void IN_Move (usercmd_t *cmd)


### PR DESCRIPTION
This also fixes a bug where some mouse input was being thrown out
when the mouse is using relative coordinates.