### PR TITLE
Changes related to demo playback

### DIFF
--- a/cl_cam.c
+++ b/cl_cam.c
@@ -693,10 +693,27 @@ static char *myftos (float f)
 	return val;
 }
 
-static void Cam_Pos_f (void)
+void Cam_Pos_Set(float x, float y, float z)
 {
 	extern qbool clpred_newpos;
 
+	cl.simorg[0] = x;
+	cl.simorg[1] = y;
+	cl.simorg[2] = z;
+	clpred_newpos = true;
+	
+	VectorCopy (cl.simorg, cl.frames[cl.validsequence & UPDATE_MASK].playerstate[cl.playernum].origin);
+	
+	if (cls.state >= ca_active && !cls.demoplayback) {
+		MSG_WriteByte (&cls.netchan.message, clc_tmove);
+		MSG_WriteCoord (&cls.netchan.message, cl.simorg[0]);
+		MSG_WriteCoord (&cls.netchan.message, cl.simorg[1]);
+		MSG_WriteCoord (&cls.netchan.message, cl.simorg[2]);
+	}
+}
+
+static void Cam_Pos_f (void)
+{
 	if (Cmd_Argc() == 1)
 	{
 		Com_Printf ("\"%s %s %s\"\n", myftos(cl.simorg[0]), myftos(cl.simorg[1]), myftos(cl.simorg[2]));
@@ -717,20 +734,17 @@ static void Cam_Pos_f (void)
 
 	if (!cls.demoplayback && !cl.spectator)
 		return;
-		
-	cl.simorg[0] = Q_atof(Cmd_Argv(1));
-	cl.simorg[1] = Q_atof(Cmd_Argv(2));
-	cl.simorg[2] = Q_atof(Cmd_Argv(3));
-	clpred_newpos = true;
-	
-	VectorCopy (cl.simorg, cl.frames[cl.validsequence & UPDATE_MASK].playerstate[cl.playernum].origin);
-	
-	if (cls.state >= ca_active && !cls.demoplayback) {
-		MSG_WriteByte (&cls.netchan.message, clc_tmove);
-		MSG_WriteCoord (&cls.netchan.message, cl.simorg[0]);
-		MSG_WriteCoord (&cls.netchan.message, cl.simorg[1]);
-		MSG_WriteCoord (&cls.netchan.message, cl.simorg[2]);
-	}
+
+	Cam_Reset();
+	Cam_Pos_Set(Q_atof(Cmd_Argv(1)), Q_atof(Cmd_Argv(2)), Q_atof(Cmd_Argv(3)));
+}
+
+void Cam_Angles_Set(float pitch, float yaw, float roll)
+{
+	cl.simangles[0] = pitch;
+	cl.simangles[1] = yaw;
+	cl.simangles[2] = roll;
+	VectorCopy (cl.simangles, cl.viewangles);
 }
 
 static void Cam_Angles_f (void)
@@ -755,11 +769,8 @@ static void Cam_Angles_f (void)
 	
 	if (!cls.demoplayback && !cl.spectator)
 		return;
-		
-	cl.simangles[0] = Q_atof(Cmd_Argv(1));
-	cl.simangles[1] = Q_atof(Cmd_Argv(2));
-	cl.simangles[2] = Q_atof(Cmd_Argv(3));
-	VectorCopy (cl.simangles, cl.viewangles);
+
+	Cam_Angles_Set(Q_atof(Cmd_Argv(1)), Q_atof(Cmd_Argv(2)), Q_atof(Cmd_Argv(3)));
 }
 
 static char *Macro_Cam_Pos_X (void) { return myftos(cl.simorg[0]); }

--- a/cl_cam.c
+++ b/cl_cam.c
@@ -113,13 +113,13 @@ qbool Cam_DrawViewModel(void) {
 	return false;
 }
 
+static qbool Cam_FirstPersonMode(void) {
+	return cl_chasecam.value && !Cvar_Value("cam_thirdperson") && !Cvar_Value("cl_camera_tpp");
+}
+
 // returns true if we should draw this player, we don't if we are chase camming
 qbool Cam_DrawPlayer(int playernum) {
-	if (cl.spectator && autocam && locked && cl_chasecam.value && 
-#ifdef JSS_CAM
-		!Cvar_Value("cam_thirdperson") &&
-#endif
-		spec_track == playernum)
+	if (cl.spectator && autocam && locked && spec_track == playernum && Cam_FirstPersonMode())
 		return false;
 	return true;
 }

--- a/cl_demo.c
+++ b/cl_demo.c
@@ -3674,7 +3674,7 @@ static vfsfile_t* CL_Open_Demo_File(char* name, qbool searchpaks, char** fullPat
 	static char fullname[MAX_OSPATH];
 	vfsfile_t *file = NULL;
 
-	*fullname = '\0';
+	memset(fullname, 0, sizeof(fullname));
 	if (fullPath != NULL)
 		*fullPath = fullname;
 

--- a/cl_ents.c
+++ b/cl_ents.c
@@ -1466,9 +1466,8 @@ guess_pm_type:
 			if (flags & PF_WEAPONFRAME)
 				MSG_WriteByte(&cls.demomessage, state->weaponframe);
 #ifdef FTE_PEXT_TRANS
-			// Should we ever send this?... 
-			//if (flags & PF_TRANS_Z && cls.fteprotocolextensions & FTE_PEXT_TRANS)
-			//	MSG_WriteByte(&cls.demomessage, state->alpha);		
+			if (flags & PF_TRANS_Z && cls.fteprotocolextensions & FTE_PEXT_TRANS)
+				MSG_WriteByte(&cls.demomessage, state->alpha);		
 #endif
 		}
 	}

