### PR TITLE
Fixes for cl_demospeed 0 affecting QTV playback

### DIFF
--- a/cl_demo.c
+++ b/cl_demo.c
@@ -4539,6 +4539,12 @@ void CL_Demo_Jump_f (void)
         return;
 	}
 
+	if (cls.mvdplayback == QTV_PLAYBACK)
+	{
+		Com_Printf("Error: cannot jump during QTV playback.\n");
+		return;
+	}
+
 	// Must be active to jump.
 	if (cls.state < ca_active)
 	{
@@ -4959,8 +4965,11 @@ double Demo_GetSpeed(void)
 
 			return demospeed;
 		}
-	}
 
+		if (!qtv_allow_pause.value)
+			return 1;
+	}
+	
 	return bound(0, cl_demospeed.value, 20);
 }
 

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -805,7 +805,7 @@ void SCR_DrawDemoClock (void) {
 	int x, y;
 	char str[80];
 
-	if (!cls.demoplayback || cls.mvdplayback == 2 || !scr_democlock.value || scr_newHud.value == 1) // newHud has its own democlock
+	if (!cls.demoplayback || cls.mvdplayback == QTV_PLAYBACK || !scr_democlock.value || scr_newHud.value == 1) // newHud has its own democlock
 		return;
 
 	if (scr_democlock.value == 2)

--- a/client.h
+++ b/client.h
@@ -41,7 +41,8 @@ typedef struct
 extern cvar_t cl_demospeed;
 extern cvar_t cl_demoteamplay;
 
-#define ISPAUSED (cl.paused || (!cl_demospeed.value && cls.demoplayback))
+#define QTV_PLAYBACK		2			// cls.mvdplayback == QTV_PLAYBACK if QTV playback
+#define ISPAUSED (cl.paused || (!cl_demospeed.value && cls.demoplayback && cls.mvdplayback != QTV_PLAYBACK))
 #define	MAX_PROJECTILES	32
 
 typedef struct 

--- a/console.c
+++ b/console.c
@@ -286,7 +286,7 @@ void Con_MessageMode_f (void) {
 }
 
 void Con_MessageMode2_f (void) {
-	if (cls.mvdplayback == 2)
+	if (cls.mvdplayback == QTV_PLAYBACK)
 	{
 		// mm2 has no meaning in QTV so let's save some keys and make it QTV->game chat
 		Con_MessageMode_Common(chat_qtvtogame);

--- a/hud_common.c
+++ b/hud_common.c
@@ -770,7 +770,7 @@ void SCR_HUD_DrawDemoClock(hud_t *hud)
         *hud_democlock_blink,
 		*hud_democlock_scale;
 
-	if (!cls.demoplayback || cls.mvdplayback == 2)
+	if (!cls.demoplayback || cls.mvdplayback == QTV_PLAYBACK)
 	{
 		HUD_PrepareDraw(hud, width, height, &x, &y);
 		return;

--- a/menu_ingame.c
+++ b/menu_ingame.c
@@ -144,7 +144,7 @@ setting botmatch_menu_entries[] = {
 #define DEMOPLAYBACK() (cls.demoplayback && cls.mvdplayback != QTV_PLAYBACK)
 #define BOTMATCH() (!strcmp(cls.gamedirfile, "fbca"))
 #define SINGLEPLAYER() (com_serveractive && cls.state == ca_active && !cl.deathmatch && maxclients.value == 1)
-#define QTVPLAYBACK() (cls.mvdplayback == 2)
+#define QTVPLAYBACK() (cls.mvdplayback == QTV_PLAYBACK)
 
 static settings_page *M_Ingame_Current(void) {
 	if (DEMOPLAYBACK()) {

--- a/movie.c
+++ b/movie.c
@@ -395,9 +395,9 @@ void Movie_TransferStereo16(void) {
 
 qbool Movie_GetSoundtime(void) {
 	int views = 1;
-	extern cvar_t cl_demospeed;
+	float demospeed = Demo_GetSpeed();
 
-	if (!movie_is_avi || !Movie_IsCapturing() || !cl_demospeed.value)
+	if (!movie_is_avi || !Movie_IsCapturing() || !demospeed)
 		return false;
 
 	if (cl_multiview.value)
@@ -405,7 +405,7 @@ qbool Movie_GetSoundtime(void) {
 		views = cl_multiview.value;
 	}
 
-	soundtime += (int)(0.5 + cls.frametime * shm->format.speed * views * (1.0 / cl_demospeed.value)); //joe: fix for slowmo/fast forward
+	soundtime += (int)(0.5 + cls.frametime * shm->format.speed * views * (1.0 / demospeed)); //joe: fix for slowmo/fast forward
 	return true;
 }
 #endif

--- a/qtv.c
+++ b/qtv.c
@@ -38,6 +38,7 @@ cvar_t  qtv_adjustmaxspeed	 = {"qtv_adjustmaxspeed",	"999"};
 cvar_t  qtv_adjustlowstart   = {"qtv_adjustlowstart",	"0.3"};
 cvar_t  qtv_adjusthighstart  = {"qtv_adjusthighstart",	"1"};
 cvar_t  qtv_say_team         = {"qtv_say_team",         "0"};
+cvar_t  qtv_allow_pause		 = {"qtv_allow_pause",      "0"};	// ignore cl_demospeed during QTV playback by default
 
 cvar_t  qtv_event_join       = {"qtv_event_join", 		" &c2F2joined&r"};
 cvar_t  qtv_event_leave      = {"qtv_event_leave", 		" &cF22left&r"};
@@ -59,6 +60,7 @@ void QTV_Init(void)
 	Cvar_Register(&qtv_adjustlowstart);
 	Cvar_Register(&qtv_adjusthighstart);
 	Cvar_Register(&qtv_say_team);
+	Cvar_Register(&qtv_allow_pause);
 
 	Cvar_Register(&qtv_event_join);
 	Cvar_Register(&qtv_event_leave);

--- a/qtv.h
+++ b/qtv.h
@@ -25,8 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define QTVBUFFERTIME bound(0.1, qtv_buffertime.value, 10)
 
-#define QTV_PLAYBACK		2			// cls.mvdplayback == QTV_PLAYBACK if QTV playback
-
 //======================================
 
 #define QTV_VERSION			1.0f		// we are support up to this QTV version
@@ -89,6 +87,7 @@ extern		cvar_t  qtv_adjustminspeed;
 extern		cvar_t  qtv_adjustmaxspeed;
 extern		cvar_t  qtv_adjustlowstart;
 extern		cvar_t  qtv_adjusthighstart;
+extern      cvar_t  qtv_allow_pause;
 
 extern		cvar_t  qtv_event_join;
 extern		cvar_t  qtv_event_leave;

--- a/vx_coronas.c
+++ b/vx_coronas.c
@@ -132,7 +132,6 @@ void R_UpdateCoronas(void)
 //R_DrawCoronas
 void R_DrawCoronas(void)
 {
-	extern cvar_t cl_demospeed; // cl_main.c
 	int i;
 	int texture = 0;
 	vec3_t dist, up, right;


### PR DESCRIPTION
Particle effects & sounds were paused, but entity movement unaffected.
It was possible previously to pause QTV playback and then start again (as long as qtv_adjustbuffers was set to 0) - if this is still required, can set qtv_allow_pause to 1.  Hopefully the new default causes less confusion.