### PR TITLE
Fixes for the nightly build scripts.

### DIFF
--- a/misc/docker-nightly-build/Dockerfile
+++ b/misc/docker-nightly-build/Dockerfile
@@ -1,18 +1,21 @@
-FROM	base/archlinux
+FROM base/archlinux
 
-MAINTAINER	Anders Lindmark <anders.lindmark@gmail.com>
+MAINTAINER Anders Lindmark <anders.lindmark@gmail.com>
 
 # Install prerequisites
-RUN		pacman-key --init && pacman-key --refresh-keys
-RUN		pacman --noconfirm -Syu && pacman-db-upgrade
-RUN		pacman --noconfirm -S gcc git make pkg-config p7zip sdl2 libpng jansson mingw-w64-gcc
+RUN pacman-key --init && pacman-key --refresh-keys
+RUN pacman --noconfirm -Syu && pacman-db-upgrade
+RUN pacman --noconfirm -S gcc git make pkg-config p7zip sdl2 libpng jansson libjpeg-turbo mingw-w64-gcc
 
-RUN		git clone https://github.com/ezQuake/ezquake-source.git
-
-ADD		mingw32-libs.tar.gz /usr/i686-w64-mingw32
-ADD		mk_nightly.sh /
+# Add libraries and buildscript
+ADD mingw32-libs.tar.gz /usr/i686-w64-mingw32
+ADD mk_nightly.sh /
 
 # Target volume for the nightly archive
-VOLUME	/nightly
+VOLUME /source
+VOLUME /nightly
 
-CMD		/mk_nightly.sh
+# Default target platform
+ENV TARGET_PLATFORM WINDOWS
+
+CMD /mk_nightly.sh

--- a/misc/docker-nightly-build/README.md
+++ b/misc/docker-nightly-build/README.md
@@ -14,28 +14,39 @@ Nightly
 -------
 If you run the build from something like crontab, i.e you only want new builds when there are new commits available, then you just need to run the container and it will check for new commits and exit if none are available.
 ```shell
-docker run -v /outputdir:/nightly localghost/ezquake_nightly
+docker run \
+	-v /outputdir:/nightly \
+	-v /sourcedir:/source \
+	localghost/ezquake_nightly
 ```
-Here we specify what directory the resulting 7zip-archive will be placed into (in this case "/outputdir")
+Here we specify what directory the resulting 7zip-archive will be placed into (in this case "/outputdir") and what directory the ezquake-source repository will be cloned into (in this case "/sourcedir")
 
-This can be done using the [`nightly.sh`](nightly.sh)-script. Set the environment variable *OUTPUTDIR* to where you want the files to go, for instance `OUTPUTDIR=/my_files ./nightly.sh`
+This can be done using the [`nightly.sh`](nightly.sh)-script. Set the environment variables *OUTPUTDIR* to where you want the files to go, and *SOURCEDIR* to where you want the ezquake source to be kept before calling the script.
 
 One-off builds
 --------------
 If you want to force a build no matter if there are new commits available or not, then you can set the FORCEBUILD environment-variable like this:
 ```shell
-docker run -v /outputdir:/nightly -e "FORCEBUILD=TRUE" localghost/ezquake_nightly
+docker run \
+	-v /outputdir:/nightly \
+	-v /sourcedir:/source \
+	-e "FORCEBUILD=TRUE" \
+	localghost/ezquake_nightly
 ```
 
-This can be done using the [`forcebuild.sh`](forcebuild.sh)-script. Set *OUTPUTDIR* as above.
+This can be done using the [`forcebuild.sh`](forcebuild.sh)-script. Set *OUTPUTDIR* and *SOURCEDIR* as above.
 
 Linux
 =====
 You can use the same image to build a linux-version of ezQuake. To do this run:
 ```shell
-docker run -v /outputdir:/nightly localghost/ezquake\_nightly -c "cd ezquake-source; git pull; make; cp ezquake-linux-x86_64 /nightly/; make clean"
+docker run \
+	-v /outputdir:/nightly \
+	-v /sourcedir:/source \
+	-e "TARGET_PLATFORM=LINUX" \
+	localghost/ezquake_nightly
 ```
 
-This can be done using the [`linux.sh`](linux.sh)-script.
+This can be done using the [`linux.sh`](linux.sh)-script. *FORCEBUILD* works here too and you need to set *OUTPUTDIR* and *SOURCEDIR* as well.
 
 Please note that the build environment this uses is *Arch Linux*, if you are compiling on another distribution of linux for use on that distribution you are probably better off installing the dependencies yourself and compiling ezQuake without using this method.

--- a/misc/docker-nightly-build/forcebuild.sh
+++ b/misc/docker-nightly-build/forcebuild.sh
@@ -1,1 +1,5 @@
-docker run -v $OUTPUTDIR:/nightly -e "FORCEBUILD=TRUE" localghost/ezquake_nightly
+docker run \
+	-v $SOURCEDIR:/source \
+	-v $OUTPUTDIR:/nightly \
+	-e "FORCEBUILD=TRUE" \
+	localghost/ezquake_nightly

--- a/misc/docker-nightly-build/linux.sh
+++ b/misc/docker-nightly-build/linux.sh
@@ -1,1 +1,5 @@
-docker run -v $OUTPUTDIR:/nightly localghost/ezquake_nightly sh -c "cd ezquake-source; git pull; make; cp ezquake-linux-x86_64 /nightly/; make clean"
+docker run \
+	-v $SOURCEDIR:/source \
+	-v $OUTPUTDIR:/nightly \
+	-e "TARGET_PLATFORM=LINUX" \
+	localghost/ezquake_nightly

--- a/misc/docker-nightly-build/nightly.sh
+++ b/misc/docker-nightly-build/nightly.sh
@@ -1,1 +1,5 @@
-docker run -v $OUTPUTDIR:/nightly localghost/ezquake_nightly
+docker run \
+	-v $SOURCEDIR:/source \
+	-v $OUTPUTDIR:/nightly \
+	localghost/ezquake_nightly
+


### PR DESCRIPTION
Updated the **Dockerfile** to 
* Include the jpeg-lib for linux builds (also updated the mingw32 archive to include this lib, which resolves issue #50 )
* Add a /source-volume to keep the source in, instead of letting them reset to the time the image was created on every run.
* Removed tab-indentation to appease the wrath of @JoakimSoderberg 

**mk_nightly.sh**
Use /source instead of container-local storage. Initialize the repository if needed.
Use the same script to build for both linux and windows builds.

Updated helper scripts and README.md reflect these changes 