--- a/cl_ents.c
+++ b/cl_ents.c
@@ -737,59 +737,59 @@ static int fix_trail_num_for_grens(int trail_num)
 
 static void missile_trail(int trail_num, model_t *model, vec3_t *old_origin, entity_t* ent, centity_t *cent)
 {
-					if (trail_num == 1)
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, ROCKET_TRAIL);
-					else if (trail_num == 2)
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, GRENADE_TRAIL);
-					else if (trail_num == 3)
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, ALT_ROCKET_TRAIL);
-					else if (trail_num == 4)
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, BLOOD_TRAIL);
-					else if (trail_num == 5)
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, BIG_BLOOD_TRAIL);
-					else if (trail_num == 6)
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, TRACER1_TRAIL);
-					else if (trail_num == 7)
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, TRACER2_TRAIL);
-					else if (trail_num == 8)
-					{
-						// VULT PARTICLES
-						byte color[3];
-						color[0] = 0; color[1] = 70; color[2] = 255;
-						FireballTrail (*old_origin, ent->origin, &cent->trail_origin, color, 2, 0.5);
-					}
-					else if (trail_num == 9)
-					{
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, LAVA_TRAIL);
-					}
-					else if (trail_num == 10)
-					{
-						// VULT PARTICLES
-						FuelRodGunTrail (*old_origin, ent->origin, ent->angles, &cent->trail_origin);
-					}
-					else if (trail_num == 11)
-					{
-						byte color[3];
-						color[0] = 255; color[1] = 70; color[2] = 5;
-						FireballTrailWave (*old_origin, ent->origin, &cent->trail_origin, color, 2, 0.5, ent->angles);
-					}
-					else if (trail_num == 12)
-					{
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, AMF_ROCKET_TRAIL);
-					}
-					else if (trail_num == 13)
-					{
-						CL_CreateBlurs (*old_origin, ent->origin, ent);
-						VectorCopy(ent->origin, cent->trail_origin);		
-					}
-					else if (trail_num == 14)
-					{
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, RAIL_TRAIL);
-					}
-					else
-					{
-						R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, GRENADE_TRAIL);
-					}
+	if (trail_num == 1)
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, ROCKET_TRAIL);
+	else if (trail_num == 2)
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, GRENADE_TRAIL);
+	else if (trail_num == 3)
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, ALT_ROCKET_TRAIL);
+	else if (trail_num == 4)
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, BLOOD_TRAIL);
+	else if (trail_num == 5)
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, BIG_BLOOD_TRAIL);
+	else if (trail_num == 6)
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, TRACER1_TRAIL);
+	else if (trail_num == 7)
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, TRACER2_TRAIL);
+	else if (trail_num == 8)
+	{
+		// VULT PARTICLES
+		byte color[3];
+		color[0] = 0; color[1] = 70; color[2] = 255;
+		FireballTrail (*old_origin, ent->origin, &cent->trail_origin, color, 2, 0.5);
+	}
+	else if (trail_num == 9)
+	{
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, LAVA_TRAIL);
+	}
+	else if (trail_num == 10)
+	{
+		// VULT PARTICLES
+		FuelRodGunTrail (*old_origin, ent->origin, ent->angles, &cent->trail_origin);
+	}
+	else if (trail_num == 11)
+	{
+		byte color[3];
+		color[0] = 255; color[1] = 70; color[2] = 5;
+		FireballTrailWave (*old_origin, ent->origin, &cent->trail_origin, color, 2, 0.5, ent->angles);
+	}
+	else if (trail_num == 12)
+	{
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, AMF_ROCKET_TRAIL);
+	}
+	else if (trail_num == 13)
+	{
+		CL_CreateBlurs (*old_origin, ent->origin, ent);
+		VectorCopy(ent->origin, cent->trail_origin);		
+	}
+	else if (trail_num == 14)
+	{
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, RAIL_TRAIL);
+	}
+	else
+	{
+		R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, GRENADE_TRAIL);
+	}
 
 }
 
@@ -1041,214 +1041,15 @@ void CL_LinkPacketEntities(void)
 				old_origin = &cent->trail_origin;
 			}
 
