### PR TITLE
KEYS_C: Let -action events fire when clearing key states.

### DIFF
--- a/keys.c
+++ b/keys.c
@@ -2254,6 +2254,9 @@ void Key_ClearStates (void)
 
 	for (i = 0; i < sizeof(keydown) / sizeof(*keydown); i++) 
 	{
+		if (keydown[i])
+			Key_Event(i, false);
+
 		keydown[i] = false;
 		key_repeats[i] = false;
 	}


### PR DESCRIPTION
Key_ClearStates is called during vid_refresh, this makes sure any keys held down at the time bound to +alias fire appropriate -alias event.