### PR TITLE
Docker nightly build

### DIFF
--- a/misc/docker-nightly-build/Dockerfile
+++ b/misc/docker-nightly-build/Dockerfile
@@ -2,12 +2,12 @@ FROM	base/archlinux
 
 MAINTAINER	Anders Lindmark <anders.lindmark@gmail.com>
 
-# Install prerequisites 
+# Install prerequisites
 RUN		pacman-key --init && pacman-key --refresh-keys
 RUN		pacman --noconfirm -Syu && pacman-db-upgrade
 RUN		pacman --noconfirm -S gcc git make pkg-config p7zip sdl2 libpng jansson mingw-w64-gcc
 
-RUN		git clone https://github.com/ezQuake/ezquake-source.git 
+RUN		git clone https://github.com/ezQuake/ezquake-source.git
 
 ADD		mingw32-libs.tar.gz /usr/i686-w64-mingw32
 ADD		mk_nightly.sh /

--- a/misc/docker-nightly-build/Dockerfile
+++ b/misc/docker-nightly-build/Dockerfile
@@ -1,0 +1,18 @@
+FROM	base/archlinux
+
+MAINTAINER	Anders Lindmark <anders.lindmark@gmail.com>
+
+# Install prerequisites 
+RUN		pacman-key --init && pacman-key --refresh-keys
+RUN		pacman --noconfirm -Syu && pacman-db-upgrade
+RUN		pacman --noconfirm -S gcc git make pkg-config p7zip sdl2 libpng jansson mingw-w64-gcc
+
+RUN		git clone https://github.com/ezQuake/ezquake-source.git 
+
+ADD		mingw32-libs.tar.gz /usr/i686-w64-mingw32
+ADD		mk_nightly.sh /
+
+# Target volume for the nightly archive
+VOLUME	/nightly
+
+CMD		/mk_nightly.sh