-			if (model->modhint == MOD_LAVABALL)
-				R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, LAVA_TRAIL);
-			else 
-			if (model->flags & EF_ROCKET)
-			{
-				if (r_rockettrail.value) 
-				{
-					missile_trail(r_rockettrail.integer, model, old_origin, &ent, cent);
-				} 
-				else 
-				{
-					VectorCopy(ent.origin, cent->trail_origin);		
-				}
-
-				// Add rocket lights
-				rocketlightsize = 200.0 * bound(0, r_rocketlight.value, 1);
-				if (rocketlightsize >= 1)
-				{
-					int bubble = gl_rl_globe.integer ? 2 : 1;
-
-					if ((r_rockettrail.value < 8 || r_rockettrail.value == 12) && model->modhint != MOD_LAVABALL)
-					{
-						dlightColorEx(r_rocketlightcolor.value, r_rocketlightcolor.string, lt_rocket, false, &cst_lt);
-						CL_NewDlightEx(state->number, ent.origin, rocketlightsize, 0.1, &cst_lt, bubble);
-						if (!ISPAUSED && amf_coronas.value) //VULT CORONAS
-							NewCorona(C_ROCKETLIGHT, ent.origin);
-					}
-					else if (r_rockettrail.value == 9 || r_rockettrail.value == 11)
-					{
-						CL_NewDlight (state->number, ent.origin, rocketlightsize, 0.1, lt_default, bubble);
-					}
-					else if (r_rockettrail.value == 8)
-					{ 
-						// PLASMA ROCKETS
-						CL_NewDlight (state->number, ent.origin, rocketlightsize, 0.1, lt_blue, bubble);
-					}
-					else if (r_rockettrail.value == 10)
-					{ 
-						// FUEL ROD GUN
-						CL_NewDlight (state->number, ent.origin, rocketlightsize, 0.1, lt_green, bubble);
-					}
-				}
-			}
-			else if (model->flags & EF_GRENADE)
-			{
-				if (model->modhint == MOD_BUILDINGGIBS)
-				{
-					R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, GRENADE_TRAIL);
-				}
-				else if (r_grenadetrail.value && model->modhint != MOD_RAIL) 
-				{
-					missile_trail(fix_trail_num_for_grens(r_grenadetrail.integer),
-						model, old_origin, &ent, cent);
-				}
-				else if (r_railtrail.value && model->modhint == MOD_RAIL) 
-				{
-					missile_trail(fix_trail_num_for_grens(r_railtrail.integer),
-						model, old_origin, &ent, cent);
-				}
-				else
-				{
-					VectorCopy(ent.origin, cent->trail_origin);
-				}
-			}
-			else if (model->flags & EF_GIB)
-			{
-				if (amf_part_gibtrails.value)
-					R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, BLEEDING_TRAIL);
-				else
-					R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, BLOOD_TRAIL);
-			}
-			else if (model->flags & EF_ZOMGIB) 
-			{
-				if (model->modhint == MOD_RAIL2)
-					R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, RAIL_TRAIL2);
-				else if (amf_part_gibtrails.value)
-					R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, BLEEDING_TRAIL);
-				else
-					R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, BIG_BLOOD_TRAIL);
-			}
-			else if (model->flags & EF_TRACER) 
-			{
-				// VULT TRACER GLOW
-				rocketlightsize = 35 * (1 + bound(0, r_rocketlight.value, 1));	
-				CL_NewDlight (state->number, ent.origin, rocketlightsize, 0.01, lt_green, true);
-				if (!ISPAUSED && amf_coronas.value)
-					NewCorona(C_WIZLIGHT, ent.origin);
-
-				R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, TRACER1_TRAIL);
-			}
-			else if (model->flags & EF_TRACER2) 
-			{
-				// VULT TRACER GLOW
-				rocketlightsize = 35 * (1 + bound(0, r_rocketlight.value, 1));	
-				CL_NewDlight (state->number, ent.origin, rocketlightsize, 0.01, lt_default, true);
-				if (!ISPAUSED && amf_coronas.value)
-					NewCorona(C_KNIGHTLIGHT, ent.origin);
-
-				R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, TRACER2_TRAIL);
-			}
-			else if (model->flags & EF_TRACER3) 
-			{
-				// VULT TRACER GLOW
-				rocketlightsize = 35 * (1 + bound(0, r_rocketlight.value, 1));	
-				CL_NewDlight (state->number, ent.origin, rocketlightsize, 0.01, lt_blue, true);
-				if (!ISPAUSED && amf_coronas.value)
-					NewCorona(C_VORELIGHT, ent.origin);
-
-				R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, VOOR_TRAIL);
-			}
-			else if (model->modhint == MOD_SPIKE && amf_nailtrail.value && !gl_no24bit.integer)
-			{
-				// VULT NAILTRAIL
-				if (amf_nailtrail_plasma.value)
-				{
-					byte color[3];
-					color[0] = 0; color[1] = 70; color[2] = 255;
-					FireballTrail (*old_origin, ent.origin, &cent->trail_origin, color, 0.6, 0.3);
-				}
-				else
-				{
-					ParticleAlphaTrail (*old_origin, ent.origin, &cent->trail_origin, 2, 0.4);
-				}
-			}			
-			else if (model->modhint == MOD_TF_TRAIL && amf_extratrails.value)
-			{
-				// VULT TRAILS
-				ParticleAlphaTrail (*old_origin, ent.origin, &cent->trail_origin, 4, 0.4);
-			}
-			else if (model->modhint == MOD_LASER && amf_extratrails.value)
-			{
-				rocketlightsize = 35 * (1 + bound(0, r_rocketlight.value, 1));	
-				CL_NewDlight (state->number, ent.origin, rocketlightsize, 0.01, lt_default, true);
-				if (!ISPAUSED && amf_coronas.value)
-					NewCorona(C_KNIGHTLIGHT, ent.origin);
-				VX_LightningTrail(*old_origin, ent.origin);
-				R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, TRACER2_TRAIL);
-			}
-			else if (model->modhint == MOD_DETPACK)
-			{
-				// VULT CORONAS
-				if (qmb_initialized) 
-				{
-					vec3_t liteorg, litestop, forward, right, up;
-					VectorCopy(ent.origin, liteorg);
-					AngleVectors(ent.angles, forward, right, up);
-					VectorMA(liteorg, -15, up, liteorg);
-					VectorMA(liteorg, -10, forward, liteorg);
-					VectorCopy(*old_origin, litestop);
-					VectorMA(litestop, -15, up, litestop);
-					VectorMA(litestop, -10, forward, litestop);
-
-					// R_ParticleTrail (*old_origin, ent.origin, &cent->trail_origin, TF_TRAIL); //for cutf tossable dets
-					ParticleAlphaTrail (*old_origin, liteorg, &cent->trail_origin, 10, 0.8);
-					if (!ISPAUSED && amf_coronas.value)
-					{
-						if (ent.skinnum > 0)
-							NewCorona(C_REDLIGHT, liteorg);
-						else
-							NewCorona(C_GREENLIGHT, liteorg);
-					}			
-				}
-			}
-
-			// VULT BUILDING SPARKS
-			if (!ISPAUSED && amf_buildingsparks.value && (model->modhint == MOD_BUILDINGGIBS && (rand() % 40 < 2)))
-			{
-				vec3_t liteorg, forward, right, up;
-				byte col[3] = {60,100,240};
-				VectorCopy(ent.origin, liteorg);
-				AngleVectors(ent.angles, forward, right, up);
-				VectorMA(liteorg, rand() % 10 - 5, up, liteorg);
-				VectorMA(liteorg, rand() % 10 - 5, right, liteorg);
-				VectorMA(liteorg, rand() % 10 - 5, forward, liteorg);
-				SparkGen (liteorg, col, (int)(6*amf_buildingsparks.value), 100, 1);
-				if (amf_coronas.value)
-					NewCorona(C_BLUESPARK, liteorg);
-			}
-			// VULT MOTION TRAILS
-			if (model->modhint == MOD_FLAG && amf_motiontrails.value)
-			{
-				CL_CreateBlurs (*old_origin, ent.origin, &ent);
-			}
-			// VULT MOTION TRAILS - Demon in pouncing animation
-			if (model->modhint == MOD_DEMON && amf_motiontrails.value)
-			{
-				if (ent.frame >= 27 && ent.frame <= 38)
-					CL_CreateBlurs (*old_origin, ent.origin, &ent);
-			}
-
-			// VULT TESLA CHARGE - Tesla or shambler in charging animation
-			if (((model->modhint == MOD_TESLA && ent.frame >= 7 && ent.frame <= 12) || 
-				(model->modhint == MOD_SHAMBLER && ent.frame >= 65 && ent.frame <=68))
-				&& !ISPAUSED && amf_cutf_tesla_effect.value)
-			{
-				vec3_t liteorg;
-				VectorCopy(ent.origin, liteorg);
-				liteorg[2] += 32;
-				VX_TeslaCharge(liteorg);
-			}
+			CL_AddParticleTrail(&ent, cent, old_origin, &cst_lt, state);
 		}
 		VectorCopy (ent.origin, cent->lerp_origin);
-		if (amf_motiontrails_wtf.value)
-			CL_CreateBlurs (ent.origin, ent.origin, &ent);
 
 		CL_AddEntity (&ent);
 	}
 }
+
+
 
 typedef struct 
 {
@@ -1417,7 +1218,7 @@ static int MVD_WeaponModelNumber (int cweapon)
 	return 0;
 }
 
