### PR TITLE
Teamplay updates for pickup detection & location reporting, compiler warning fixes

### DIFF
--- a/client.h
+++ b/client.h
@@ -586,6 +586,10 @@ typedef struct {
 	int			minlight;
 
 	interpolate_t	int_projectiles[MAX_PROJECTILES];
+
+	int         last_armor_pickup;
+	int         last_weapon_pickup;
+	int         last_ammo_pickup;
 } clientState_t;
 
 extern	clientState_t	cl;

--- a/gl_rpart.c
+++ b/gl_rpart.c
@@ -988,7 +988,11 @@ __inline static void AddParticle(part_type_t type, vec3_t org, int count, float 
 	if (!qmb_initialized)
 		Sys_Error("QMB particle added without initialization");
 
-	assert(size > 0 && time > 0);
+	if (size <= 0 || time <= 0)
+	{
+		Con_DPrintf("AddParticle() failed, type %d, size %f, time %f\n", type, size, time);
+		return;
+	}
 
 	if (type < 0 || type >= num_particletypes)
 		Sys_Error("AddParticle: Invalid type (%d)", type);
@@ -2922,7 +2926,7 @@ void VX_TeslaCharge (vec3_t org)
 void VX_LightningBeam (vec3_t start, vec3_t end)
 {
 	//col_t color={120,140,255,255};
-	AddParticle(p_lightningbeam, start, 1, 100, cls.frametime*2, amf_lightning_color.color, end);
+	AddParticle(p_lightningbeam, start, 1, 100, min(0.013, cls.frametime*2), amf_lightning_color.color, end);
 }
 
 //VULT PARTICLES

--- a/hud_common.c
+++ b/hud_common.c
@@ -5609,7 +5609,7 @@ void SCR_HUD_DrawScoresBar(hud_t *hud)
 			if(	(cls.demoplayback && !cl.spectator && !cls.mvdplayback && strcmp(sorted_teams[i].name, cl.players[cl.playernum].team) == 0) ||
 				((cls.demoplayback || cl.spectator) && ((strcmp(cl.players[spec_track].team, sorted_teams[i].name) == 0) && (Cam_TrackNum() >= 0))) ||
 				(strcmp(sorted_teams[i].name, cl.players[cl.playernum].team) == 0) ||
-				((cls.demoplayback || cl.spectator) && Cam_TrackNum() < 0))
+				((cls.mvdplayback || cl.spectator) && Cam_TrackNum() < 0))
 			{
 				s_team = sorted_teams[i].frags;
 				n_team = sorted_teams[i].name;
@@ -5632,7 +5632,7 @@ void SCR_HUD_DrawScoresBar(hud_t *hud)
 			if ((cls.demoplayback && !cl.spectator && !cls.mvdplayback && strcmp(cl.players[sorted_players[i].playernum].name, cl.players[cl.playernum].name) == 0) ||
 				((cls.demoplayback || cl.spectator) && ((strcmp(cl.players[spec_track].name, cl.players[sorted_players[i].playernum].name) == 0) && (Cam_TrackNum() >= 0))) ||
 				(strcmp(cl.players[sorted_players[i].playernum].name, cl.players[cl.playernum].name) == 0) ||
-				((cls.demoplayback || cl.spectator) && Cam_TrackNum() < 0))
+				((cls.mvdplayback || cl.spectator) && Cam_TrackNum() < 0))
 			{
 				// This is the current player
 				s_team = cl.players[sorted_players[i].playernum].frags;

--- a/menu_mp3player.c
+++ b/menu_mp3player.c
@@ -446,11 +446,8 @@ void M_Menu_MP3_Playlist_Read(void) {
 void M_Menu_MP3_Playlist_Draw(void) {
 	int		index, print_time, i, count;
 	char 	name[PLAYLIST_MAXTITLE], *s;
-	float 	realtime;
 
 	static int last_status,last_elapsed, last_total, last_current;
-
-	realtime = Sys_DoubleTime();
 
 	last_status = MP3_GetStatus();
 

--- a/movie.c
+++ b/movie.c
@@ -377,8 +377,6 @@ short* Movie_SoundBuffer(void)
 }
 
 void Movie_TransferStereo16(void) {
-	int val, i;
-
 	if (!movie_is_avi || !Movie_IsCapturing())
 		return;
 

--- a/mp3_winamp.c
+++ b/mp3_winamp.c
@@ -229,10 +229,8 @@ void MP3_WINAMP_Execute_f(void)
 
 #define WINAMP_COMMAND(Name, Param)									\
 	void MP3_WINAMP_##Name##_f(void) {								\
-		int ret;													\
-																	\
 		if (MP3_WINAMP_IsPlayerRunning())							\
-			ret = SendMessage(mp3_hwnd, WM_COMMAND, Param, 0);		\
+			SendMessage(mp3_hwnd, WM_COMMAND, Param, 0);		\
 		else														\
 			Com_Printf("%s is not running\n", mp3_player->PlayerName_LeadingCaps); \
 	}
@@ -510,7 +508,7 @@ void MP3_WINAMP_GetSongTitle(int track_num, char *song, size_t song_len) {
 
 void MP3_WINAMP_PrintPlaylist_f(void) 
 {
-	int i, current;
+	int i, current = 0;
 
 	/* Force a cache refill */
 	if (MP3_WINAMP_CachePlaylist())
@@ -526,7 +524,7 @@ void MP3_WINAMP_PrintPlaylist_f(void)
 
 void MP3_WINAMP_PlayTrackNum_f(void) 
 {
-	int pos, length;
+	int pos, length = 0;
 
 	if (!MP3_WINAMP_IsPlayerRunning()) {
 		Com_Printf("%s is not running\n", mp3_player->PlayerName_LeadingCaps);

--- a/sv_main.c
+++ b/sv_main.c
@@ -25,8 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 int telnetport = 0; // FIXME, perhaps just remove rest of telnet code
 
-struct timeval select_timeout;
-
 qbool		host_initialized;		// true if into command execution (compatability)
 qbool		host_everything_loaded;	// true if OnChange() applied to every var, end of Host_Init()
 
@@ -45,20 +43,6 @@ cvar_t	sv_cpserver = {"sv_cpserver", "0"};	// some cp servers couse lags on map 
 
 cvar_t	sv_mintic = {"sv_mintic","0.013"};	// bound the size of the
 cvar_t	sv_maxtic = {"sv_maxtic","0.1"};	// physics time tic
-
-void OnChange_sysselecttimeout_var (cvar_t *var, char *value, qbool *cancel);
-cvar_t	sys_select_timeout = {"sys_select_timeout",
-#ifdef _WIN32
-							"10000"
-#else
-							"1000000"
-#endif
-							, 0, OnChange_sysselecttimeout_var};
-// MUST be set to ~ (sv_mintic / 1.3) * 1 000 000 = 10 000
-// (else can occur packets lost if sv_minping > 0)
-// if set too low then occur higher CPU usage
-
-cvar_t	sys_restart_on_error = {"sys_restart_on_error", "0"};
 
 //cvar_t	developer = {"developer", "0"};		// show extra messages
 
@@ -3292,8 +3276,6 @@ void SV_InitLocal (void)
 
 	Cvar_Register (&sv_mintic);
 	Cvar_Register (&sv_maxtic);
-	Cvar_Register (&sys_select_timeout);
-	Cvar_Register (&sys_restart_on_error);
 
 	Cvar_Register (&skill);
 	Cvar_Register (&coop);
@@ -3621,23 +3603,6 @@ void SV_ExtractFromUserinfo (client_t *cl, qbool namechanged)
 
 //============================================================================
 
-void OnChange_sysselecttimeout_var (cvar_t *var, char *value, qbool *cancel)
-{
-	int t = Q_atoi (value);
-	if (t <= 1000000 && t >= 10)
-	{
-		select_timeout.tv_sec  =  t / 1000000;
-#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)) && defined(KQUEUE)
-		select_timeout.tv_nsec = (t - select_timeout.tv_sec) * 1000;
-#else
-		select_timeout.tv_usec =  t - select_timeout.tv_sec;
-#endif
-		return;
-	}
-
-	Con_Printf("WARNING: sys_select_timeout can't be less then 10 (10 microseconds) and more then 1 000 000 (1 second).\n");
-	*cancel = true;
-}
 //bliP: 24/9 logdir ->
 void OnChange_logdir_var (cvar_t *var, char *value, qbool *cancel)
 {

--- a/sys.h
+++ b/sys.h
@@ -177,12 +177,6 @@ int		Sys_compare_by_name (const void *a, const void *b);
 #define SORT_BY_DATE	1
 #define SORT_BY_NAME	2
 
-#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)) && defined(KQUEUE)
-	extern struct timespec select_timeout;
-#else
-	extern struct timeval  select_timeout;
-#endif
-
 
 // library loading.
 

--- a/teamplay.c
+++ b/teamplay.c
@@ -44,7 +44,10 @@ cvar_t	cl_parseFunChars = {"cl_parseFunChars", "1"};
 cvar_t	cl_nofake = {"cl_nofake", "2"};
 cvar_t	tp_loadlocs = {"tp_loadlocs", "1"};
 cvar_t  tp_pointpriorities = {"tp_pointpriorities", "0"}; // FIXME: buggy
-
+cvar_t  tp_fixedLocLength = {"tp_fixedloclength", "0"};
+cvar_t  tp_fixedLocCentered = {"tp_fixedloccentered", "0"};
+cvar_t  tp_tooktimeout = {"tp_tooktimeout", "15"};
+cvar_t  tp_pointtimeout = {"tp_pointtimeout", "15"};
 
 cvar_t  cl_teamtopcolor = {"teamtopcolor", "-1", 0, OnChangeColorForcing};
 cvar_t  cl_teambottomcolor = {"teambottomcolor", "-1", 0, OnChangeColorForcing};
@@ -496,7 +499,7 @@ char *Macro_Took (void)
 // returns location of the last item picked up
 char *Macro_TookLoc (void)
 {
-	if (!vars.tooktime || cls.realtime > vars.tooktime + TP_TOOK_EXPIRE_TIME)
+	if (TOOK_EMPTY())
 		strlcpy (macro_buf, tp_name_someplace.string, sizeof(macro_buf));
 	else
 		strlcpy (macro_buf, vars.tookloc, sizeof(macro_buf));
@@ -506,7 +509,7 @@ char *Macro_TookLoc (void)
 // %i macro - last item picked up in "name at location" style
 char *Macro_TookAtLoc (void)
 {
-	if (!vars.tooktime || cls.realtime > vars.tooktime + TP_TOOK_EXPIRE_TIME)
+	if (TOOK_EMPTY())
 		strlcpy (macro_buf, tp_name_nothing.string, sizeof(macro_buf));
 	else {
 		strlcpy (macro_buf, va("%s %s %s", vars.tookname, tp_name_at.string, vars.tookloc), sizeof(macro_buf));
@@ -536,7 +539,7 @@ char *Macro_PointLocation (void)
 
 char *Macro_LastPointAtLoc (void)
 {
-	if (!vars.pointtime || cls.realtime - vars.pointtime > TP_POINT_EXPIRE_TIME)
+	if (!vars.pointtime || cls.realtime - vars.pointtime > tp_pointtimeout.value)
 		strlcpy (macro_buf, tp_name_nothing.string, sizeof(macro_buf));
 	else
 		snprintf (macro_buf, sizeof(macro_buf), "%s %s %s", vars.pointname, tp_name_at.string, vars.pointloc[0] ? vars.pointloc : Macro_Location());
@@ -2185,6 +2188,7 @@ char *TP_LocationName(vec3_t location)
 	cvar_t *cvar;
 	static qbool recursive;
 	static char	buf[1024], newbuf[MAX_LOC_NAME];
+	int maxlength = MAX_LOC_NAME - 1;
 
 	if (!locdata || cls.state != ca_active)
 		return tp_name_someplace.string;
@@ -2204,38 +2208,57 @@ char *TP_LocationName(vec3_t location)
 		}
 	}
 
+	if (tp_fixedLocLength.integer)
+		maxlength = min(tp_fixedLocLength.integer, maxlength);
 
 	newbuf[0] = 0;
 	out = newbuf;
 	in = best->name;
-	while (*in && out - newbuf < sizeof(newbuf) - 1) {
+	while (*in && out - newbuf < maxlength) {
 		if (!strncasecmp(in, "$loc_name_", 10)) {
+			int remaining_space = maxlength - (out - newbuf);
+
 			in += 10;
 			for (i = 0; i < NUM_LOCMACROS; i++) {
 				if (!strncasecmp(in, locmacros[i].macro, strlen(locmacros[i].macro))) {
+
 					if ((cvar = Cvar_Find(va("loc_name_%s", locmacros[i].macro))))
 						value = cvar->string;
 					else
 						value = locmacros[i].val;
-					if (out - newbuf >= sizeof(newbuf) - strlen(value) - 1)
-						goto done_locmacros;
-					strcpy(out, value);
-					out += strlen(value);
+					strncpy(out, value, min(remaining_space, strlen(value)));
+					out += min(remaining_space, strlen(value));
 					in += strlen(locmacros[i].macro);
 					break;
 				}
 			}
 			if (i == NUM_LOCMACROS) {
-				if (out - newbuf >= sizeof(newbuf) - 10 - 1)
-					goto done_locmacros;
-				strcpy(out, "$loc_name_");
-				out += 10;
+				strncpy(out, "$loc_name_", min(remaining_space, 10));
+				out += min(remaining_space, 10);
 			}
 		} else {
 			*out++ = *in++;
 		}
 	}
-done_locmacros:
+
+	if (tp_fixedLocLength.integer)
+	{
+		int i = 0;
+		int padding = maxlength - (out - newbuf);
+
+		// Pad left hand side
+		if (tp_fixedLocCentered.value && padding > 1)
+		{
+			memmove(newbuf + padding / 2, newbuf, out - newbuf);
+			out += padding / 2;
+			for (i = 0; i < padding / 2; ++i)
+				newbuf[i] = ' ';
+		}
+
+		// Pad right hand side
+		while (out - newbuf < maxlength)
+			*out++ = ' ';
+	}
 	*out = 0;
 
 	buf[0] = 0;
@@ -3526,8 +3549,12 @@ void TP_Init (void)
 
 	Cvar_SetCurrentGroup(CVAR_GROUP_COMMUNICATION);
 	Cvar_Register (&tp_loadlocs);
+	Cvar_Register (&tp_fixedLocLength);
+	Cvar_Register (&tp_fixedLocCentered);
 	Cvar_Register (&tp_pointpriorities);
 	Cvar_Register (&tp_weapon_order);
+	Cvar_Register (&tp_tooktimeout);
+	Cvar_Register (&tp_pointtimeout);
 
 	Cvar_SetCurrentGroup(CVAR_GROUP_ITEM_NAMES);
 	Cvar_Register (&tp_name_separator);

--- a/teamplay.h
+++ b/teamplay.h
@@ -217,11 +217,10 @@ extern tvars_t vars;
 
 extern char *TP_PlayerName (void);
 
-#define	TP_TOOK_EXPIRE_TIME		15
-#define	TP_POINT_EXPIRE_TIME	TP_TOOK_EXPIRE_TIME
+extern cvar_t tp_tooktimeout;
 
 extern void TP_FindPoint (void);
-#define TOOK_EMPTY() (!vars.tooktime || cls.realtime > vars.tooktime + TP_TOOK_EXPIRE_TIME)
+#define TOOK_EMPTY() (!vars.tooktime || cls.realtime > vars.tooktime + tp_tooktimeout.value)
 
 // updates the state of vars.needflags
 void TP_GetNeed(void);

--- a/tr_types.h
+++ b/tr_types.h
@@ -61,11 +61,8 @@ extern glconfig_t	glConfig;
 // latched variables that can only change over a restart
 //
 
-extern cvar_t	r_allowExtensions;
 extern cvar_t	r_colorbits;
 extern cvar_t	r_stereo;
-extern cvar_t	r_stencilbits;
-extern cvar_t	r_depthbits;
 extern cvar_t	r_fullscreen;
 extern cvar_t	vid_width;
 extern cvar_t	vid_height;

--- a/utils.c
+++ b/utils.c
@@ -758,7 +758,6 @@ void CopyToClipboard(const char *text)
 #ifdef _WIN32
     if (OpenClipboard(NULL))
     {
-        HANDLE i;
         LPTSTR  lptstrCopy;
         HGLOBAL hglbCopy;
 
@@ -767,7 +766,7 @@ void CopyToClipboard(const char *text)
         lptstrCopy = GlobalLock(hglbCopy);
         strcpy((char *)lptstrCopy, text);
         GlobalUnlock(hglbCopy);
-        i = SetClipboardData(CF_TEXT, hglbCopy);
+        SetClipboardData(CF_TEXT, hglbCopy);
 
         CloseClipboard();
     }

--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -84,11 +84,8 @@ static int modelist_count;
 extern cvar_t sys_inactivesleep;
 
 // latched variables that can only change over a restart
-cvar_t r_allowExtensions      = {"vid_allowExtensions",   "1",   CVAR_LATCH };
 cvar_t r_colorbits            = {"vid_colorbits",         "0",   CVAR_LATCH };
 cvar_t r_stereo               = {"vid_stereo",            "0",   CVAR_LATCH };
-cvar_t r_stencilbits          = {"vid_stencilbits",       "8",   CVAR_LATCH };
-cvar_t r_depthbits            = {"vid_depthbits",         "0",   CVAR_LATCH };
 cvar_t r_fullscreen           = {"vid_fullscreen",        "1",   CVAR_LATCH };
 cvar_t r_displayRefresh       = {"vid_displayfrequency",  "0",   CVAR_LATCH };
 cvar_t vid_displayNumber      = {"vid_displaynumber",     "0",   CVAR_LATCH };
@@ -548,10 +545,7 @@ void VID_RegisterLatchCvars(void)
 	Cvar_Register(&vid_height);
 	Cvar_Register(&vid_win_width);
 	Cvar_Register(&vid_win_height);
-	Cvar_Register(&r_allowExtensions);
 	Cvar_Register(&r_colorbits);
-	Cvar_Register(&r_stencilbits);
-	Cvar_Register(&r_depthbits);
 	Cvar_Register(&r_fullscreen);
 	Cvar_Register(&r_displayRefresh);
 	Cvar_Register(&vid_usedesktopres);


### PR DESCRIPTION
Removed references to unused variables, initialised some that weren't set in all paths
Removed some unused console variables
Bugfix for recent score_bar change (.qwd playback affected)
Teamplay: fix for tp_took when item pickup sound arrives before stat update
Teamplay: took & point timeouts are variable, instead of fixed 15s
Teamplay: location descriptions can be fixed width
