### PR TITLE
Multi-monitors, non-american keyboard layouts, cyrillic characters & a fakeshaft experiment

### DIFF
--- a/cl_main.c
+++ b/cl_main.c
@@ -128,6 +128,8 @@ cvar_t	cl_demospeed = {"cl_demospeed", "1"};
 cvar_t	cl_staticsounds = {"cl_staticSounds", "1"};
 cvar_t	cl_fakeshaft = {"cl_fakeshaft", "0", 0, Rulesets_OnChange_cl_fakeshaft};
 cvar_t	cl_fakeshaft_extra_updates = {"cl_fakeshaft_extra_updates", "1"};
+cvar_t  cl_fakeshaft_clientside_beams = {"cl_fakeshaft_clientside_beams", "1"};
+cvar_t  cl_fakeshaft_clientside_damage = { "cl_fakeshaft_clientside_damage", "1" };
 cvar_t	cl_parseWhiteText = {"cl_parseWhiteText", "1"};
 cvar_t	cl_filterdrawviewmodel = {"cl_filterdrawviewmodel", "0"};
 cvar_t	cl_demoPingInterval = {"cl_demoPingInterval", "5"};
@@ -1837,6 +1839,9 @@ void CL_InitLocal (void)
 	Cvar_Register (&r_flagcolor);
 	Cvar_Register (&cl_fakeshaft);
 	Cvar_Register (&cl_fakeshaft_extra_updates);
+	Cvar_Register (&cl_fakeshaft_clientside_beams);
+	Cvar_Register (&cl_fakeshaft_clientside_damage);
+
 	Cmd_AddLegacyCommand ("cl_truelightning", "cl_fakeshaft");
 	Cvar_Register (&r_telesplash);
 	Cvar_Register (&r_shaftalpha);

--- a/cl_parse.c
+++ b/cl_parse.c
@@ -1624,6 +1624,10 @@ void CL_ParseSoundlist (void)
 			if (str[0] == '/')
 				str++; // hexum -> fixup server error (submitted by empezar bug #1026106)
 			strlcpy (cl.sound_name[numsounds], str, sizeof(cl.sound_name[numsounds]));
+
+			// Store index to lg firing sound for cl_fakeshaft 3
+			if (!strcmp(str, "weapons/lhit.wav"))
+				cl.fakeshaft.soundIndex = numsounds;
 		}
 
 		n = MSG_ReadByte();
@@ -1652,6 +1656,10 @@ void CL_ParseSoundlist (void)
 				Host_Error ("Server sent too many sound_precache");
 			str = MSG_ReadString ();
 			strlcpy (cl.sound_name[numsounds], str, sizeof(cl.sound_name[numsounds]));
+
+			// Store index to lg firing sound for cl_fakeshaft 3
+			if (!strcmp(str, "weapons/lhit.wav"))
+				cl.fakeshaft.soundIndex = numsounds;
 		} while (*str);
 	}
 
@@ -1922,6 +1930,12 @@ void CL_ParseStartSoundPacket(void)
 
 	if (cls.demoseeking)
 		return;
+
+	if (FakeshaftClientsideBeamsEnabled()) {
+		// If generating client-side beams, we will have created the sound ourselves
+		if (ent == cl.playernum + 1 && sound_num == cl.fakeshaft.soundIndex && channel == 1)
+			return;
+	}
 
     S_StartSound (ent, channel, cl.sound_precache[sound_num], pos, volume/255.0, attenuation);
 

--- a/client.h
+++ b/client.h
@@ -444,6 +444,13 @@ extern clientPersistent_t	cls;
 #define PAUSED_SERVER		1
 #define PAUSED_DEMO			2
 