-void CL_ParsePlayerinfo (void) 
+void CL_ParsePlayerinfo (sizebuf_t* demo_output) 
 {
 	extern cvar_t cl_fix_mvd;
 	int	msec, flags, pm_code;
@@ -1518,12 +1319,25 @@ void CL_ParsePlayerinfo (void)
 
 		state->frame = MSG_ReadByte ();
 
+		if (demo_output)
+		{
+			MSG_WriteByte(demo_output, num);
+			MSG_WriteShort(demo_output, flags);
+			MSG_WriteCoord(demo_output, state->origin[0]);
+			MSG_WriteCoord(demo_output, state->origin[1]);
+			MSG_WriteCoord(demo_output, state->origin[2]);
+			MSG_WriteByte(demo_output, state->frame);
+		}
+
 		// the other player's last move was likely some time before the packet was sent out,
 		// so accurately track the exact time it was valid at
 		if (flags & PF_MSEC) 
 		{
 			msec = MSG_ReadByte ();
 			state->state_time = parsecounttime - msec * 0.001;
+
+			if (demo_output)
+				MSG_WriteByte(demo_output, msec);
 		} 
 		else
 		{
@@ -1533,6 +1347,8 @@ void CL_ParsePlayerinfo (void)
 		if (flags & PF_COMMAND) 
 		{
 			MSG_ReadDeltaUsercmd (&nullcmd, &state->command, cl.protoversion);
+			if (demo_output)
+				MSG_WriteDeltaUsercmd(demo_output, &nullcmd, &state->command);
 			CL_CalcPlayerFPS(info, state->command.msec);
 		}
 		else
@@ -1549,27 +1365,47 @@ void CL_ParsePlayerinfo (void)
 		for (i = 0; i < 3; i++)
 		{
 			if (flags & (PF_VELOCITY1 << i) )
+			{
 				state->velocity[i] = MSG_ReadShort();
+				if (demo_output)
+					MSG_WriteShort(demo_output, state->velocity[i]);
+			}
 			else
 				state->velocity[i] = 0;
 		}
 		if (flags & PF_MODEL)
+		{
 			state->modelindex = MSG_ReadByte ();
+			if (demo_output)
+				MSG_WriteByte(demo_output, state->modelindex);
+		}
 		else
 			state->modelindex = cl_modelindices[mi_player];
 
 		if (flags & PF_SKINNUM)
+		{
 			state->skinnum = MSG_ReadByte ();
+			if (demo_output)
+				MSG_WriteByte(demo_output, state->skinnum);
+		}
 		else
 			state->skinnum = 0;
 
 		if (flags & PF_EFFECTS)
+		{
 			state->effects = MSG_ReadByte ();
+			if (demo_output)
+				MSG_WriteByte(demo_output, state->effects);
+		}
 		else
 			state->effects = 0;
 
 		if (flags & PF_WEAPONFRAME)
+		{
 			state->weaponframe = MSG_ReadByte ();
+			if (demo_output)
+				MSG_WriteByte(demo_output, state->weaponframe);
+		}
 		else
 			state->weaponframe = 0;
 
@@ -1577,7 +1413,11 @@ void CL_ParsePlayerinfo (void)
 	state->alpha = 255;
 #ifdef FTE_PEXT_TRANS
 		if (flags & PF_TRANS_Z && cls.fteprotocolextensions & FTE_PEXT_TRANS)
+		{
 			state->alpha = MSG_ReadByte();
+			if (demo_output)
+				MSG_WriteByte(demo_output, state->alpha);
+		}
 #endif
 
 		if (cl.z_ext & Z_EXT_PM_TYPE)
@@ -2389,3 +2229,217 @@ void CL_CalcPlayerFPS(player_info_t *info, int msec)
     }
 }
 
+// Moved out of CL_LinkPacketEntities() so NQD playback can use same code.
+void CL_AddParticleTrail(entity_t* ent, centity_t* cent, vec3_t* old_origin, customlight_t* cst_lt, entity_state_t *state)
+{
+	model_t* model = cl.model_precache[state->modelindex];
+	float rocketlightsize = 0.0f;
+
+	if (model->modhint == MOD_LAVABALL)
+	{
+		R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, LAVA_TRAIL);
+	}
+	else
+	{
+		if (model->flags & EF_ROCKET)
+		{
+			if (r_rockettrail.value)
+			{
+				missile_trail(r_rockettrail.integer, model, old_origin, ent, cent);
+			}
+			else
+			{
+				VectorCopy(ent->origin, cent->trail_origin);
+			}
+
+			// Add rocket lights
+			rocketlightsize = 200.0 * bound(0, r_rocketlight.value, 1);
+			if (rocketlightsize >= 1)
+			{
+				int bubble = gl_rl_globe.integer ? 2 : 1;
+
+				if ((r_rockettrail.value < 8 || r_rockettrail.value == 12) && model->modhint != MOD_LAVABALL)
+				{
+					dlightColorEx(r_rocketlightcolor.value, r_rocketlightcolor.string, lt_rocket, false, cst_lt);
+					CL_NewDlightEx(state->number, ent->origin, rocketlightsize, 0.1, cst_lt, bubble);
+					if (!ISPAUSED && amf_coronas.value) //VULT CORONAS
+						NewCorona(C_ROCKETLIGHT, ent->origin);
+				}
+				else if (r_rockettrail.value == 9 || r_rockettrail.value == 11)
+				{
+					CL_NewDlight(state->number, ent->origin, rocketlightsize, 0.1, lt_default, bubble);
+				}
+				else if (r_rockettrail.value == 8)
+				{
+					// PLASMA ROCKETS
+					CL_NewDlight(state->number, ent->origin, rocketlightsize, 0.1, lt_blue, bubble);
+				}
+				else if (r_rockettrail.value == 10)
+				{
+					// FUEL ROD GUN
+					CL_NewDlight(state->number, ent->origin, rocketlightsize, 0.1, lt_green, bubble);
+				}
+			}
+		}
+		else if (model->flags & EF_GRENADE)
+		{
+			if (model->modhint == MOD_BUILDINGGIBS)
+			{
+				R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, GRENADE_TRAIL);
+			}
+			else if (r_grenadetrail.value && model->modhint != MOD_RAIL)
+			{
+				missile_trail(fix_trail_num_for_grens(r_grenadetrail.integer),
+					model, old_origin, ent, cent);
+			}
+			else if (r_railtrail.value && model->modhint == MOD_RAIL)
+			{
+				missile_trail(fix_trail_num_for_grens(r_railtrail.integer),
+					model, old_origin, ent, cent);
+			}
+			else
+			{
+				VectorCopy(ent->origin, cent->trail_origin);
+			}
+		}
+		else if (model->flags & EF_GIB)
+		{
+			if (amf_part_gibtrails.value)
+				R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, BLEEDING_TRAIL);
+			else
+				R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, BLOOD_TRAIL);
+		}
+		else if (model->flags & EF_ZOMGIB)
+		{
+			if (model->modhint == MOD_RAIL2)
+				R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, RAIL_TRAIL2);
+			else if (amf_part_gibtrails.value)
+				R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, BLEEDING_TRAIL);
+			else
+				R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, BIG_BLOOD_TRAIL);
+		}
+		else if (model->flags & EF_TRACER)
+		{
+			// VULT TRACER GLOW
+			rocketlightsize = 35 * (1 + bound(0, r_rocketlight.value, 1));
+			CL_NewDlight(state->number, ent->origin, rocketlightsize, 0.01, lt_green, true);
+			if (!ISPAUSED && amf_coronas.value)
+				NewCorona(C_WIZLIGHT, ent->origin);
+
+			R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, TRACER1_TRAIL);
+		}
+		else if (model->flags & EF_TRACER2)
+		{
+			// VULT TRACER GLOW
+			rocketlightsize = 35 * (1 + bound(0, r_rocketlight.value, 1));
+			CL_NewDlight(state->number, ent->origin, rocketlightsize, 0.01, lt_default, true);
+			if (!ISPAUSED && amf_coronas.value)
+				NewCorona(C_KNIGHTLIGHT, ent->origin);
+
+			R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, TRACER2_TRAIL);
+		}
+		else if (model->flags & EF_TRACER3)
+		{
+			// VULT TRACER GLOW
+			rocketlightsize = 35 * (1 + bound(0, r_rocketlight.value, 1));
+			CL_NewDlight(state->number, ent->origin, rocketlightsize, 0.01, lt_blue, true);
+			if (!ISPAUSED && amf_coronas.value)
+				NewCorona(C_VORELIGHT, ent->origin);
+
+			R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, VOOR_TRAIL);
+		}
+		else if (model->modhint == MOD_SPIKE && amf_nailtrail.value && !gl_no24bit.integer)
+		{
+			// VULT NAILTRAIL
+			if (amf_nailtrail_plasma.value)
+			{
+				byte color[3];
+				color[0] = 0; color[1] = 70; color[2] = 255;
+				FireballTrail(*old_origin, ent->origin, &cent->trail_origin, color, 0.6, 0.3);
+			}
+			else
+			{
+				ParticleAlphaTrail(*old_origin, ent->origin, &cent->trail_origin, 2, 0.4);
+			}
+		}
+		else if (model->modhint == MOD_TF_TRAIL && amf_extratrails.value)
+		{
+			// VULT TRAILS
+			ParticleAlphaTrail(*old_origin, ent->origin, &cent->trail_origin, 4, 0.4);
+		}
+		else if (model->modhint == MOD_LASER && amf_extratrails.value)
+		{
+			rocketlightsize = 35 * (1 + bound(0, r_rocketlight.value, 1));
+			CL_NewDlight(state->number, ent->origin, rocketlightsize, 0.01, lt_default, true);
+			if (!ISPAUSED && amf_coronas.value)
+				NewCorona(C_KNIGHTLIGHT, ent->origin);
+			VX_LightningTrail(*old_origin, ent->origin);
+			R_ParticleTrail(*old_origin, ent->origin, &cent->trail_origin, TRACER2_TRAIL);
+		}
+		else if (model->modhint == MOD_DETPACK)
+		{
+			// VULT CORONAS
+			if (qmb_initialized)
+			{
+				vec3_t liteorg, litestop, forward, right, up;
+				VectorCopy(ent->origin, liteorg);
+				AngleVectors(ent->angles, forward, right, up);
+				VectorMA(liteorg, -15, up, liteorg);
+				VectorMA(liteorg, -10, forward, liteorg);
+				VectorCopy(*old_origin, litestop);
+				VectorMA(litestop, -15, up, litestop);
+				VectorMA(litestop, -10, forward, litestop);
+
+				// R_ParticleTrail (*old_origin, ent->origin, &cent->trail_origin, TF_TRAIL); //for cutf tossable dets
+				ParticleAlphaTrail(*old_origin, liteorg, &cent->trail_origin, 10, 0.8);
+				if (!ISPAUSED && amf_coronas.value)
+				{
+					if (ent->skinnum > 0)
+						NewCorona(C_REDLIGHT, liteorg);
+					else
+						NewCorona(C_GREENLIGHT, liteorg);
+				}
+			}
+		}
+
+		// VULT BUILDING SPARKS
+		if (!ISPAUSED && amf_buildingsparks.value && (model->modhint == MOD_BUILDINGGIBS && (rand() % 40 < 2)))
+		{
+			vec3_t liteorg, forward, right, up;
+			byte col[3] = { 60, 100, 240 };
+			VectorCopy(ent->origin, liteorg);
+			AngleVectors(ent->angles, forward, right, up);
+			VectorMA(liteorg, rand() % 10 - 5, up, liteorg);
+			VectorMA(liteorg, rand() % 10 - 5, right, liteorg);
+			VectorMA(liteorg, rand() % 10 - 5, forward, liteorg);
+			SparkGen(liteorg, col, (int)(6 * amf_buildingsparks.value), 100, 1);
+			if (amf_coronas.value)
+				NewCorona(C_BLUESPARK, liteorg);
+		}
+		// VULT MOTION TRAILS
+		if (model->modhint == MOD_FLAG && amf_motiontrails.value)
+		{
+			CL_CreateBlurs(*old_origin, ent->origin, ent);
+		}
+		// VULT MOTION TRAILS - Demon in pouncing animation
+		if (model->modhint == MOD_DEMON && amf_motiontrails.value)
+		{
+			if (ent->frame >= 27 && ent->frame <= 38)
+				CL_CreateBlurs(*old_origin, ent->origin, ent);
+		}
+
+		// VULT TESLA CHARGE - Tesla or shambler in charging animation
+		if (((model->modhint == MOD_TESLA && ent->frame >= 7 && ent->frame <= 12) ||
+			(model->modhint == MOD_SHAMBLER && ent->frame >= 65 && ent->frame <= 68))
+			&& !ISPAUSED && amf_cutf_tesla_effect.value)
+		{
+			vec3_t liteorg;
+			VectorCopy(ent->origin, liteorg);
+			liteorg[2] += 32;
+			VX_TeslaCharge(liteorg);
+		}
+	}
+
+	if (amf_motiontrails_wtf.value)
+		CL_CreateBlurs(ent->origin, ent->origin, ent);
+}

