### PR TITLE
Various small fixes & qtv_fixuser command

### DIFF
--- a/cl_parse.c
+++ b/cl_parse.c
@@ -129,7 +129,6 @@ char *svc_strings[] = {
 
 const int num_svc_strings = sizeof(svc_strings)/sizeof(svc_strings[0]);
 
-int	oldparsecountmod;
 int	parsecountmod;
 double	parsecounttime;
 
@@ -1937,8 +1936,6 @@ void CL_ParseClientdata (void)
 	frame_t *frame;
 
 	// calculate simulated time of message
-	oldparsecountmod = parsecountmod;
-
 	newparsecount = cls.netchan.incoming_acknowledged;
 
 	cl.oldparsecount = (cls.mvdplayback) ? newparsecount - 1 : cl.parsecount;
@@ -3179,7 +3176,7 @@ void CL_MuzzleFlash (void)
 		return;
 
 	dl = CL_AllocDlight(-i);
-	state = &cl.frames[cls.mvdplayback ? oldparsecountmod : parsecountmod].playerstate[i - 1];
+	state = &cl.frames[cls.mvdplayback ? (cl.oldparsecount & UPDATE_MASK) : parsecountmod].playerstate[i - 1];
 
 	if ((i - 1) == cl.viewplayernum)
 	{

--- a/config_manager.c
+++ b/config_manager.c
@@ -258,6 +258,7 @@ void DumpVariablesDefaults_f(void)
 	cvar_group_t *group;
     char filepath[MAX_PATH];
     FILE *f;
+	qbool anyUngrouped = false;
 
     snprintf(filepath, sizeof(filepath), "%s/ezquake/configs/cvar_defaults.cfg", com_basedir);
 
@@ -273,6 +274,16 @@ void DumpVariablesDefaults_f(void)
 
         for (var = group->head; var; var = var->next_in_group) {
 			fprintf(f, "%s \"%s\"\n", var->name, var->defaultvalue);
+		}
+	}
+
+	// Add those without
+	for (var = cvar_vars; var; var = var->next) {
+		if (!var->group && !(var->flags & (CVAR_USER_CREATED | CVAR_ROM | CVAR_INIT))) {
+			if (!anyUngrouped)
+				fprintf(f, "\n//\n");
+			fprintf(f, "%s \"%s\"\n", var->name, var->defaultvalue);
+			anyUngrouped = true;
 		}
 	}
 


### PR DESCRIPTION
score_bar changes are response to request from andeh, so he can get hud to keep scores in same position as point of view changes (example https://www.youtube.com/watch?v=3mJDh8NNSsQ)

qtv_fixuser allows user to directly set name/team/colour of users when viewing a QTV stream (commonly-deployed version of QTV has bug that can corrupt userinfo strings)

Muzzle flashes - during MVD playback, client was creating dynamic lights for muzzle flashes several (sometimes 63 by end of demo) frames behind the current frame.  (example at https://www.youtube.com/watch?v=GlFJWXR2jdM)