### PR TITLE
Don't download mingw32-libs from external source

### DIFF
--- a/misc/docker-nightly-build/Dockerfile
+++ b/misc/docker-nightly-build/Dockerfile
@@ -7,8 +7,7 @@ RUN pacman-key --init && pacman-key --refresh-keys
 RUN pacman --noconfirm -Syu && pacman-db-upgrade
 RUN pacman --noconfirm -S gcc git make pkg-config p7zip sdl2 libpng jansson libjpeg-turbo mingw-w64-gcc
 
-# Add libraries and buildscript
-ADD mingw32-libs.tar.gz /usr/i686-w64-mingw32
+# Add buildscript
 ADD mk_nightly.sh /
 
 # Target volume for the nightly archive

--- a/misc/docker-nightly-build/README.md
+++ b/misc/docker-nightly-build/README.md
@@ -2,7 +2,11 @@ This method of building ezQuake requires *Docker*. You can read more about it an
 
 Initialization
 ==============
-First, you need to create the docker image. To do this, run `build_image.sh`.
+First, you need to create the docker image. You can do this by running
+```shell
+docker build -t localghost/ezquake_nightly .
+```
+or using the [`build_image.sh`](build_image.sh)-script.
 This will create a docker image based on Arch Linux that contains the libraries and tools required to compile linux and windows versions of ezQuake.
 
 Now that we have the image ready we can use it to start containers to build ezQuake.

--- a/misc/docker-nightly-build/build_image.sh
+++ b/misc/docker-nightly-build/build_image.sh
@@ -1,3 +1,1 @@
-wget http://uttergrottan.localghost.net/ezquake/dev/libs/mingw32-libs.tar.gz
 docker build -t localghost/ezquake_nightly .
-rm mingw32-libs.tar.gz


### PR DESCRIPTION
Now that the mingw32-libs are in the repository we don't need to download them when building the image