--- a/cl_main.c
+++ b/cl_main.c
@@ -2171,7 +2171,7 @@ static double MinPhysFrameTime (void)
 	float physfps = ((cl.spectator && !cls.demoplayback) ? cl_physfps_spectator.value : cl_physfps.value);
 
 	// this makes things smooth in mvd demo play back, since mvd interpolation applied each frame
-	if (cls.demoplayback && cls.mvdplayback)
+	if (cls.demoplayback)
 		return 0;
 
 	// the user can lower it for testing (or really shit connection)
@@ -2945,20 +2945,12 @@ void CL_UpdateCaption(qbool force)
 
 void OnChangeDemoTeamplay (cvar_t *var, char *value, qbool *cancel)
 {
-	int i = 0;
-
-	cl.teamplay = (*value != '0');
-
 	if (cls.nqdemoplayback) 
 	{
-		for (i = 0; i < sizeof(cl.players) / sizeof(cl.players[0]); ++i)
-		{
-			player_info_t* player = &cl.players[i];
+		cl.teamplay = (*value != '0');
 
-			// All white with <= -99 frags => spectator
-			player->spectator = (*player->name && cl.teamplay && player->real_topcolor == 0 && player->real_bottomcolor == 0 && player->frags <= -99);
-		}
+		NQD_SetSpectatorFlags();
+
+		OnChangeColorForcing(var, value, cancel);
 	}
-
-	OnChangeColorForcing(var, value, cancel);
 }

--- a/cl_nqdemo.c
+++ b/cl_nqdemo.c
@@ -25,7 +25,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "qsound.h"
 #include "hud.h"
 #include "hud_common.h"
-
+#include "vx_stuff.h"
+#include "settings.h"
+#ifdef _WIN32
+#include "movie.h"
+#endif
 
 #define MAX_BIG_MSGLEN 8000
 int CL_Demo_Read(void *buf, int size, qbool peek);
@@ -106,7 +110,38 @@ static vec3_t	nq_mvelocity[2];
 static vec3_t	nq_mviewangles[2];
 static vec3_t	nq_mviewangles_temp;
 static qbool	standard_quake = true;
+static demoseekingtype_t nq_lastseektype = DST_SEEKING_NONE;
 