--- a/misc/docker-nightly-build/README.md
+++ b/misc/docker-nightly-build/README.md
@@ -1,0 +1,41 @@
+This method of building ezQuake requires *Docker*. You can read more about it and download it from [here](https://www.docker.com/ "Docker homepage")
+
+Initialization
+==============
+First, you need to create the docker image. To do this, run `build_image.sh`.
+This will create a docker image based on Arch Linux that contains the libraries and tools required to compile linux and windows versions of ezQuake.
+
+Now that we have the image ready we can use it to start containers to build ezQuake.
+
+
+Windows
+=======
+Nightly
+-------
+If you run the build from something like crontab, i.e you only want new builds when there are new commits available, then you just need to run the container and it will check for new commits and exit if none are available.
+```shell
+docker run -v /outputdir:/nightly localghost/ezquake_nightly
+```
+Here we specify what directory the resulting 7zip-archive will be placed into (in this case "/outputdir")
+
+This can be done using the [`nightly.sh`](nightly.sh)-script. Set the environment variable *OUTPUTDIR* to where you want the files to go, for instance `OUTPUTDIR=/my_files ./nightly.sh`
+
+One-off builds
+--------------
+If you want to force a build no matter if there are new commits available or not, then you can set the FORCEBUILD environment-variable like this:
+```shell
+docker run -v /outputdir:/nightly -e "FORCEBUILD=TRUE" localghost/ezquake_nightly
+```
+
+This can be done using the [`forcebuild.sh`](forcebuild.sh)-script. Set *OUTPUTDIR* as above.
+
+Linux
+=====
+You can use the same image to build a linux-version of ezQuake. To do this run:
+```shell
+docker run -v /outputdir:/nightly localghost/ezquake\_nightly -c "cd ezquake-source; git pull; make; cp ezquake-linux-x86_64 /nightly/; make clean"
+```
+
+This can be done using the [`linux.sh`](linux.sh)-script.
+
+Please note that the build environment this uses is *Arch Linux*, if you are compiling on another distribution of linux for use on that distribution you are probably better off installing the dependencies yourself and compiling ezQuake without using this method.

--- a/misc/docker-nightly-build/build_image.sh
+++ b/misc/docker-nightly-build/build_image.sh
@@ -1,0 +1,3 @@
+wget http://uttergrottan.localghost.net/ezquake/dev/libs/mingw32-libs.tar.gz
+docker build -t localghost/ezquake_nightly .
+rm mingw32-libs.tar.gz

--- a/misc/docker-nightly-build/forcebuild.sh
+++ b/misc/docker-nightly-build/forcebuild.sh
@@ -1,0 +1,3 @@
+cd $(/usr/bin/dirname $0)
+OUTPUTDIR=$(cat image_outputdir)
+docker run -v $OUTPUTDIR:/nightly -e "FORCEBUILD=TRUE" localghost/ezquake_nightly

--- a/misc/docker-nightly-build/forcebuild.sh
+++ b/misc/docker-nightly-build/forcebuild.sh
@@ -1,3 +1,1 @@
-cd $(/usr/bin/dirname $0)
-OUTPUTDIR=$(cat image_outputdir)
 docker run -v $OUTPUTDIR:/nightly -e "FORCEBUILD=TRUE" localghost/ezquake_nightly

--- a/misc/docker-nightly-build/image_outputdir
+++ b/misc/docker-nightly-build/image_outputdir
@@ -1,1 +1,0 @@
-/where/you/want/the/nightly/archive/to/go

--- a/misc/docker-nightly-build/image_outputdir
+++ b/misc/docker-nightly-build/image_outputdir
@@ -1,0 +1,1 @@
+/where/you/want/the/nightly/archive/to/go

--- a/misc/docker-nightly-build/linux.sh
+++ b/misc/docker-nightly-build/linux.sh
@@ -1,2 +1,1 @@
-OUTPUTDIR=/where/you/want/the/linux/binary/to/go
 docker run -v $OUTPUTDIR:/nightly localghost/ezquake_nightly sh -c "cd ezquake-source; git pull; make; cp ezquake-linux-x86_64 /nightly/; make clean"

--- a/misc/docker-nightly-build/linux.sh
+++ b/misc/docker-nightly-build/linux.sh
@@ -1,0 +1,2 @@
+OUTPUTDIR=/where/you/want/the/linux/binary/to/go
+docker run -v $OUTPUTDIR:/nightly localghost/ezquake_nightly sh -c "cd ezquake-source; git pull; make; cp ezquake-linux-x86_64 /nightly/; make clean"

--- a/misc/docker-nightly-build/mk_nightly.sh
+++ b/misc/docker-nightly-build/mk_nightly.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+cd ezquake-source
+
+OREV=$(git rev-parse HEAD)
+git pull
+NREV=$(git rev-parse HEAD)
+
+if [ "$OREV" = "$NREV" ]; then
+	echo "No new build needed"
+	if [ -z "$FORCEBUILD" ]; then 
+		exit 0
+	fi
+fi
+
+DATE=$(date +"%F")
+SHORTREV=$(git rev-parse --short HEAD)
+
+EZQUAKE_FNAME="ezquake-$SHORTREV.exe"
+ARCHIVE_FNAME="$DATE-$SHORTREV-ezquake.7z"
+
+build() {
+	echo "Building ezquake $NREV" | tee -a build.log
+	EZ_CONFIG_FILE=.config_windows make |& tee -a build.log
+	if [ -e ezquake.exe ]; then
+		mv ezquake.exe $EZQUAKE_FNAME
+	else
+		echo "No output file"
+		make clean
+		exit 1
+	fi
+}
+
+make_readme() {
+	cat > README_nightly.txt <<- EOM
+		ezQuake nightly build
+
+		Please notice that this build is still in alpha so expect various problems.
+		Report any bugs at https://github.com/ezQuake/ezquake-source/issues or in #ezquake on quakenet.
+
+		Changes from last nightly build:
+	EOM
+	git log $NREV...$OREV >> README_nightly.txt
+}
+
+make_archive() {
+	if [ -e $EZQUAKE_FNAME ]; then
+		FILES+="$EZQUAKE_FNAME "
+	fi
+	if [ -e build.log ]; then
+		FILES+="build.log "
+	fi
+	if [ -e README_nightly.txt ]; then
+		FILES+="README_nightly.txt "
+	fi
+	7z a /nightly/$ARCHIVE_FNAME $FILES
+}
+
+cleanup() {
+	make clean
+	rm build.log README_nightly.txt
+}
+
+build
+make_readme
+make_archive
+cleanup

--- a/misc/docker-nightly-build/nightly.sh
+++ b/misc/docker-nightly-build/nightly.sh
@@ -1,4 +1,1 @@
-cd $(/usr/bin/dirname $0)
-OUTPUTDIR=$(cat image_outputdir)
 docker run -v $OUTPUTDIR:/nightly localghost/ezquake_nightly
-

--- a/misc/docker-nightly-build/nightly.sh
+++ b/misc/docker-nightly-build/nightly.sh
@@ -1,0 +1,4 @@
+cd $(/usr/bin/dirname $0)
+OUTPUTDIR=$(cat image_outputdir)
+docker run -v $OUTPUTDIR:/nightly localghost/ezquake_nightly
+


### PR DESCRIPTION
Scripts and Dockerfile to build windows and linux versions of ezquake. Used to create nightly builds.