### PR TITLE
Fix for downloading files with whitespace in their names

### DIFF
--- a/cl_cmd.c
+++ b/cl_cmd.c
@@ -654,7 +654,7 @@ void CL_Download_f (void){
 	}
 	else
 		dir = cls.gamedir; // not a demo
-	
+
 	// download to a temp name, and only rename
 	// to the real name when done, so if interrupted
 	// a runt file wont be left
@@ -669,12 +669,12 @@ void CL_Download_f (void){
 
 	if (cls.mvdplayback == QTV_PLAYBACK)
 	{
-		QTV_Cmd_Printf(QTV_EZQUAKE_EXT_DOWNLOAD, "download %s", filename);
+		QTV_Cmd_Printf(QTV_EZQUAKE_EXT_DOWNLOAD, "download \"%s\"", filename);
 	}
 	else
 	{
 		MSG_WriteByte (&cls.netchan.message, clc_stringcmd);
-		SZ_Print (&cls.netchan.message, va("download %s", filename));
+		SZ_Print (&cls.netchan.message, va("download \"%s\"", filename));
 	}
 }
 

--- a/cl_parse.c
+++ b/cl_parse.c
@@ -517,12 +517,12 @@ qbool CL_CheckOrDownloadFile (char *filename)
 
 	if (cls.mvdplayback == QTV_PLAYBACK) 
 	{
-		QTV_Cmd_Printf(QTV_EZQUAKE_EXT_DOWNLOAD, "download %s", filename);
+		QTV_Cmd_Printf(QTV_EZQUAKE_EXT_DOWNLOAD, "download \"%s\"", filename);
 	}
 	else 
 	{
 		MSG_WriteByte (&cls.netchan.message, clc_stringcmd);
-		MSG_WriteString (&cls.netchan.message, va("download %s", filename));
+		MSG_WriteString (&cls.netchan.message, va("download \"%s\"", filename));
 	}
 
 	cls.downloadnumber++;


### PR DESCRIPTION
Encloses the "download" command's argument in quotations before
passing it around.