+static void CL_CheckForNQDSeekPointFound(void) 
+{
+	float demotime = nq_mtime[0];
+
+	// Check for rewind only the first time we want to seek through the demo 
+	if (cls.demoseeking != nq_lastseektype)
+		CL_Demo_Check_For_Rewind(nq_mtime[0]);
+	nq_lastseektype = cls.demoseeking;
+		
+	if (cls.demoseeking == DST_SEEKING_STATUS)
+		CL_Demo_Jump_Status_Check();
+
+	// If we found demomark, we should stop seeking, so reset time to the proper value.
+	if (cls.demoseeking == DST_SEEKING_FOUND) 
+	{
+		cls.demotime = demotime; // this will trigger seeking stop
+	}
+
+	// If we've reached our seek goal, stop seeking.
+	if (cls.demoseeking && cls.demotime <= demotime && cls.state >= ca_active)
+	{
+		cls.demoseeking = DST_SEEKING_NONE;
+		cls.demotime = demotime; 
+
+		if (cls.demorewinding)
+		{
+			CL_Demo_Stop_Rewinding();
+		}
+	}
+}
 
 static qbool CL_GetNQDemoMessage (void)
 {
@@ -131,12 +166,9 @@ static qbool CL_GetNQDemoMessage (void)
 			if (cls.framecount == cls.td_startframe + 1)
 				cls.td_starttime = Sys_DoubleTime();
 		}
-		else if (cl.time <= nq_mtime[0])
-		{
+		else if (cl.time <= nq_mtime[0] && ! cls.demoseeking)
 			return false;		// don't need another message yet
-		}
 	}
-
 
 	// get the next message
 	CL_Demo_Read(&net_message.cursize, 4, false);
@@ -282,6 +314,8 @@ static void NQD_ParseUpdatecolors (void)
 {
 	int	i, colors;
 	int top, bottom;
+	qbool client_team_changed = false;
+	qbool player_skin_changed = false;
 
 	i = MSG_ReadByte ();
 	if (i >= nq_maxclients)
@@ -291,10 +325,37 @@ static void NQD_ParseUpdatecolors (void)
 	// fill in userinfo values
 	top = min(colors & 15, 13);
 	bottom = min((colors >> 4) & 15, 13);
+
+	if (cl_demoteamplay.integer)
+		cl.players[i].spectator = (top == 0 && bottom == 0 && cl.players[i].frags <= -99);
+	else 
+		cl.players[i].spectator = 0;
+
+	client_team_changed = (cl.playernum == i && bottom != cl.players[i].real_bottomcolor);
+	player_skin_changed = (top != cl.players[i].real_topcolor || bottom != cl.players[i].real_bottomcolor);
+
 	Info_SetValueForKey (cl.players[i].userinfo, "topcolor", va("%i", top), MAX_INFO_KEY);
 	Info_SetValueForKey (cl.players[i].userinfo, "bottomcolor", va("%i", bottom), MAX_INFO_KEY);
 
-	CL_NewTranslation (i);
+	if (cl.players[i].spectator)
+	{
+		Info_SetValueForKey (cl.players[i].userinfo, "team", "", MAX_INFO_KEY);	// In NQ, team = bottom color
+		strlcpy(cl.players[i].team, "", sizeof(cl.players[i].team));
+	}
+	else 
+	{
+		char* bottom_as_string = SettingColorName(bottom); 
+		Info_SetValueForKey (cl.players[i].userinfo, "team", bottom_as_string, MAX_INFO_KEY);	// In NQ, team = bottom color
+		strlcpy(cl.players[i].team, bottom_as_string, sizeof(cl.players[i].team));
+	}
+
+	cl.players[i].real_topcolor = top;
+	cl.players[i].real_bottomcolor = bottom;
+
+	if (TP_NeedRefreshSkins() && client_team_changed)
+		TP_RefreshSkins();
+	else if (player_skin_changed)
+		TP_RefreshSkin(i);
 	Sbar_Changed ();
 }
 
@@ -418,6 +479,7 @@ static void NQD_ParseServerData (void)
 //
 
 	// precache models
+	*mapname = 0;
 	for (nummodels=1 ; ; nummodels++)
 	{
 		str = MSG_ReadString ();
@@ -427,6 +489,9 @@ static void NQD_ParseServerData (void)
 			Host_Error ("Server sent too many model precaches");
 		strlcpy (cl.model_name[nummodels], str, sizeof(cl.model_name[0]));
 		Mod_TouchModel (str);
+
+		if (nummodels == 1)
+			COM_StripExtension (COM_SkipPath(cl.model_name[1]), mapname);
 	}
 
 	// precache sounds
@@ -443,6 +508,8 @@ static void NQD_ParseServerData (void)
 
 	// now we try to load everything else until a cache allocation fails
 	cl.clipmodels[1] = CM_LoadMap (cl.model_name[1], true, NULL, &cl.map_checksum2);
+	if (!com_serveractive)
+		Cvar_ForceSet (&host_mapname, mapname);
 	COM_StripExtension (COM_SkipPath(cl.model_name[1]), mapname);
 	cl.map_checksum2 = Com_TranslateMapChecksum (mapname, cl.map_checksum2);
 
@@ -466,7 +533,7 @@ static void NQD_ParseServerData (void)
 	if (!cl.model_precache[1])
 		Host_Error ("NQD_ParseServerData: NULL worldmodel");
 
-//	CL_ClearParticles (); @ZQ@
+	Classic_InitParticles (); 
 	CL_FindModelNumbers ();
 	R_NewMap (false);
 	TP_NewMap ();
@@ -486,6 +553,12 @@ static void NQD_ParseServerData (void)
 	cl.servertime_works = true;
 //	cl.allow_fbskins = true; @ZQ@
 	cls.state = ca_onserver;
