### PR TITLE
remove "SDL2" include prefix. everywhere else it is without and this …

### DIFF
--- a/vid.h
+++ b/vid.h
@@ -18,7 +18,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // vid.h -- video driver defs
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #define VID_CBITS 6
 #define VID_GRADES (1 << VID_CBITS)


### PR DESCRIPTION
…fixes broken osx el capitan build. it seems the default user include path is no longer exported.