+// Settings to support cl_fakeshaft 3
+typedef struct fakeshaft_s {
+	int soundIndex;						// Index for weapons/lhit.wav
+	int nextBloodTime;					// Used to limit blood instances, or we quickly run out of particles
+	vec3_t bloodPoint;					// Where last blood point was generated - filter server blood by proximity
+	float nextSoundTime;				// If we're generating beams, create sounds every 0.6 seconds
+} fakeshaft_t;
 
 /// a structure that is wiped completely at every server signon
 typedef struct {
@@ -586,6 +593,8 @@ typedef struct {
 	int			minlight;
 
 	interpolate_t	int_projectiles[MAX_PROJECTILES];
+
+	fakeshaft_t	fakeshaft;
 } clientState_t;
 
 extern	clientState_t	cl;
@@ -642,6 +651,9 @@ extern  cvar_t  cl_backpackfilter;
 extern	cvar_t	cl_muzzleflash;
 extern	cvar_t	cl_fakeshaft;
 extern	cvar_t	cl_fakeshaft_extra_updates;
+extern  cvar_t  cl_fakeshaft_clientside_beams;
+extern  cvar_t  cl_fakeshaft_clientside_damage;
+
 
 extern cvar_t r_rockettrail;
 extern cvar_t r_grenadetrail;
@@ -999,3 +1011,7 @@ qbool CL_QueInputPacket(void);
 void CL_UnqueOutputPacket(qbool sendall);
 
 // ===================================================================================
+
+// cl_fakeshaft 3 toggles
+qbool FakeshaftClientsideBeamsEnabled(void);
+qbool FakeshaftClientsideDamageEnabled(void);

--- a/cmd.c
+++ b/cmd.c
@@ -445,6 +445,7 @@ void Cmd_StuffCmds_f (void)
 void Cmd_Exec_f (void)
 {
 	char *f, name[MAX_OSPATH];
+	char reset_bindphysical[128];
 	int mark;
 
 	if (Cmd_Argc () != 2) {
@@ -471,14 +472,20 @@ void Cmd_Exec_f (void)
 		Com_Printf("execing %s/%s\n", FS_Locate_GetPath(name), name);
 	}
 
+	// All config files default to con_bindphysical 1, and would have to over-ride if they
+	//   want different behaviour.
+	sprintf(reset_bindphysical, "\ncon_bindphysical %d\n", con_bindphysical.integer);
 	if (cbuf_current == &cbuf_svc) {
+		Cbuf_AddTextEx (&cbuf_main, "con_bindphysical 1\n");
 		Cbuf_AddTextEx (&cbuf_main, f);
-		Cbuf_AddTextEx (&cbuf_main, "\n");
-	} else
-	{
-		Cbuf_InsertText ("\n");
-		Cbuf_InsertText (f);
+		Cbuf_AddTextEx (&cbuf_main, reset_bindphysical);
 	}
+	else {
+		Cbuf_InsertTextEx (&cbuf_main, reset_bindphysical);
+		Cbuf_InsertTextEx (&cbuf_main, f);
+		Cbuf_InsertTextEx (&cbuf_main, "con_bindphysical 1\n");
+	}
+	
 	Hunk_FreeToLowMark (mark);
 }
 

--- a/config_manager.c
+++ b/config_manager.c
@@ -104,8 +104,9 @@ void DumpBindings (FILE *f)
 static qbool Config_Unsaved_Cvar(const char *name)
 {
 	return (!strcmp(name, "cl_delay_packet"))
-	    || (!strcmp(name, "cl_proxyaddr"))
-	    || (!strcmp(name, "hud_planmode"));
+        || (!strcmp(name, "cl_proxyaddr"))
+        || (!strcmp(name, "hud_planmode"))
+        || (!strcmp(name, "con_bindphysical"));
 }
 
 #define CONFIG_MAX_COL 60

--- a/console.c
+++ b/console.c
@@ -73,8 +73,9 @@ cvar_t      con_sound_mm2_volume    = {"s_mm2_volume",    "1"};
 cvar_t      con_sound_spec_volume   = {"s_spec_volume",   "1"};
 cvar_t      con_sound_other_volume  = {"s_otherchat_volume",  "1"};
 
-cvar_t      con_timestamps  = {"con_timestamps", "0"};
-cvar_t      con_shift  = {"con_shift", "-10"};
+cvar_t      con_timestamps          = {"con_timestamps", "0"};
+cvar_t      con_shift               = {"con_shift", "-10"};
+cvar_t      cl_textEncoding         = {"cl_textencoding", "0"};
 
 #define	NUM_CON_TIMES 16
 float		con_times[NUM_CON_TIMES];	// cls.realtime time the line was generated
@@ -472,6 +473,8 @@ void Con_Init (void) {
 
     Cvar_ResetCurrentGroup();
 
+	Cvar_Register(&cl_textEncoding);
+
 	Cmd_AddCommand ("toggleconsole", Con_ToggleConsole_f);
 	Cmd_AddCommand ("messagemode", Con_MessageMode_f);
 	Cmd_AddCommand ("messagemode2", Con_MessageMode2_f);
@@ -648,7 +651,7 @@ void Con_PrintW (wchar *txt) {
 					Con_Linefeed ();
 				y = con.current % con_totallines;
 				idx = y * con_linewidth + con.x;
-				con.text[idx] = c | mask | con_ormask;
+				con.text[idx] = c | (c <= 0x7F ? mask | con_ormask : 0);	// only apply mask if in 'standard' charset
 				memset(&con.clr[idx], 0, sizeof(clrinfo_t)); // zeroing whole struct
 				con.clr[idx].c = color;
 				con.clr[idx].i = idx; // no, that not stupid :P

--- a/draw.h
+++ b/draw.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef __DRAW_H__
 #define __DRAW_H__
 
-#define MAX_CHARSETS 16
+#define MAX_CHARSETS 256
 extern int		char_textures[MAX_CHARSETS];
 
 typedef struct

--- a/gl_draw.c
+++ b/gl_draw.c
@@ -689,6 +689,7 @@ static int Draw_LoadCharset(const char *name)
 {
 	int flags = TEX_ALPHA | TEX_NOCOMPRESS | TEX_NOSCALE | TEX_NO_TEXTUREMODE;
 	int texnum;
+	int i = 0;
 	qbool loaded = false;
 
 	//
@@ -716,9 +717,21 @@ static int Draw_LoadCharset(const char *name)
 		return 1;
 	}
 
-	// Load cyrillic charset if available
-	Load_Locale_Charset(name, "cyr", 1, 0x0400, flags);
+	// Load alternate charsets if available
+	for (i = 1; i < MAX_CHARSETS; ++i)
+	{
+		char charsetName[10];
+		int textureNumber;
+		
+		snprintf(charsetName, sizeof(charsetName), "%03d", i);
 
+		textureNumber = Load_Locale_Charset(name, charsetName, i, i << 8, flags);
+
+		// 2.2 only supported -cyr suffix
+		if (i == 4 && !textureNumber)
+			Load_Locale_Charset(name, "cyr", 4, 0x0400, flags);
+	}
+	
 	// apply gl_smoothfont
 	Apply_OnChange_gl_smoothfont(gl_smoothfont.integer);
 

--- a/in_sdl2.c
+++ b/in_sdl2.c
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 cvar_t	m_filter        = {"m_filter",       "0", CVAR_SILENT};
 cvar_t	cl_keypad       = {"cl_keypad",      "1", CVAR_SILENT};
-cvar_t	m_showrate      = {"m_showrate",     "0", CVAR_SILENT};
 
 extern int mx, my;
 extern qbool mouseinitialized;
@@ -105,10 +104,6 @@ void IN_MouseMove (usercmd_t *cmd)
 
 void IN_Move (usercmd_t *cmd)
 {
-	if (m_showrate.value && (mx || my)) {
-		Com_Printf("Not implemented.\n");
-	}
-
 	IN_MouseMove (cmd);
 }
 
@@ -116,7 +111,6 @@ void IN_Init (void)
 {
 	Cvar_SetCurrentGroup (CVAR_GROUP_INPUT_MOUSE);
 	Cvar_Register (&m_filter);
-	Cvar_Register (&m_showrate);
 
 	Cvar_SetCurrentGroup (CVAR_GROUP_INPUT_KEYBOARD);
 	Cvar_Register (&cl_keypad);

--- a/keys.h
+++ b/keys.h
@@ -227,6 +227,8 @@ extern int		key_linepos;
 extern int		edit_line;
 extern qbool	con_redchars;
 
+extern cvar_t	con_bindphysical;
+
 #define CONSOLE_LINE_EMPTY() (!key_lines[edit_line][1])
 
 // }

--- a/menu.c
+++ b/menu.c
@@ -488,7 +488,10 @@ void M_Main_Key (int key) {
 	switch (key) {
 	case K_ESCAPE:
 	case K_MOUSE2:
-		key_dest = key_game;
+		if (cls.state < ca_active)
+			key_dest = key_console;
+		else 
+			key_dest = key_game;
 		m_state = m_none;
 		break;
 

--- a/rulesets.c
+++ b/rulesets.c
@@ -417,7 +417,9 @@ void Rulesets_OnChange_cl_fakeshaft (cvar_t *var, char *value, qbool *cancel)
 
 
  	if (!cl.spectator && cls.state != ca_disconnected) {
-		if (fakeshaft == 2)
+		if (fakeshaft == 3)
+			Cbuf_AddText("say fakeshaft 3 (fakeshaft 0 for antilag, and extra client-side prediction)\n");
+		else if (fakeshaft == 2)
 			Cbuf_AddText("say fakeshaft 2 (emulation of fakeshaft 0 for servers with antilag feature)\n");
 		else if (fakeshaft > 0.999)
 			Cbuf_AddText ("say fakeshaft on\n");

--- a/teamplay.c
+++ b/teamplay.c
@@ -1165,7 +1165,7 @@ wchar *TP_ParseWhiteText (const wchar *s, qbool team, int offset)
 				continue;
 			}
 		}
-		if (*p != 10 && *p != 13 && !(p==s && (*p==1 || *p==2)))
+		if (*p != 10 && *p != 13 && !(p==s && (*p==1 || *p==2)) && *p <= 0x7F)
 			*out++ = *p | 128;	// convert to red
 		else
 			*out++ = *p;

--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -55,6 +55,9 @@ static void GrabMouse(qbool grab, qbool raw);
 static void GfxInfo_f(void);
 static void HandleEvents();
 static void VID_UpdateConRes(void);
+static int VID_DisplayNumber(qbool fullscreen);
+static void VID_RelativePositionFromAbsolute(int* x, int* y, int* display);
+static void VID_AbsolutePositionFromRelative(int* x, int* y, int* display);
 void IN_Restart_f(void);
 
 static SDL_Window       *sdl_window;
@@ -90,6 +93,7 @@ cvar_t r_stencilbits          = {"vid_stencilbits",       "8",   CVAR_LATCH };
 cvar_t r_depthbits            = {"vid_depthbits",         "0",   CVAR_LATCH };
 cvar_t r_fullscreen           = {"vid_fullscreen",        "1",   CVAR_LATCH };
 cvar_t r_displayRefresh       = {"vid_displayfrequency",  "0",   CVAR_LATCH };
+cvar_t vid_displayNumber	  = {"vid_displaynumber",     "0",   CVAR_LATCH };
 cvar_t vid_usedesktopres      = {"vid_usedesktopres",     "1",   CVAR_LATCH };
 cvar_t vid_win_borderless     = {"vid_win_borderless",    "0",   CVAR_LATCH };
 cvar_t vid_width              = {"vid_width",             "0",   CVAR_LATCH };
@@ -107,6 +111,7 @@ cvar_t r_win_save_pos         = {"vid_win_save_pos",      "1",   CVAR_SILENT };
 cvar_t r_win_save_size        = {"vid_win_save_size",     "1",   CVAR_SILENT };
 cvar_t vid_xpos               = {"vid_xpos",              "3",   CVAR_SILENT };
 cvar_t vid_ypos               = {"vid_ypos",              "39",  CVAR_SILENT };
+cvar_t vid_win_displayNumber  = {"vid_win_displaynumber", "0",   CVAR_SILENT };
 cvar_t r_conwidth             = {"vid_conwidth",          "0",   CVAR_NO_RESET | CVAR_SILENT, conres_changed_callback };
 cvar_t r_conheight            = {"vid_conheight",         "0",   CVAR_NO_RESET | CVAR_SILENT, conres_changed_callback };
 cvar_t r_conscale             = {"vid_conscale",          "2.0", CVAR_NO_RESET | CVAR_SILENT, conres_changed_callback };
@@ -263,8 +268,15 @@ static void window_event(SDL_WindowEvent *event)
 
 		case SDL_WINDOWEVENT_MOVED:
 			if (!(flags & SDL_WINDOW_FULLSCREEN) && r_win_save_pos.integer) {
-				Cvar_SetValue(&vid_ypos, event->data2);
-				Cvar_SetValue(&vid_xpos, event->data1);
+				int displayNumber = 0;
+				int x = event->data1;
+				int y = event->data2;
+
+				VID_RelativePositionFromAbsolute(&x, &y, &displayNumber);
+
+				Cvar_SetValue(&vid_win_displayNumber, displayNumber);
+				Cvar_SetValue(&vid_xpos, x);
+				Cvar_SetValue(&vid_ypos, y);
 			}
 			break;
 
@@ -504,6 +516,7 @@ void VID_RegisterLatchCvars(void)
 	Cvar_Register(&vid_usedesktopres);
 	Cvar_Register(&vid_win_borderless);
 	Cvar_Register(&gl_multisamples);
+	Cvar_Register(&vid_displayNumber);
 
 	Cvar_ResetCurrentGroup();
 }
@@ -525,6 +538,7 @@ void VID_RegisterCvars(void)
 	Cvar_Register(&r_conscale);
 	Cvar_Register(&vid_flashonactivity);
 	Cvar_Register(&r_showextensions);
+	Cvar_Register(&vid_win_displayNumber);
 
 	Cvar_ResetCurrentGroup();
 }
@@ -549,7 +563,7 @@ static void VID_SetupResolution(void)
 
 	if (r_fullscreen.integer == 1) {
 		if (vid_usedesktopres.integer == 1) {
-			if (SDL_GetDesktopDisplayMode(0, &display_mode) == 0) {
+			if (SDL_GetDesktopDisplayMode(VID_DisplayNumber(true), &display_mode) == 0) {
 				glConfig.vidWidth = display_mode.w;
 				glConfig.vidHeight = display_mode.h;
 				glConfig.displayFrequency = display_mode.refresh_rate;
@@ -685,9 +699,34 @@ static void VID_SDL_Init(void)
 	VID_SetupResolution();
 
 	if (r_fullscreen.integer == 0) {
-		sdl_window = SDL_CreateWindow(WINDOW_CLASS_NAME, vid_xpos.integer, vid_ypos.integer, glConfig.vidWidth, glConfig.vidHeight, flags);
+		int displayNumber = VID_DisplayNumber(false);
+		int xpos = vid_xpos.integer;
+		int ypos = vid_ypos.integer;
+
+		VID_AbsolutePositionFromRelative(&xpos, &ypos, &displayNumber);
+
+		sdl_window = SDL_CreateWindow(WINDOW_CLASS_NAME, xpos, ypos, glConfig.vidWidth, glConfig.vidHeight, flags);
 	} else {
-		sdl_window = SDL_CreateWindow(WINDOW_CLASS_NAME, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, glConfig.vidWidth, glConfig.vidHeight, flags);
+		int windowWidth = glConfig.vidWidth;
+		int windowHeight = glConfig.vidHeight;
+		int windowX = SDL_WINDOWPOS_CENTERED;
+		int windowY = SDL_WINDOWPOS_CENTERED;
+		int displayNumber = VID_DisplayNumber(true);
+		SDL_Rect bounds;
+
+		if (SDL_GetDisplayBounds(displayNumber, &bounds) == 0)
+		{
+			windowX = bounds.x;
+			windowY = bounds.y;
+			windowWidth = bounds.w;
+			windowHeight = bounds.h;
+		}
+		else
+		{
+			Com_Printf("Couldn't determine bounds of display #%d, defaulting to main display\n");
+		}
+
+		sdl_window = SDL_CreateWindow(WINDOW_CLASS_NAME, windowX, windowY, windowWidth, windowHeight, flags);
 	}
 
 	if (r_fullscreen.integer > 0 && vid_usedesktopres.integer != 1) {
@@ -941,7 +980,7 @@ static void GfxInfo_f(void)
 
 	Com_Printf_State(PRINT_ALL, "PIXELFORMAT: color(%d-bits) Z(%d-bit)\n             stencil(%d-bits)\n", glConfig.colorBits, glConfig.depthBits, glConfig.stencilBits);
 
-	if (SDL_GetCurrentDisplayMode(0, &current) != 0) {
+	if (SDL_GetCurrentDisplayMode(VID_DisplayNumber(r_fullscreen.value), &current) != 0) {
 		current.refresh_rate = 0; // print 0Hz if we run into problem fetching data
 	}
 
@@ -959,7 +998,7 @@ static void GfxInfo_f(void)
 
 static void VID_ParseCmdLine(void)
 {
-	int i, w = 0, h = 0;
+	int i, w = 0, h = 0, display = 0;
 
 	if (COM_CheckParm("-window") || COM_CheckParm("-startwindowed")) {
 		Cvar_LatchedSetValue(&r_fullscreen, 0);
@@ -975,6 +1014,15 @@ static void VID_ParseCmdLine(void)
 
 	w = ((i = COM_CheckParm("-width"))  && i + 1 < COM_Argc()) ? Q_atoi(COM_Argv(i + 1)) : 0;
 	h = ((i = COM_CheckParm("-height")) && i + 1 < COM_Argc()) ? Q_atoi(COM_Argv(i + 1)) : 0;
+
+	display = ((i = COM_CheckParm("-display")) && i + 1 < COM_Argc()) ? Q_atoi(COM_Argv(i + 1)) : 0;
+	if (i) {
+		if (COM_CheckParm("-window")) {
+			Cvar_LatchedSetValue(&vid_win_displayNumber, display);
+		} else {
+			Cvar_LatchedSetValue(&vid_displayNumber, display);
+		}
+	}
 
 	if (w && h) {
 		if (COM_CheckParm("-window")) {
@@ -1110,3 +1158,61 @@ void VID_Init(unsigned char *palette) {
 	GL_Init(); // Real OpenGL stuff, vid_common_gl.c
 }
 
+// Returns valid display number
+static int VID_DisplayNumber(qbool fullscreen)
+{
+	int displayNumber = (fullscreen ? vid_displayNumber.value : vid_win_displayNumber.value);
+	int displays = SDL_GetNumVideoDisplays();
+
+	return max(0, min(displays - 1, displayNumber));
+}
+
+// Converts co-ordinates for the whole desktop to co-ordinates for a specific display
+static void VID_RelativePositionFromAbsolute(int* x, int* y, int* display)
+{
+	int displays = SDL_GetNumVideoDisplays();
+	int i = 0;
+
+	for (i = 0; i < displays; ++i)
+	{
+		SDL_Rect bounds;
+
+		if (SDL_GetDisplayBounds(i, &bounds) == 0)
+		{
+			if (*x >= bounds.x && *x < bounds.x + bounds.w && *y >= bounds.y && *y < bounds.y + bounds.h)
+			{
+				*x = *x - bounds.x;
+				*y = *y - bounds.y;
+				*display = i;
+				return;
+			}
+		}
+	}
+
+	*display = 0;
+}
+
+// Converts co-ordinates for a specific display to those for whole desktop
+static void VID_AbsolutePositionFromRelative(int* x, int* y, int* display)
+{
+	SDL_Rect bounds;
+	int width = 0;
+	int height = 0;
+	
+	// Try and get bounds for the specified display - default back to main display if there's an issue
+	if (SDL_GetDisplayBounds(*display, &bounds))
+	{
+		*display = 0;
+		if (SDL_GetDisplayBounds(*display, &bounds))
+		{
+			// Still an issue - reset back to top-left of screen
+			Com_Printf("Error detecting resolution...\n");
+			*x = *y = 0;
+			return;
+		}
+	}
+
+	// Adjust co-ordinates, making sure some of the window will always be visible
+	*x = bounds.x + min(*x, bounds.w - 30);
+	*y = bounds.y + min(*y, bounds.h - 30);
+}

--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -93,7 +93,7 @@ cvar_t r_stencilbits          = {"vid_stencilbits",       "8",   CVAR_LATCH };
 cvar_t r_depthbits            = {"vid_depthbits",         "0",   CVAR_LATCH };
 cvar_t r_fullscreen           = {"vid_fullscreen",        "1",   CVAR_LATCH };
 cvar_t r_displayRefresh       = {"vid_displayfrequency",  "0",   CVAR_LATCH };
-cvar_t vid_displayNumber	  = {"vid_displaynumber",     "0",   CVAR_LATCH };
+cvar_t vid_displayNumber      = {"vid_displaynumber",     "0",   CVAR_LATCH };
 cvar_t vid_usedesktopres      = {"vid_usedesktopres",     "1",   CVAR_LATCH };
 cvar_t vid_win_borderless     = {"vid_win_borderless",    "0",   CVAR_LATCH };
 cvar_t vid_width              = {"vid_width",             "0",   CVAR_LATCH };
@@ -723,7 +723,7 @@ static void VID_SDL_Init(void)
 		}
 		else
 		{
-			Com_Printf("Couldn't determine bounds of display #%d, defaulting to main display\n");
+			Com_Printf("Couldn't determine bounds of display #%d, defaulting to main display\n", displayNumber);
 		}
 
 		sdl_window = SDL_CreateWindow(WINDOW_CLASS_NAME, windowX, windowY, windowWidth, windowHeight, flags);


### PR DESCRIPTION
This will need a reasonable amount of testing by people with varying configurations.

- Extra cvars to choose which display to use (vid_displayNumber / vid_win_displayNumber).

- Support for keyboard layouts - in SDL2 this means picking up the TextInput event, as the unicode character(s) don't get passed with key up/down.  Have done some testing of other layouts, generating cyrillic characters, euro symbols etc.  See below for change to bind command.

- Cyrillic characters - now support various encoding methods for unicode for outgoing characters (cl_textencoding cvar), but default is 2.2's k8 encoding (more work to be done for utf8 generally)

- Character sets can now cover the 3-byte range of utf8 values (0-0xFFFF), if initial charset is called XXX then system will attempt to load XXX-yyy (yyy = 001 upwards), with special case for -004 falling back to -cyr, for backwards compatibility with existing configurations.

- cl_fakeshaft 3 - very experimental change to 'fix' the shaft's position being antilagged but on/off status and all damage indicators being lagged as usual - probably no benefit over LAN, possibly no benefit at all.  Not expected to hurt nor help LG % very much, but remove worries where the player appears to be shooting the opponent but no damage/blood is appearing.  Downside is an FPS hit for the collision detection of beam & opponents.

- con_bindphysical cvar: bind command behaviour changes if executed in a script or at the console.  Example of problem:

> User is in DVORAK layout
> Type type "bind o +back" at the console.
> To type the o, they would have pressed the button that Quake/QWERTY considers to be S
> They then execute a configuration someone has given them, that person has QWERTY keyboard
> Configuration contains "bind s +back"
> In this case, s means Quake key S

To solve this, con_bindphysical determines if the bind key refers to the physical key or a logical key that matches the user's keyboard layout.  When a configuration file is executed, con_bindphysical is set to 1, and reset back to its original value after execution.  This means that all configuration files passed around will be saved in the second format, and so the layout of the keys for playing the game will remain constant.

If there was a need for a key to correspond to a command (for example, a demo-watching config where T toggled teaminfo overlay, R toggled layout etc) then the configuration file would have to contain "con_bindphysical 0" at the top... then whoever executed it (on whatever layout) would always press the key labelled on their keyboard as R, regardless of what layout it was.  Hopefully this keeps backwards compatibility with existing config files but allows an easy way to bind keys at the console.