+	CL_Demo_Check_For_Rewind(nq_mtime[0]);
+
+	// Demos don't store this so we set from user-defined option
+	cl.teamplay = cl_demoteamplay.integer;
+
+	nq_lastseektype == DST_SEEKING_NONE;
 }
 
 /*
@@ -540,15 +613,6 @@ Back from NetQuake
 */
 static void CL_ParseParticleEffect (void)
 {
-	/* hifi: unused variable warnings cleaned up, kept null parsing */
-	int i;
-	for (i = 0; i < 3; i++)
-		MSG_ReadCoord ();
-	for (i = 0; i < 3; i++)
-		MSG_ReadChar ();
-	MSG_ReadByte ();
-	MSG_ReadByte ();
-/* ##
 	vec3_t		org, dir;
 	int			i, count, color;
 
@@ -561,10 +625,9 @@ static void CL_ParseParticleEffect (void)
 
 	// now run the effect
 	if (count == 255)
-		CL_ParticleExplosion (org);
-	else
-		CL_RunParticleEffect2 (org, dir, color, count, 1);
-*/
+		Classic_ParticleExplosion (org);
+	else 
+		R_RunParticleEffect (org, dir, color, count);
 }
 
 /*
@@ -594,6 +657,7 @@ static void NQD_ParseUpdate (int bits)
 		//TP_ExecTrigger ("f_spawn");
 		SCR_EndLoadingPlaque ();
 		cls.state = ca_active;
+		CL_Demo_Check_For_Rewind(nq_mtime[0]);
 	}
 
 	if (bits & NQ_U_MOREBITS)
@@ -641,8 +705,8 @@ static void NQD_ParseUpdate (int bits)
 	if (modnum != state->modelindex)
 	{
 		state->modelindex = modnum;
-	// automatic animation (torches, etc) can be either all together
-	// or randomized
+		// automatic animation (torches, etc) can be either all together
+		// or randomized
 		if (modnum)
 		{
 			/*if (model->synctype == ST_RAND)
@@ -796,6 +860,7 @@ void NQD_LinkEntities (void)
 	float				autorotate;
 	int					i;
 	int					num;
+	customlight_t		cst_lt = { 0 };
 
 	f = NQD_LerpPoint ();
 
@@ -902,20 +967,27 @@ void NQD_LinkEntities (void)
 		// set colormap
 		if (state->colormap && state->colormap <= MAX_CLIENTS
 			&& state->modelindex == cl_modelindices[mi_player]
-		)
+		) 
+		{
 			ent.colormap = cl.players[state->colormap-1].translations;
+			ent.scoreboard = &cl.players[state->colormap-1];
+		}
 		else
+		{
 			ent.colormap = vid.colormap;
+			ent.scoreboard = NULL;
+		}
 
 		// set skin
 		ent.skinnum = state->skinnum;
-		
+
 		// set frame
 		ent.frame = state->frame;
 		if (cent->frametime >= 0 && cent->frametime <= cl.time) {
 			ent.oldframe = cent->oldframe;
 			ent.framelerp = (cl.time - cent->frametime) * 10;
-if (ent.oldframe != ent.frame) Com_DPrintf ("framelerp %f\n", ent.framelerp); 
+			//if (ent.oldframe != ent.frame) 
+				//Com_DPrintf("framelerp %f\n", ent.framelerp);
 		} else {
 			ent.oldframe = ent.frame;
 			ent.framelerp = -1;
@@ -940,32 +1012,7 @@ if (ent.oldframe != ent.frame) Com_DPrintf ("framelerp %f\n", ent.framelerp);
 					}
 			}
 
-#if 0	//##
-			if (modelflags & EF_ROCKET)
-			{
-				if (r_rockettrail.value) {
-					if (r_rockettrail.value == 2)
-						CL_GrenadeTrail (old_origin, ent.origin);
-					else
-						CL_RocketTrail (old_origin, ent.origin);
-				}
-
-				if (r_rocketlight.value)
-					CL_NewDlight (state->number, ent.origin, 200, 0.1, lt_rocket);
-			}
-			else if (modelflags & EF_GRENADE && r_grenadetrail.value)
-				CL_GrenadeTrail (old_origin, ent.origin);
-			else if (modelflags & EF_GIB)
-				CL_BloodTrail (old_origin, ent.origin);
-			else if (modelflags & EF_ZOMGIB)
-				CL_SlightBloodTrail (old_origin, ent.origin);
-			else if (modelflags & EF_TRACER)
-				CL_TracerTrail (old_origin, ent.origin, 52);
-			else if (modelflags & EF_TRACER2)
-				CL_TracerTrail (old_origin, ent.origin, 230);
-			else if (modelflags & EF_TRACER3)
-				CL_VoorTrail (old_origin, ent.origin);
-#endif
+			CL_AddParticleTrail (&ent, cent, &old_origin, &cst_lt, state);
 		}
 
 		VectorCopy (ent.origin, cent->lerp_origin);
@@ -1046,7 +1093,7 @@ static void NQD_ParseServerMessage (void)
 		switch (cmd)
 		{
 		default:
-			Host_Error ("CL_ParseServerMessage: Illegible server message");
+			Host_Error ("CL_ParseServerMessage: Illegible server message (cmd %i)\n", cmd);
 			break;
 
 		case svc_nop:
@@ -1055,7 +1102,10 @@ static void NQD_ParseServerMessage (void)
 		case nq_svc_time:
 			nq_mtime[1] = nq_mtime[0];
 			nq_mtime[0] = MSG_ReadFloat ();
+			if (demostarttime < 0)
+				demostarttime = nq_mtime[0];
 			cl.servertime = nq_mtime[0];
+			CL_CheckForNQDSeekPointFound();
 			message_with_datagram = true;
 			break;
 
@@ -1216,12 +1266,14 @@ static void NQD_ParseServerMessage (void)
 		case svc_intermission:
 			cl.intermission = 1;
 			cl.completed_time = cl.time;
+			cl.solo_completed_time = cl.servertime;
 			VectorCopy (nq_last_fixangle, cl.simangles);
 			break;
 
 		case svc_finale:
 			cl.intermission = 2;
 			cl.completed_time = cl.time;
+			cl.solo_completed_time = cl.servertime;
 			SCR_CenterPrint (MSG_ReadString ());
 			VectorCopy (nq_last_fixangle, cl.simangles);
 			break;
@@ -1229,6 +1281,7 @@ static void NQD_ParseServerMessage (void)
 		case nq_svc_cutscene:
 			cl.intermission = 3;
 			cl.completed_time = cl.time;
+			cl.solo_completed_time = cl.servertime;
 			SCR_CenterPrint (MSG_ReadString ());
 			VectorCopy (nq_last_fixangle, cl.simangles);
 			break;
@@ -1243,9 +1296,15 @@ static void NQD_ParseServerMessage (void)
 
 void NQD_ReadPackets (void)
 {
+	extern qbool	host_skipframe;
+
 	while (CL_GetNQDemoMessage()) {
 		NQD_ParseServerMessage();
 	}
+
+	// If we're seeking, demotime is set to the target time: stop demotime from being advanced as normal
+	if (cls.demoseeking)
+		host_skipframe = true;
 }
 
 

--- a/cl_parse.c
+++ b/cl_parse.c
@@ -3598,12 +3598,8 @@ void CL_ParseServerMessage (void)
 				{
 					CL_InitialiseDemoMessageIfRequired();
 					MSG_WriteByte(&cls.demomessage, svc_playerinfo);
-					CL_ParsePlayerinfo(&cls.demomessage);
 				}
-				else 
-				{
-					CL_ParsePlayerinfo(NULL);
-				}
+				CL_ParsePlayerinfo();
 				break;
 			}
 			case svc_nails:

--- a/cl_view.c
+++ b/cl_view.c
@@ -848,9 +848,9 @@ void V_AddViewWeapon (float bob) {
 	}
 
 	// fudge position around to keep amount of weapon visible roughly equal with different FOV
-	if (scr_viewsize.value == 110)
+	if (cl_sbar.value && scr_viewsize.value == 110)
 		cent->current.origin[2] += 1;
-	else if (scr_viewsize.value == 100)
+	else if (cl_sbar.value && scr_viewsize.value == 100)
 		cent->current.origin[2] += 2;
 	else if (scr_viewsize.value == 90)
 		cent->current.origin[2] += 1;

--- a/client.h
+++ b/client.h
@@ -39,6 +39,8 @@ typedef struct
 } static_sound_t;
 
 extern cvar_t cl_demospeed;
+extern cvar_t cl_demoteamplay;
+
 #define ISPAUSED (cl.paused || (!cl_demospeed.value && cls.demoplayback))
 #define	MAX_PROJECTILES	32
 
@@ -697,6 +699,9 @@ void CL_Stop_f (void);
 void CL_CheckQizmoCompletion(void);
 void CL_Demo_Jump(double seconds, int relative, demoseekingtype_t seeking);
 void CL_Demo_Init(void);
+void CL_Demo_Jump_Status_Check (void);
+void CL_Demo_Check_For_Rewind(float nextdemotime);
+void CL_Demo_Stop_Rewinding(void);
 double Demo_GetSpeed(void);
 qbool CL_IsDemoExtension(const char *filename);
 
@@ -832,6 +837,7 @@ extern struct model_s *cl_flame0_model;
 void CL_InitEnts(void);
 void CL_AddEntity (entity_t *ent);
 void CL_ClearScene (void) ;
+void CL_AddParticleTrail(entity_t* ent, centity_t* cent, vec3_t* old_origin, customlight_t* cst_lt, entity_state_t *state);
 
 dlighttype_t dlightColor(float f, dlighttype_t def, qbool random);
 customlight_t *dlightColorEx(float f, char *str, dlighttype_t def, qbool random, customlight_t *l);
@@ -870,6 +876,8 @@ extern int	spec_track; // player# of who we are tracking
 
 int WhoIsSpectated (void);
 void CL_Cam_SetKiller(int killernum, int victimnum);
+void Cam_Angles_Set(float pitch, float yaw, float roll);
+void Cam_Pos_Set(float x, float y, float z);
 
 qbool Cam_DrawViewModel (void);
 qbool Cam_DrawPlayer (int playernum);

--- a/client.h
+++ b/client.h
@@ -687,6 +687,7 @@ usermainbuttons_t CL_GetLastCmd (void);
 void NQD_StartPlayback (void);
 void NQD_LinkEntities (void);
 void NQD_ReadPackets (void);
+void NQD_SetSpectatorFlags (void);
 
 // cl_demo.c
 qbool CL_GetDemoMessage (void);

--- a/com_msg.c
+++ b/com_msg.c
@@ -593,7 +593,7 @@ void MSG_ReadDeltaUsercmd (usercmd_t *from, usercmd_t *move, int protoversion)
 
 	bits = MSG_ReadByte ();
 
-	if (protoversion == 26) {
+	if (protoversion <= 26) {
 		// read current angles
 		if (bits & CM_ANGLE1)
 			move->angles[0] = MSG_ReadAngle16 ();
@@ -634,10 +634,10 @@ void MSG_ReadDeltaUsercmd (usercmd_t *from, usercmd_t *move, int protoversion)
 		move->impulse = MSG_ReadByte ();
 
 	// read time to run command
-	if (protoversion == 26) {
-		if (bits & CM_MSEC)
-			move->msec = MSG_ReadByte ();
-	} else {
+	if (protoversion <= 26 && (bits & CM_MSEC)) {
+		move->msec = MSG_ReadByte ();
+	} 
+	else if (protoversion >= 27) {
 		move->msec = MSG_ReadByte (); // always sent
 	}
 }

--- a/in_sdl2.c
+++ b/in_sdl2.c
@@ -158,10 +158,6 @@ void IN_Shutdown(void)
 
 /* FIXME? */
 
-int ctrlDown = 0;
-int shiftDown = 0;
-int altDown = 0;
-
-int isAltDown(void) {return altDown;}
-int isCtrlDown(void) {return ctrlDown;}
-int isShiftDown(void) {return shiftDown;}
+int isAltDown(void) { return keydown[K_ALT]; }
+int isCtrlDown(void) { return keydown[K_CTRL]; }
+int isShiftDown(void) { return keydown[K_SHIFT]; }

--- a/movie.h
+++ b/movie.h
@@ -29,9 +29,12 @@ qbool Movie_IsCapturing(void);
 void Movie_Stop(void);
 void Movie_TransferStereo16(void);
 qbool Movie_GetSoundtime(void);
+short* Movie_SoundBuffer(void);
 
 extern cvar_t movie_fps;
 extern cvar_t movie_steadycam;
+extern cvar_t movie_quietcapture;
+
 extern qbool	movie_is_avi;	//joe: capturing to avi
 
 #endif

--- a/settings.h
+++ b/settings.h
@@ -137,4 +137,6 @@ typedef struct {
 	qbool mini;			// minimalistic version (doesn't display help and has infinite scrolling)
 } settings_page;
 
+char* SettingColorName(int color);
+
 #endif // __SETTINGS_H__

--- a/settings_page.c
+++ b/settings_page.c
@@ -60,6 +60,18 @@ static float SliderPos(float min, float max, float val) { return (val-min)/(max-
 static const char* colors[14] = { "White", "Brown", "Lavender", "Khaki", "Red", "Lt Brown", "Peach", "Lt Peach", "Purple", "Dk Purple", "Tan", "Green", "Yellow", "Blue" };
 #define COLORNAME(x) colors[bound(0, ((int) x), sizeof(colors) / sizeof(char*) - 1)]
 
+char* SettingColorName(int color)
+{
+	static char tempBuffer[64];
+
+	if (color < 0 || color > sizeof(colors) / sizeof(colors[0]))
+		Host_Error("SettingColorName(color %d) out of range.\n", color);
+
+	strlcpy(tempBuffer, colors[color], sizeof(tempBuffer));
+
+	return tempBuffer;
+}
+
 float VARFVAL(const cvar_t *v)
 {
     if ((v->flags & CVAR_LATCH) && v->latchedString)

--- a/snd_dma.c
+++ b/snd_dma.c
@@ -670,12 +670,6 @@ static void GetSoundtime (void)
 	int samplepos, fullsamples;
 	static int buffers, oldsamplepos;
 
-	//joe: capturing audio
-#ifdef _WIN32
-	if (Movie_GetSoundtime())
-		return;
-#endif
-
 	fullsamples = shm->sampleframes;
 	samplepos = SNDDMA_GetDMAPos();
 
@@ -692,7 +686,11 @@ static void GetSoundtime (void)
 
 	oldsamplepos = samplepos;
 
-	soundtime = buffers * fullsamples + samplepos / shm->format.channels;
+#ifdef _WIN32
+	//joe: capturing audio
+	if (!Movie_GetSoundtime())
+		soundtime = buffers * fullsamples + samplepos / shm->format.channels;
+#endif
 }
 
 void S_ExtraUpdate (void)


### PR DESCRIPTION
Mostly changes to let me watch/re-record old demos

NQ demos: player colours set correctly, particle trails/effects back in, demo_jump working, can force team skins with help of cl_demoteamplay
QW demos: can now playback from 2.1 (protocol versions 24/25), demo rewinding works
MV demos: cam_pos stops tracking, if in free camera mode, camera position is restored after rewinding
Video capture: Can split .avi files to be stitched together later (workaround for http://sourceforge.net/p/ezquake/bugs/520/), demo_capture_quiet option to disable playback during capture.
Demo browser: plays the file you select when you have two files with valid demo extensions in same directory

