### PR TITLE
HELP: Link cvars to groups

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -1,70 +1,73 @@
 {
   "groups": [
-    "",
-    "#No Group#",
-    "Chat Settings",
-    "Config Management",
-    "Console Settings",
-    "Crosshair Settings",
-    "Demo Handling",
-    "FPS and EyeCandy Settings",
-    "Input - Keyboard",
-    "Input - Misc",
-    "Input - Mouse",
-    "IRC Client",
-    "Item Names",
-    "Item Need Amounts",
-    "Lighting",
-    "Match Tools",
-    "Menu",
-    "MP3 Settings",
-    "MQWCL HUD",
-    "MultiView Demos",
-    "Network Settings",
-    "Not settable",
-    "Obselete",
-    "Obselete (2.2)",
-    "Obselete (2.2) - Custom Browser Fields",
-    "Obselete (3.0) - Audio",
-    "Obselete (3.0) - Authentication",
-    "Obselete (3.0) - Input Systems",
-    "Obselete (3.0) - Invalid",
-    "Obselete (3.0) - Software Renderer",
-    "Obselete (3.0) - Video",
-    "Obselete (3.0) - VOIP",
-    "Obselete (Commands)",
-    "Obselete (server infokeys)",
-    "OpenGL Rendering",
-    "Particle Effects",
-    "Player Settings",
-    "QTV Settings",
-    "Screen \u0026 Powerup Blends",
-    "Screen Settings",
-    "Screenshot Settings",
-    "Server Browser",
-    "Server Settings",
-    "Skin Settings",
-    "Sound Settings",
-    "Spectator Tracking",
-    "Status Bar and Scoreboard",
-    "System Settings",
-    "Teamplay Communications",
-    "Texture Settings",
-    "Turbulency and Sky Settings",
-    "Video Settings",
-    "View Settings",
-    "Weapon View Model Settings"
+    { "id": "1", "name": "", "major-group": "Miscellaneous" },
+    { "id": "2", "name": "#No Group#", "major-group": "Miscellaneous" },
+    { "id": "3", "name": "Chat Settings", "major-group": "HUD" },
+    { "id": "4", "name": "Config Management", "major-group": "Miscellaneous" },
+    { "id": "5", "name": "Console Settings", "major-group": "HUD" },
+    { "id": "6", "name": "Crosshair Settings", "major-group": "Graphics" },
+    { "id": "7", "name": "Demo Handling", "major-group": "Demos" },
+    { "id": "8", "name": "FPS and EyeCandy Settings", "major-group": "Graphics" },
+    { "id": "9", "name": "Input - Keyboard", "major-group": "Input" },
+    { "id": "10", "name": "Input - Misc", "major-group": "Input" },
+    { "id": "11", "name": "Input - Mouse", "major-group": "Input" },
+    { "id": "12", "name": "IRC Client", "major-group": "Miscellaneous" },
+    { "id": "13", "name": "Item Names", "major-group": "Teamplay" },
+    { "id": "14", "name": "Item Need Amounts", "major-group": "Teamplay" },
+    { "id": "15", "name": "Lighting", "major-group": "Graphics" },
+    { "id": "16", "name": "Match Tools", "major-group": "Demos" },
+    { "id": "17", "name": "Menu", "major-group": "Miscellaneous" },
+    { "id": "18", "name": "MP3 Settings", "major-group": "Sound" },
+    { "id": "19", "name": "MQWCL HUD", "major-group": "HUD" },
+    { "id": "20", "name": "MultiView Demos", "major-group": "Demos" },
+    { "id": "21", "name": "Network Settings", "major-group": "Multiplayer" },
+    { "id": "22", "name": "Not settable", "major-group": "Miscellaneous" },
+    { "id": "23", "name": "Obsolete", "major-group": "Obsolete" },
+    { "id": "24", "name": "Obsolete (2.2)", "major-group": "Obsolete" },
+    { "id": "25", "name": "Obsolete (2.2) - Custom Browser Fields", "major-group": "Obsolete" },
+    { "id": "26", "name": "Obsolete (3.0) - Audio", "major-group": "Obsolete" },
+    { "id": "27", "name": "Obsolete (3.0) - Authentication", "major-group": "Obsolete" },
+    { "id": "28", "name": "Obsolete (3.0) - Input Systems", "major-group": "Obsolete" },
+    { "id": "29", "name": "Obsolete (3.0) - Invalid", "major-group": "Obsolete" },
+    { "id": "30", "name": "Obsolete (3.0) - Software Renderer", "major-group": "Obsolete" },
+    { "id": "31", "name": "Obsolete (3.0) - Video", "major-group": "Obsolete" },
+    { "id": "32", "name": "Obsolete (3.0) - VOIP", "major-group": "Obsolete" },
+    { "id": "33", "name": "Obsolete (Commands)", "major-group": "Obsolete" },
+    { "id": "34", "name": "Obsolete (server infokeys)", "major-group": "Obsolete" },
+    { "id": "35", "name": "OpenGL Rendering", "major-group": "Graphics" },
+    { "id": "36", "name": "Particle Effects", "major-group": "Graphics" },
+    { "id": "37", "name": "Player Settings", "major-group": "Multiplayer" },
+    { "id": "38", "name": "QTV Settings", "major-group": "Multiplayer" },
+    { "id": "39", "name": "Screen \u0026 Powerup Blends", "major-group": "Graphics" },
+    { "id": "40", "name": "Screen Settings", "major-group": "Graphics" },
+    { "id": "41", "name": "Screenshot Settings", "major-group": "Graphics" },
+    { "id": "42", "name": "Server Browser", "major-group": "Multiplayer" },
+    { "id": "43", "name": "Server Settings", "major-group": "Server" },
+    { "id": "44", "name": "Skin Settings", "major-group": "Multiplayer" },
+    { "id": "45", "name": "Sound Settings", "major-group": "Sound" },
+    { "id": "46", "name": "Spectator Tracking", "major-group": "Multiplayer" },
+    { "id": "47", "name": "Status Bar and Scoreboard", "major-group": "HUD" },
+    { "id": "48", "name": "System Settings", "major-group": "Miscellaneous" },
+    { "id": "49", "name": "Teamplay Communications", "major-group": "Teamplay" },
+    { "id": "50", "name": "Texture Settings", "major-group": "Graphics" },
+    { "id": "51", "name": "Turbulency and Sky Settings", "major-group": "Graphics" },
+    { "id": "52", "name": "Video Settings", "major-group": "Graphics" },
+    { "id": "53", "name": "View Settings", "major-group": "Graphics" },
+    { "id": "54", "name": "Weapon View Model Settings", "major-group": "Graphics" }
   ],
   "vars": {
     "_vid_default_mode": {
+      "group-id": "31",
       "desc": "This variable sets the default video mode that the client uses.",
       "type": "float"
     },
     "_vid_default_mode_win": {
+      "group-id": "31",
       "desc": "This variable sets the default video mode that the client uses when windowed.",
       "type": "float"
     },
     "_windowed_mouse": {
+      "group-id": "28",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable windowed mouse support so you can use the mouse in other applications." },
@@ -72,6 +75,7 @@
       ]
     },
     "allow_download": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -79,6 +83,7 @@
       ]
     },
     "allow_download_demos": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "0", "description": "Disable" },
@@ -86,6 +91,7 @@
       ]
     },
     "allow_download_gfx": {
+      "group-id": "43",
       "desc": "Enables downloading files from the server from the gfx directory",
       "remarks": "Server-side",
       "type": "boolean",
@@ -95,6 +101,7 @@
       ]
     },
     "allow_download_maps": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -102,6 +109,7 @@
       ]
     },
     "allow_download_models": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -109,6 +117,7 @@
       ]
     },
     "allow_download_other": {
+      "group-id": "43",
       "desc": "Enables downloading files from the server which are not in \\\"skins\\\", \\\"progs\\\", \\\"sound\\\", \\\"maps\\\" nor \\\"gfx\\\" directories",
       "remarks": "Server-side",
       "type": "boolean",
@@ -118,6 +127,7 @@
       ]
     },
     "allow_download_pakmaps": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -125,6 +135,7 @@
       ]
     },
     "allow_download_skins": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -132,6 +143,7 @@
       ]
     },
     "allow_download_sounds": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -139,6 +151,7 @@
       ]
     },
     "allow_f_cmdline": {
+      "group-id": "3",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Your client will not respond to f_cmdline checks." },
@@ -146,6 +159,7 @@
       ]
     },
     "allow_f_system": {
+      "group-id": "3",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Your client will not respond to f_system checks." },
@@ -153,6 +167,7 @@
       ]
     },
     "allow_scripts": {
+      "group-id": "9",
       "desc": "Possibility to prove, that you do NOT use scripts. Of course, values 0 and 1 will block \u0027rotate\u0027 command.",
       "remarks": "Your current \u0027allow_scripts\u0027 setting will be reported to \u0027f_scripts\u0027 query and anyone will be able to check it. If anyone said \u0027f_scripts\u0027 since last mapchange, the client will also autoreport any change of allow_scripts. So if you don\u0027t use scripts, turn them off to prove you don\u0027t use them. And remember - scripts _are allowed_, so don\u0027t call ppl who use them \u0027cheaters\u0027.\n\nThis variable will be set to 0 on startup if a command line switches -norjscripts or -noscripts are used",
       "type": "enum",
@@ -163,9 +178,11 @@
       ]
     },
     "auth_timeout": {
+      "group-id": "43",
       "type": "float"
     },
     "auth_validate": {
+      "group-id": "27",
       "remarks": "If you have \n\u0027auth_warninvalid 1\u0027 and someone gives a dirty hash in a version response \n(because they are using a hacked client that can\u0027t work out the right \nresponse), the client will print something like \n\u0027Warning Invalid Client: playername (userid)\u0027 in your console (\u0027auth_warninvalid 0\u0027 is default).",
       "type": "boolean",
       "values": [
@@ -174,6 +191,7 @@
       ]
     },
     "auth_viewcrc": {
+      "group-id": "27",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "the client hides the authentication CRC in f_version responses." },
@@ -181,10 +199,12 @@
       ]
     },
     "auth_warninvalid": {
+      "group-id": "27",
       "desc": "Check auth_validate.",
       "type": "float"
     },
     "b_switch": {
+      "group-id": "37",
       "desc": "This variable allows you to define the highest weapon that the client should switch \nto upon a backpack pickup. The possible arguments of \"b_switch\" refer to the \nimpulse that is used to switch to a certain weapon.  Note that a setting of 1 will effectively disable backpack weapon switching.",
       "type": "enum",
       "values": [
@@ -199,14 +219,17 @@
       ]
     },
     "baseskin": {
+      "group-id": "44",
       "desc": "Defines what skin you see other people using if you don\u0027t have their skin and don\u0027t have skin forcing on.",
       "type": "string"
     },
     "bgmvolume": {
+      "group-id": "45",
       "desc": "This variable sets the volume of the CD music.",
       "type": "float"
     },
     "block_switch": {
+      "group-id": "31",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not block task-switching" },
@@ -214,10 +237,12 @@
       ]
     },
     "bottomcolor": {
+      "group-id": "37",
       "desc": "Sets the pants color.",
       "type": "enum"
     },
     "cam_dist": {
+      "group-id": "46",
       "desc": "for use with cam_thirdperson. Use +forward/+back to adjust it smoothly",
       "type": "float",
       "values": [
@@ -225,6 +250,7 @@
       ]
     },
     "cam_lockdir": {
+      "group-id": "46",
       "desc": "Force camera to locked direction mode",
       "type": "boolean",
       "values": [
@@ -233,6 +259,7 @@
       ]
     },
     "cam_lockpos": {
+      "group-id": "46",
       "desc": "Force camera to locked position mode",
       "remarks": "EXPEREMENTAL",
       "type": "boolean",
@@ -242,6 +269,7 @@
       ]
     },
     "cam_thirdperson": {
+      "group-id": "46",
       "desc": "Enables third person view in demo playback and spectator mode. In track mode, we look at the person being tracked rather than through his eyes.\nUnlike cl_camera_tpp, you can use the mouse to look around.",
       "remarks": "in track mode, we look at the person being tracked rather than through his eyes",
       "type": "boolean",
@@ -251,14 +279,17 @@
       ]
     },
     "cam_zoomaccel": {
+      "group-id": "46",
       "desc": "To control how fast you zoom in onto the target with +forward/+back in cam_thirdperson mode",
       "type": "float"
     },
     "cam_zoomspeed": {
+      "group-id": "46",
       "desc": "To control how fast you zoom in onto the target with +forward/+back in cam_thirdperson mode.",
       "type": "float"
     },
     "cfg_backup": {
+      "group-id": "4",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "No backup of your config." },
@@ -266,18 +297,22 @@
       ]
     },
     "cfg_browser_democolor": {
+      "group-id": "25",
       "desc": "Color of the demo entries in the cfg browser",
       "type": "string"
     },
     "cfg_browser_dircolor": {
+      "group-id": "25",
       "desc": "Color of the dir entries in the cfg browser",
       "type": "string"
     },
     "cfg_browser_interline": {
+      "group-id": "25",
       "desc": "Size of the space between entries in the cfg browser",
       "type": "integer"
     },
     "cfg_browser_scrollnames": {
+      "group-id": "25",
       "desc": "Toggle scrolling of the filenames in the cfg browser",
       "type": "boolean",
       "values": [
@@ -286,10 +321,12 @@
       ]
     },
     "cfg_browser_selectedcolor": {
+      "group-id": "25",
       "desc": "Color of the selected entries in the cfg browser",
       "type": "string"
     },
     "cfg_browser_showdate": {
+      "group-id": "25",
       "desc": "Toggle the date column in the cfg browser",
       "type": "boolean",
       "values": [
@@ -298,6 +335,7 @@
       ]
     },
     "cfg_browser_showsize": {
+      "group-id": "25",
       "desc": "Toggle the file size column in the cfg browser",
       "type": "boolean",
       "values": [
@@ -306,6 +344,7 @@
       ]
     },
     "cfg_browser_showstatus": {
+      "group-id": "25",
       "desc": "Toggle the display of the status bar in the cfg browser",
       "type": "boolean",
       "values": [
@@ -314,6 +353,7 @@
       ]
     },
     "cfg_browser_showtime": {
+      "group-id": "25",
       "desc": "Toggle the time column in the cfg browser",
       "type": "boolean",
       "values": [
@@ -322,10 +362,12 @@
       ]
     },
     "cfg_browser_sortmode": {
+      "group-id": "25",
       "desc": "Sorting mode in the cfg browser. Each number represents one column. Their order represents the priority of the sorting.",
       "type": "string"
     },
     "cfg_browser_stripnames": {
+      "group-id": "25",
       "desc": "Toggle stripping of the filenames in the cfg browser",
       "type": "boolean",
       "values": [
@@ -334,10 +376,12 @@
       ]
     },
     "cfg_browser_zipcolor": {
+      "group-id": "25",
       "desc": "Color of the zip entries in the cfg browser",
       "type": "string"
     },
     "cfg_legacy_exec": {
+      "group-id": "4",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Do not execute config.cfg and frontend.cfg in gamedir ever." },
@@ -347,6 +391,7 @@
       ]
     },
     "cfg_save_aliases": {
+      "group-id": "4",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Won\u0027t save aliases." },
@@ -354,6 +399,7 @@
       ]
     },
     "cfg_save_binds": {
+      "group-id": "4",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Won\u0027t save binds." },
@@ -361,6 +407,7 @@
       ]
     },
     "cfg_save_cmdline": {
+      "group-id": "4",
       "remarks": "course).",
       "type": "boolean",
       "values": [
@@ -369,6 +416,7 @@
       ]
     },
     "cfg_save_cmds": {
+      "group-id": "4",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Won\u0027t save commands." },
@@ -376,6 +424,7 @@
       ]
     },
     "cfg_save_cvars": {
+      "group-id": "4",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Won\u0027t save variables." },
@@ -383,6 +432,7 @@
       ]
     },
     "cfg_save_onquit": {
+      "group-id": "4",
       "desc": "When enabled, your main configuration (config.cfg) will be saved when you exit the application",
       "remarks": "Configuration will be saved in the main user configuration file, that is config.cfg which can either be placed in the quake/ezquake/configs in your quakedir, or in your home dir in /ezquake, depending on cfg_use_home setting.",
       "type": "boolean",
@@ -392,10 +442,12 @@
       ]
     },
     "cfg_save_sysinfo": {
+      "group-id": "4",
       "desc": "Not implemented yet.",
       "type": "boolean"
     },
     "cfg_save_unchanged": {
+      "group-id": "4",
       "remarks": "config file.",
       "type": "boolean",
       "values": [
@@ -404,6 +456,7 @@
       ]
     },
     "cfg_save_userinfo": {
+      "group-id": "4",
       "remarks": "Note: \u0027cfg_save_userinfo 1\u0027 is best for teamfortress so you don\u0027t get kicked for changing bottom color. cfg_save will never save the password variable, even though technically it is a userinfo variable.",
       "type": "enum",
       "values": [
@@ -413,10 +466,12 @@
       ]
     },
     "cfg_use_gamedir": {
+      "group-id": "4",
       "desc": "If set \u0026 gamedir is not \u0027qw\u0027, configurations will be saved to subdirectory based on gamedir.\nUseful if configurations differ depending on gametype (e.g. team fortress)",
       "type": "boolean"
     },
     "cfg_use_home": {
+      "group-id": "4",
       "desc": "When turned on, configutaion will be saved into user\u0027s profile (home) directory.",
       "remarks": "This affects only cfg_save and cfg_load commands.",
       "type": "boolean",
@@ -426,10 +481,12 @@
       ]
     },
     "cl_anglespeedkey": {
+      "group-id": "9",
       "desc": "This variable sets multiplier by which your \"cl_yawspeed\" (how fast you turn) is\nmultiplied when running (+speed).",
       "type": "float"
     },
     "cl_backpackfilter": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "0", "description": "Don\u0027t filter backpacks." },
@@ -437,22 +494,27 @@
       ]
     },
     "cl_backspeed": {
+      "group-id": "9",
       "desc": "This allows you to set your backward speed. Obviously this is also limited by\nthe server, usually to \"320\".",
       "type": "float"
     },
     "cl_bob": {
+      "group-id": "54",
       "desc": "This variable controls how much your weapon moves up and down when walking.",
       "type": "float"
     },
     "cl_bobcycle": {
+      "group-id": "54",
       "desc": "This variable determines how quickly your weapon moves up and down when walking.",
       "type": "float"
     },
     "cl_bobup": {
+      "group-id": "54",
       "desc": "This variable controls how long your weapon stays up before cycling when \nwalking.",
       "type": "float"
     },
     "cl_bonusflash": {
+      "group-id": "39",
       "desc": "Controls weapon and item pickup flash.",
       "type": "boolean",
       "values": [
@@ -461,19 +523,23 @@
       ]
     },
     "cl_c2sImpulseBackup": {
+      "group-id": "21",
       "desc": "Used with cl_c2spps, it controls how many backup copies of packets with non-zero \nimpulses are to be sent to the server. The recommended value is 3, \nbut you can try 2 or even 1 to reduce traffic if you don\u0027t have any packet loss.",
       "type": "integer"
     },
     "cl_c2spps": {
+      "group-id": "21",
       "desc": "Packet filtering (a la Qizmo\u0027s .c2spps command). Use this to reduce network traffic\nif you\u0027re playing on a 28800 (or worse) connection and can\u0027t set cl_maxfps 72 \nbecause it causes lag.  Also consider use of FPS independent physics in conjunction with cl_physfps.",
       "type": "integer"
     },
     "cl_camera_death": {
+      "group-id": "46",
       "desc": "Camera view above your body after death.",
       "remarks": "Enabled only for viewing demos and observing games.",
       "type": "boolean"
     },
     "cl_camera_tpp": {
+      "group-id": "46",
       "remarks": "Enabled only for viewing demos and observing games.",
       "type": "enum",
       "values": [
@@ -483,6 +549,7 @@
       ]
     },
     "cl_camera_tpp_distance": {
+      "group-id": "46",
       "desc": "Sets distance of 3rd person camera from tracked player.",
       "remarks": "Set cl_camera_tpp 1 first. See cl_camera_tpp_height too.",
       "type": "float",
@@ -491,6 +558,7 @@
       ]
     },
     "cl_camera_tpp_height": {
+      "group-id": "46",
       "desc": "Sets vertical position of 3rd person camera.",
       "remarks": "Set cl_camera_tpp 1 first.",
       "type": "float",
@@ -499,6 +567,7 @@
       ]
     },
     "cl_chasecam": {
+      "group-id": "46",
       "desc": "Toggle between 3rd-person view and 1st-person view while observing or during demo playback.",
       "type": "boolean",
       "values": [
@@ -507,6 +576,7 @@
       ]
     },
     "cl_chatmode": {
+      "group-id": "5",
       "desc": "Console chat mode.",
       "type": "enum",
       "values": [
@@ -516,11 +586,13 @@
       ]
     },
     "cl_chunksperframe": {
+      "group-id": "21",
       "desc": "Affects the download speed when using chunked downloads, more chunks per frame results in higher download speed",
       "remarks": "Servers can limit the amount of chunks sent per frame",
       "type": "integer"
     },
     "cl_clock": {
+      "group-id": "40",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Off." },
@@ -529,6 +601,7 @@
       ]
     },
     "cl_clock_format": {
+      "group-id": "40",
       "desc": "Changes the format of the clock which is displayed if cl_clock is non-zero.",
       "remarks": "%H represents hours, %M minutes, %S seconds. There are many other flags you can use. See strftime (C language) documentation for closer info.",
       "type": "string",
@@ -537,18 +610,22 @@
       ]
     },
     "cl_clock_x": {
+      "group-id": "40",
       "desc": "Horizontal coordinates of the clock.",
       "type": "float"
     },
     "cl_clock_y": {
+      "group-id": "40",
       "desc": "Vertical coordinates of the clock.\nIf \u003c 0, the coordinates are calculated from bottom up, e.g. -1 means the screen line just above the scoreboard.",
       "type": "float"
     },
     "cl_cmdline": {
+      "group-id": "2",
       "desc": "Read-only variable showing you what were the commandline options used to launch the client",
       "type": "string"
     },
     "cl_confirmquit": {
+      "group-id": "40",
       "desc": "This sets whether to confirm on quit (1) or quit with no confirmation (0).",
       "type": "boolean",
       "values": [
@@ -557,18 +634,22 @@
       ]
     },
     "cl_crossx": {
+      "group-id": "6",
       "desc": "This variable allows you to move the position of the crosshair on the X-axis\nby the specified amount of pixels.",
       "type": "float"
     },
     "cl_crossy": {
+      "group-id": "6",
       "desc": "This variable allows you to move the position of the crosshair on the Y-axis\nby the specified amount of pixels.",
       "type": "float"
     },
     "cl_crypt_rcon": {
+      "group-id": "21",
       "desc": "Encrypts rcon messages sent to server.",
       "type": "boolean"
     },
     "cl_curlybraces": {
+      "group-id": "5",
       "desc": "Enables new syntax to be used for Quake scripting allowing you to enclose commands into curly braces",
       "remarks": "See scripting manual for further info",
       "type": "boolean",
@@ -578,6 +659,7 @@
       ]
     },
     "cl_deadbodyFilter": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "0", "description": "Don\u0027t filter dead bodies." },
@@ -587,6 +669,7 @@
       ]
     },
     "cl_delay_packet": {
+      "group-id": "21",
       "desc": "Client will delay incoming and outgoing packets allowing user to increase his ping in the game.",
       "remarks": "Players can use this to get equivalent pings on server. If you enter delay of 20 miliseconds, incoming packets will be delayed by 10 miliseconds, outgoing packets too. It\u0027s preferred to use the least value that gives you your desired ping.",
       "type": "integer",
@@ -595,6 +678,7 @@
       ]
     },
     "cl_democlock": {
+      "group-id": "40",
       "desc": "A clock showing how much time has elapsed since the start of the demo.",
       "type": "boolean",
       "values": [
@@ -603,14 +687,17 @@
       ]
     },
     "cl_democlock_x": {
+      "group-id": "40",
       "desc": "Determine where the democlock is positioned on your screen on the X co-ordinate.",
       "type": "float"
     },
     "cl_democlock_y": {
+      "group-id": "40",
       "desc": "Determine where the democlock is positioned on your screen on the Y co-ordinate.",
       "type": "float"
     },
     "cl_demoPingInterval": {
+      "group-id": "7",
       "desc": "How often to request ping updates when recording demos. This variable doesn\u0027t \naffect ping updates when the scoreboard is shown (they are always one update per 2 seconds).",
       "type": "integer",
       "values": [
@@ -618,6 +705,7 @@
       ]
     },
     "cl_demoplay_flash": {
+      "group-id": "39",
       "desc": "Reduces flash grenade effect when watching demos.",
       "type": "float",
       "values": [
@@ -625,14 +713,17 @@
       ]
     },
     "cl_demospeed": {
+      "group-id": "7",
       "desc": "Controls the speed of demo playback in percentage (can be changed during demo playback if you wish).",
       "type": "float"
     },
     "cl_demoteamplay": {
+      "group-id": "7",
       "desc": "If set, teamplay settings enabled during .dem playback.",
       "type": "boolean"
     },
     "cl_earlypackets": {
+      "group-id": "21",
       "desc": "Read network data independently on physical frames. When using independent physics, network data will be read as early as possible, compared to the old way when it was read only on every physframe (77 times per second).",
       "type": "boolean",
       "values": [
@@ -641,6 +732,7 @@
       ]
     },
     "cl_fakename": {
+      "group-id": "3",
       "desc": "Automatically prefixes all team messages with a shorter version of your nick unless the message has a \"fake\" part already (so no configs are broken).",
       "remarks": "Applies for say_team and messagemode2",
       "type": "string",
@@ -649,14 +741,17 @@
       ]
     },
     "cl_fakename_suffix": {
+      "group-id": "3",
       "desc": "Suffix for cl_fakename.",
       "type": "string"
     },
     "cl_fakeshaft": {
+      "group-id": "8",
       "desc": "Smoothes out shaft movement, 0 means no smoothing at all, 1 = 100% smoothing;\na value of about 0.5 is recommended for modem players.  Note that this only affects the visual display of the shaft beam; the \u0027true\u0027 beam remains in the original location.",
       "type": "float"
     },
     "cl_fakeshaft_extra_updates": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "0", "description": "Update shaft position only when network packet received from server" },
@@ -664,6 +759,7 @@
       ]
     },
     "cl_filterdrawviewmodel": {
+      "group-id": "54",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Off." },
@@ -671,6 +767,7 @@
       ]
     },
     "cl_fix_mvd": {
+      "group-id": "21",
       "desc": "A fix for buggy MVD demos, making the client to parse them properly",
       "remarks": "Was caused by a flaw in MVDSV server",
       "type": "boolean",
@@ -680,6 +777,7 @@
       ]
     },
     "cl_floodprot": {
+      "group-id": "3",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable floodprot." },
@@ -687,18 +785,22 @@
       ]
     },
     "cl_forwardspeed": {
+      "group-id": "9",
       "desc": "This allows you to set your forward speed. Obviously this is also limited by the\nserver, usually to \"320\".",
       "type": "float"
     },
     "cl_fp_messages": {
+      "group-id": "3",
       "desc": "This variable is used in conjunction with the variable \"cl_fp_persecond\" to\ndefine when the floodprot protection should be triggered (if \"cl_floodprot\"\nis set to \"1\").",
       "type": "float"
     },
     "cl_fp_persecond": {
+      "group-id": "3",
       "desc": "This variable is used in conjunction with the variable \"cl_fp_messages\" to\ndefine when the floodprot protection should be triggered (if \"cl_floodprot\"\nis set to \"1\").",
       "type": "float"
     },
     "cl_gameclock": {
+      "group-id": "40",
       "desc": "Displays clock with seconds on the screen.\n",
       "remarks": "Use cl_gameclock_x and cl_gameclock_y to place it anywhere on the screen.",
       "type": "enum",
@@ -711,21 +813,25 @@
       ]
     },
     "cl_gameclock_offset": {
+      "group-id": "40",
       "desc": "Allows using gameclock in custom mods that don\u0027t support standard KT-like clock synchronization",
       "remarks": "Some Capture The Flag or Team Fortress mods can take a use of this.",
       "type": "integer"
     },
     "cl_gameclock_x": {
+      "group-id": "40",
       "desc": "Adjusts horizontal placement of the clock with seconds.",
       "remarks": "See cl_gameclock for detailed info about the clock.",
       "type": "float"
     },
     "cl_gameclock_y": {
+      "group-id": "40",
       "desc": "Adjusts vertical placement of the clock with seconds.",
       "remarks": "See cl_gameclock for detailed info about the clock.",
       "type": "float"
     },
     "cl_gibFilter": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Gibs are displayed." },
@@ -733,18 +839,22 @@
       ]
     },
     "cl_hidenails": {
+      "group-id": "8",
       "desc": "Toggles nails visibility.",
       "type": "float"
     },
     "cl_hiderockets": {
+      "group-id": "8",
       "desc": "Toggles rockets visibility. Variable cl_r2g must be 0 to cl_hiderockets 1 work.",
       "type": "float"
     },
     "cl_hightrack": {
+      "group-id": "46",
       "desc": "Turns auto-tracking player with most frags ON when spectating or watching a demo.",
       "type": "float"
     },
     "cl_hud": {
+      "group-id": "40",
       "desc": "Enables/Disables strings-hud. Strings hud is not mqwcl hud. It gives you ability put any string (or value of some variable) on your hud.",
       "remarks": "Strings hud banned for ruleset smackdown",
       "type": "boolean",
@@ -754,6 +864,7 @@
       ]
     },
     "cl_hudswap": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "The inventory is drawn on the right side of the screen." },
@@ -761,6 +872,7 @@
       ]
     },
     "cl_iDrive": {
+      "group-id": "9",
       "desc": "Emulates \"strafe script\". When turned on you will always move to some direction when holding both keys +moveleft and +moveright (or +forward and +back). If you have this turned on, it will be reported in your f_ruleset reply with as (+i) flag. Cannot be changed during the gameplay.",
       "type": "boolean",
       "values": [
@@ -769,6 +881,7 @@
       ]
     },
     "cl_independentPhysics": {
+      "group-id": "8",
       "desc": "This enables independent physics. This means that you can achieve more FPS in the game than allowed by the server. The amount of FPS used to communicate with the server is set by /cl_physfps and the amount of graphics FPS is set by /cl_maxfps. Note that you must have vid_vsync 0.",
       "remarks": "This variable can only be switched from 0\u003c-\u003e1 when disconnected from a server (Qizmo/eztv are also servers).",
       "type": "boolean",
@@ -778,6 +891,7 @@
       ]
     },
     "cl_keypad": {
+      "group-id": "9",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "QW compatibility where the keypad keys act the same key name, eg KP_8 acts like uparrow would." },
@@ -785,6 +899,7 @@
       ]
     },
     "cl_lerp_monsters": {
+      "group-id": "8",
       "desc": "Enables linear interpolation on Quake monsters and creatures",
       "type": "boolean",
       "values": [
@@ -793,6 +908,7 @@
       ]
     },
     "cl_loadFragfiles": {
+      "group-id": "47",
       "remarks": "Also needed to parse stats for extended scoreboard and frags tracker.",
       "type": "boolean",
       "values": [
@@ -801,10 +917,12 @@
       ]
     },
     "cl_maxfps": {
+      "group-id": "8",
       "desc": "This variable sets the maximum limit for frames-per-second. Please see vid_vsync, cl_independentphysics, and cl_physfps.",
       "type": "float"
     },
     "cl_mediaroot": {
+      "group-id": "48",
       "desc": "Changes where demos, screenshots and logs are saved, how variables demo_dir, sshot_dir and log_dir are treated.",
       "type": "enum",
       "values": [
@@ -814,6 +932,7 @@
       ]
     },
     "cl_model_bobbing": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Off." },
@@ -821,10 +940,12 @@
       ]
     },
     "cl_movespeedkey": {
+      "group-id": "9",
       "desc": "This variable is the multiplier for how fast you move when running (+speed) in\nrelation to when walking (-speed).",
       "type": "float"
     },
     "cl_multiview": {
+      "group-id": "40",
       "desc": "This client adds a multiview component to mvd playback. Upto four views can be displayed at once. Use this variable to turn multiview on.",
       "type": "enum",
       "values": [
@@ -836,6 +957,7 @@
       ]
     },
     "cl_muzzleflash": {
+      "group-id": "8",
       "type": "enum",
       "values": [
         { "name": "0", "description": "All turned off." },
@@ -844,6 +966,7 @@
       ]
     },
     "cl_mvdisplayhud": {
+      "group-id": "40",
       "desc": "Toggle drawing of small compact HUD in each screen of Multiview control.",
       "remarks": "Also see cl_mvhudpos and cl_mvhudvertical when this is set to a value greater than 1.",
       "type": "enum",
@@ -857,6 +980,7 @@
       ]
     },
     "cl_mvhudflip": {
+      "group-id": "40",
       "desc": "Flips the mini-HUD in multiview mode.",
       "remarks": "This only works when cl_mvdisplayhud is greater than 1. See also cl_mvhudvertical and cl_mvhudpos.",
       "type": "boolean",
@@ -866,6 +990,7 @@
       ]
     },
     "cl_mvhudpos": {
+      "group-id": "40",
       "desc": "Sets the position of the multiview mini-HUDs.",
       "remarks": "This only applies to the mini-HUD when cl_mvdisplayhud has a value greater than 1. Otherwise old mini-HUD will be used (just strings).",
       "type": "string",
@@ -880,6 +1005,7 @@
       ]
     },
     "cl_mvhudvertical": {
+      "group-id": "40",
       "desc": "Set whetever the mini-HUDs in multiview mode will be drawn vertically or not.",
       "remarks": "This only applies if cl_mvdisplayhud has a value greater than 1, otherwise the old style is used for the mini-HUDs (only strings).",
       "type": "boolean",
@@ -889,6 +1015,7 @@
       ]
     },
     "cl_mvinset": {
+      "group-id": "40",
       "desc": "Turns inset screen with multitrack on/off.",
       "type": "boolean",
       "values": [
@@ -897,6 +1024,7 @@
       ]
     },
     "cl_mvinsetcrosshair": {
+      "group-id": "40",
       "desc": "Turn crosshair in inset POV in multiview on/off.",
       "type": "boolean",
       "values": [
@@ -905,6 +1033,7 @@
       ]
     },
     "cl_mvinsethud": {
+      "group-id": "40",
       "desc": "Turns inset HUD for inset POV with multiview on/off.",
       "type": "boolean",
       "values": [
@@ -913,6 +1042,7 @@
       ]
     },
     "cl_name_as_skin": {
+      "group-id": "44",
       "desc": "Allows you to override user skin settings and use player\u0027s name or ID as a his (her) skin",
       "remarks": "There are many other skin settings that can override, e.g. all enemy*skin, team*skin settings override this setting.",
       "type": "enum",
@@ -923,6 +1053,7 @@
       ]
     },
     "cl_newlerp": {
+      "group-id": "8",
       "desc": "Experimental rockets/grenades/spikes smoothing code.\n\nDefault value 0.1 means: use 90% of our \u0027vision\u0027 and 10% of server \u0027vision\u0027. Should be OK for most case, but floating ping (see remarks)",
       "remarks": "This smoothing algorithm works good only with stable ping.",
       "type": "float",
@@ -931,6 +1062,7 @@
       ]
     },
     "cl_nodelta": {
+      "group-id": "21",
       "desc": "Control the network packet delta compression. When you get blue lines\nin your netgraph, you should set \u0027cl_nodelta 1\u0027.",
       "type": "boolean",
       "values": [
@@ -939,6 +1071,7 @@
       ]
     },
     "cl_nofake": {
+      "group-id": "3",
       "desc": "This command effects name faking using $/ or cl_fakename used by players.",
       "type": "enum",
       "values": [
@@ -948,6 +1081,7 @@
       ]
     },
     "cl_nolerp": {
+      "group-id": "8",
       "desc": "Allows you to disable the linear interpolation (lerp) of objects in the game. Information about objects\u0027 states arrive periodically via the net connection. By default between these moments the client tries to interpolate where the object are. After the new packet arrives client corrects the position of the object. If the interpolation is disabled, client will leave object in the state described in the last received packet until a new one arrives.",
       "type": "boolean",
       "values": [
@@ -956,6 +1090,7 @@
       ]
     },
     "cl_nolerp_on_entity": {
+      "group-id": "8",
       "desc": "Disables linear interpolation only when player is standing on an entity.\nIt is a workaround to remove jittering of floating platforms under feets.",
       "remarks": "No effect if fps independent physics is turned off.\nSee cl_nolerp.",
       "type": "boolean",
@@ -965,6 +1100,7 @@
       ]
     },
     "cl_nopred": {
+      "group-id": "21",
       "desc": "For debugging, disables movement prediction for your character; other players are still predicted.",
       "type": "boolean",
       "values": [
@@ -973,10 +1109,12 @@
       ]
     },
     "cl_novweps": {
+      "group-id": "8",
       "desc": "If set, disables support for zquake vwep extension",
       "type": "boolean"
     },
     "cl_onload": {
+      "group-id": "40",
       "desc": "Tells what will be the start-up screen of the client",
       "type": "string",
       "values": [
@@ -986,6 +1124,7 @@
       ]
     },
     "cl_parseFrags": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -993,6 +1132,7 @@
       ]
     },
     "cl_parseFunChars": {
+      "group-id": "3",
       "remarks": "Full list:\n$R - red lamp\n$G - green lamp\n$B - blue lamp\n$Y - yellow lamp\n$\\ - carridge return\n$( - big left bracket\n$= - big equal sign\n$) - big right bracket\n$. - red middle dot\n$, - white dot (names only)\n$\u003c - small left bracket\n$- - small equal sign\n$\u003e - small right bracket\n$a - big grey block\n$: - line feed\n$b - filled red block\n$d - right pointing red arrow\n$[ - gold left square bracket\n$] - gold right square bracket\n$^ - white ^ (names only)\n^x - red x (names only)\n$0-9 - yellow number\n$xyy - char with hex code yy\n(In order to use the lamps, you\u0027ll need the Ocrana pak).",
       "type": "boolean",
       "values": [
@@ -1001,6 +1141,7 @@
       ]
     },
     "cl_parseSay": {
+      "group-id": "3",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable %-macros (%a %h %b etc...)" },
@@ -1008,6 +1149,7 @@
       ]
     },
     "cl_parseWhiteText": {
+      "group-id": "3",
       "desc": "Convert text between { and } to white or not in chat/team chat.",
       "type": "enum",
       "values": [
@@ -1017,10 +1159,12 @@
       ]
     },
     "cl_pext": {
+      "group-id": "21",
       "desc": "If set, enable support for FTE\u0027s protocol extensions",
       "type": "boolean"
     },
     "cl_pext_256packetentities": {
+      "group-id": "21",
       "desc": "Allow protocol extension for allowing more packet entities.",
       "type": "boolean",
       "values": [
@@ -1029,10 +1173,12 @@
       ]
     },
     "cl_pext_alpha": {
+      "group-id": "21",
       "desc": "If set, enable support for FTE\u0027s alpha attribute protocol extension",
       "type": "boolean"
     },
     "cl_pext_chunkeddownloads": {
+      "group-id": "21",
       "desc": "Enables protocol extension called \\\"Chunked downloads\\\". Allows you to download maps and demos from servers faster.",
       "type": "boolean",
       "values": [
@@ -1041,10 +1187,12 @@
       ]
     },
     "cl_pext_floatcoords": {
+      "group-id": "21",
       "desc": "If set, enable support for FTE\u0027s floating point coordinate protocol extension.",
       "type": "boolean"
     },
     "cl_pext_other": {
+      "group-id": "21",
       "desc": "Allows other protocol extensions other than Chunked downloads",
       "type": "boolean",
       "values": [
@@ -1053,19 +1201,23 @@
       ]
     },
     "cl_physfps": {
+      "group-id": "8",
       "desc": "Sets the amount of FPS used to communicate with the server. This variable is used when cl_independentphysics 1 is set, and controls the FPS sent/received to/from the server. The graphical FPS is limited by cl_maxfps (vid_vsync must be 0). When set to 0, the current cl_maxfps value is used. When cl_maxfps is set to 0 too, client displays as much FPS as server and data rate allows.",
       "type": "float"
     },
     "cl_physfps_spectator": {
+      "group-id": "8",
       "desc": "Amount of updates the client will send/receive while being spectator. Lower values make the client smooth-out the field of view movement greatly.",
       "remarks": "This can increase your ping (only) when you are a spectator.",
       "type": "integer"
     },
     "cl_pitchspeed": {
+      "group-id": "9",
       "desc": "This variable determines how fast you you turn up/down when using \"+lookup\" and\n\"+lookdown\".",
       "type": "float"
     },
     "cl_predict_half": {
+      "group-id": "21",
       "remarks": "The new default eliminates player models\u0027 jittering when independent physics is enabled; a possible downside is larger prediction errors of modem players\u0027 movement, hence the option to revert to old behavior.",
       "type": "boolean",
       "values": [
@@ -1074,6 +1226,7 @@
       ]
     },
     "cl_predict_players": {
+      "group-id": "21",
       "desc": "This toggles the prediction for other players\u0027 movement. Unless you are having \nproblems this variable should be left at \"1\".",
       "type": "boolean",
       "values": [
@@ -1082,11 +1235,13 @@
       ]
     },
     "cl_proxyaddr": {
+      "group-id": "21",
       "desc": "IP address of the proxy server to use while connecting to servers.",
       "remarks": "This will override the /connect and /reconnect commands so that the connection is established via given proxy server.",
       "type": "string"
     },
     "cl_r2g": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Normal rockets models." },
@@ -1094,6 +1249,7 @@
       ]
     },
     "cl_restrictions": {
+      "group-id": "3",
       "desc": "Triggers and re/msg trigger restrictions for spectator and demoplay modes",
       "remarks": "FuhQuake always behave as cl_restrictions 1.\nQW262 by default it have cl_restrictions 1.",
       "type": "boolean",
@@ -1103,6 +1259,7 @@
       ]
     },
     "cl_rollalpha": {
+      "group-id": "53",
       "desc": "You can turn off the \u0027dodging\u0027 or \u0027rolling\u0027 effect for your own point of view while still see other player models affected by cl_rollangle.",
       "remarks": "-ruleset smackdown disables it and sets the value to default",
       "type": "integer",
@@ -1111,14 +1268,17 @@
       ]
     },
     "cl_rollangle": {
+      "group-id": "53",
       "desc": "This variable controls how much your screen tilts when strafing.",
       "type": "float"
     },
     "cl_rollspeed": {
+      "group-id": "53",
       "desc": "This variable controls how quickly you and other players straighten out after \nstrafing.",
       "type": "float"
     },
     "cl_savehistory": {
+      "group-id": "5",
       "desc": "Save console commands history to .ezquake_history.\nLoads history from this file while starting ezquake.",
       "type": "boolean",
       "values": [
@@ -1127,6 +1287,7 @@
       ]
     },
     "cl_sayfilter_coloredtext": {
+      "group-id": "49",
       "desc": "Allows you to filter your own outgoing messages out of markup that is used in this client to send colored text.",
       "remarks": "Colored text is not supported by some other clients. See cl_sayfilter_sendboth for compatibility mode with other clients. If you want to filter incoming messages out of colors, use scr_coloredtext.",
       "type": "enum",
@@ -1137,6 +1298,7 @@
       ]
     },
     "cl_sayfilter_sendboth": {
+      "group-id": "49",
       "desc": "When used with cl_sayfilter_coloredtext, sends two versions of the teamplay colored messages: colored one with \"#c\" at the end and uncolored version of the message with \"#u\" at the end of the message",
       "remarks": "FuhQuake users then can use \"filter #u\" to see only uncolored messages, ezQuake users can set \"filter #c\" to see only colored messages",
       "type": "boolean",
@@ -1146,6 +1308,7 @@
       ]
     },
     "cl_sbar": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Use the new transparent HUD." },
@@ -1153,6 +1316,7 @@
       ]
     },
     "cl_showkeycodes": {
+      "group-id": "1",
       "desc": "This variable enables/disables the output of informations to the currently pressed and/or released keys.",
       "type": "enum",
       "values": [
@@ -1163,6 +1327,7 @@
       ]
     },
     "cl_shownet": {
+      "group-id": "40",
       "desc": "This variable toggles the display of current net info.",
       "type": "enum",
       "values": [
@@ -1172,10 +1337,12 @@
       ]
     },
     "cl_sidespeed": {
+      "group-id": "9",
       "desc": "This allows you to set your strafe speed. Obviously this is also limited by the\nserver, usually to \"320\".",
       "type": "float"
     },
     "cl_smartjump": {
+      "group-id": "9",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Off." },
@@ -1183,9 +1350,11 @@
       ]
     },
     "cl_solid_players": {
+      "group-id": "21",
       "type": ""
     },
     "cl_startupdemo": {
+      "group-id": "7",
       "desc": "Demo that should be played on client\u0027s startup.",
       "type": "string",
       "values": [
@@ -1193,6 +1362,7 @@
       ]
     },
     "cl_staticSounds": {
+      "group-id": "45",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable static sounds." },
@@ -1200,6 +1370,7 @@
       ]
     },
     "cl_textencoding": {
+      "group-id": "48",
       "desc": "Determines method used to encoding non-standard characters in outgoing messages.",
       "type": "enum",
       "values": [
@@ -1209,14 +1380,17 @@
       ]
     },
     "cl_timeout": {
+      "group-id": "21",
       "desc": "This variable defines the timeout value in seconds until the client considers\nhimself to be disconnected from the server.",
       "type": "float"
     },
     "cl_upspeed": {
+      "group-id": "9",
       "desc": "This allows you to set the speed with which you move up and down in liquids or in spectator mode.\nObviously this is also limited by the server, usually to 320*0.7 = 224 when being in liquid and to 500 in spectator mode.",
       "type": "float"
     },
     "cl_useimagesinfraglog": {
+      "group-id": "47",
       "desc": "Turns on using images in the frags tracker window to show which weapon did take the role in the frag",
       "remarks": "See Tracer Stats manual page for further info",
       "type": "boolean",
@@ -1226,6 +1400,7 @@
       ]
     },
     "cl_useproxy": {
+      "group-id": "21",
       "desc": "This toggles whether Qizmo should be used (if detected) to a server. When\nenabled the server browser will use an existing connection to a Qizmo when \nconnecting another server by using the ezQuake Server Browser.",
       "type": "boolean",
       "values": [
@@ -1234,6 +1409,7 @@
       ]
     },
     "cl_verify_qwprotocol": {
+      "group-id": "40",
       "desc": "Enables the check on client startup for handling URLs starting with qw://",
       "remarks": "When enabled and the client is not associated with handling of qw:// URLs, user will be prompted if he wishes to associate the client with the protocol",
       "type": "boolean",
@@ -1243,14 +1419,17 @@
       ]
     },
     "cl_voip_capturingvol ": {
+      "group-id": "32",
       "desc": "Voice (VOIP) support. Volume multiplier applied while capturing, to avoid your audio from being heard by others.",
       "type": "integer"
     },
     "cl_voip_micamp": {
+      "group-id": "32",
       "desc": "Amplifies your microphone when using voip.",
       "type": "integer"
     },
     "cl_voip_play": {
+      "group-id": "32",
       "desc": "Enables voip (voice chat) playback.",
       "type": "boolean",
       "values": [
@@ -1259,6 +1438,7 @@
       ]
     },
     "cl_voip_send": {
+      "group-id": "32",
       "desc": "Enable sending of voice (voip) to the server.",
       "remarks": "Commands +void / -void emulate toggling this value to 2.",
       "type": "enum",
@@ -1269,6 +1449,7 @@
       ]
     },
     "cl_voip_showmeter": {
+      "group-id": "32",
       "desc": "Shows your speech volume above the at the bottom-left of the screen.",
       "type": "enum",
       "values": [
@@ -1278,24 +1459,29 @@
       ]
     },
     "cl_voip_showmeter_x": {
+      "group-id": "32",
       "desc": "Adjust horizontal position of the voice volume meter.",
       "remarks": "See cl_voip_showmeter.",
       "type": "integer"
     },
     "cl_voip_showmeter_y": {
+      "group-id": "32",
       "desc": "Adjust vertical position of the voice volume meter.",
       "remarks": "See cl_voip_showmeter.",
       "type": "integer"
     },
     "cl_voip_vad_delay": {
+      "group-id": "32",
       "desc": "Keeps sending voice data for this many seconds after voice activation would normally stop.",
       "type": "float"
     },
     "cl_voip_vad_threshhold": {
+      "group-id": "32",
       "desc": "This is the threshhold for voice-activation-detection when sending voip data.",
       "type": "float"
     },
     "cl_warncmd": {
+      "group-id": "2",
       "remarks": "Note: Not saved to config with cfg_save command.",
       "type": "boolean",
       "values": [
@@ -1304,9 +1490,11 @@
       ]
     },
     "cl_warnexec": {
+      "group-id": "5",
       "type": ""
     },
     "cl_weaponforgetorder": {
+      "group-id": "9",
       "type": "boolean",
       "values": [
         { "name": "1", "description": "weapon/impulse command picks best weapon out of those available at the time of the command" },
@@ -1314,6 +1502,7 @@
       ]
     },
     "cl_weaponhide": {
+      "group-id": "9",
       "desc": "On -attack will cause your weapon to be automatically switched back to the shotgun or axe.",
       "remarks": "This is used in majority of teamplay games. If you don\u0027t have ammo for shotgun the axe gets selected.",
       "type": "enum",
@@ -1324,6 +1513,7 @@
       ]
     },
     "cl_weaponhide_axe": {
+      "group-id": "9",
       "desc": "Determines if axe should be used as \"dummy\" weapon when using automated weapon hiding (cl_weaponhide).",
       "remarks": "See cl_weaponhide and cl_weaponpreselect.",
       "type": "boolean",
@@ -1333,6 +1523,7 @@
       ]
     },
     "cl_weaponpreselect": {
+      "group-id": "9",
       "desc": "When using the weapon command, this variable allows weapon preselection instead of standard immediate weapon selection. Preselection means that the preselected weapon will be switch right before +attack command, that is right before you shoot from your weapon.",
       "remarks": "Usefull in most teamplay games where you don\u0027t want to carry your best weapon in your hands but want to be ready to instantly shoot from it. Note: Doesn\u0027t work for impulse command, you have to use new weapon command.",
       "type": "enum",
@@ -1345,6 +1536,7 @@
       ]
     },
     "cl_window_caption": {
+      "group-id": "40",
       "desc": "Choose different window caption formats for your taskbar when you play in windowed mode or when the client is minimized in the taskbar.",
       "remarks": "The caption doesn\u0027t refresh regularly on some configurations. We recommend to use vid_flashonactivity 1 as well.",
       "type": "boolean",
@@ -1354,10 +1546,12 @@
       ]
     },
     "cl_yawspeed": {
+      "group-id": "9",
       "desc": "This variable defines how quickly you turn left (+left) or right (+right).",
       "type": "float"
     },
     "con_bindphysical": {
+      "group-id": "5",
       "desc": "Affects behaviour of bind command.",
       "remarks": "con_bindphysical will always be set to 1 at start of executing a script, and be reset after.",
       "type": "boolean",
@@ -1367,6 +1561,7 @@
       ]
     },
     "con_clearnotify": {
+      "group-id": "5",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Messages stay even when you toggle console." },
@@ -1374,6 +1569,7 @@
       ]
     },
     "con_completion_changed_mark": {
+      "group-id": "5",
       "desc": "Whether add or not asterisk before variables which values were changed.",
       "remarks": "Works only with con_completion_format \u003e 0.",
       "type": "boolean",
@@ -1383,6 +1579,7 @@
       ]
     },
     "con_completion_color_changed_mark": {
+      "group-id": "5",
       "desc": "Color of changed mark used in modern completion formatting.",
       "remarks": "Example: 39f",
       "type": "string",
@@ -1391,6 +1588,7 @@
       ]
     },
     "con_completion_color_colon": {
+      "group-id": "5",
       "desc": "Color of colon used in modern completion formatting.",
       "remarks": "Example: 39f",
       "type": "string",
@@ -1399,6 +1597,7 @@
       ]
     },
     "con_completion_color_name": {
+      "group-id": "5",
       "desc": "Color of variable name in used in modern completion formatting.",
       "remarks": "Example: 39f",
       "type": "string",
@@ -1407,6 +1606,7 @@
       ]
     },
     "con_completion_color_quotes_current": {
+      "group-id": "5",
       "desc": "Color of quotes of current variable value used in modern completion formatting.",
       "remarks": "Example: 39f",
       "type": "string",
@@ -1415,6 +1615,7 @@
       ]
     },
     "con_completion_color_quotes_default": {
+      "group-id": "5",
       "desc": "Color of quotes of default variable value used in modern completion formatting.",
       "remarks": "Example: 39f",
       "type": "string",
@@ -1423,6 +1624,7 @@
       ]
     },
     "con_completion_color_title": {
+      "group-id": "5",
       "desc": "Color of completion type title (variables, aliases or commands) used in modern completion formatting.",
       "remarks": "Example: 39f",
       "type": "string",
@@ -1431,6 +1633,7 @@
       ]
     },
     "con_completion_color_value_current": {
+      "group-id": "5",
       "desc": "Color of current variable value used in modern completion formatting.",
       "remarks": "Example: 39f",
       "type": "string",
@@ -1439,6 +1642,7 @@
       ]
     },
     "con_completion_color_value_default": {
+      "group-id": "5",
       "desc": "Color of default variable value used in modern completion formatting.",
       "remarks": "Example: 39f",
       "type": "string",
@@ -1447,6 +1651,7 @@
       ]
     },
     "con_completion_format": {
+      "group-id": "5",
       "desc": "Console completion variants format.",
       "remarks": "Modern - plain list with colorization.\nOld - somehow grouped list without colorization.",
       "type": "enum",
@@ -1460,11 +1665,13 @@
       ]
     },
     "con_completion_padding": {
+      "group-id": "5",
       "desc": "Number of spaces to pad command completion variants.",
       "remarks": "con_completion_format must be \u003e 1",
       "type": "integer"
     },
     "con_fragmessages": {
+      "group-id": "47",
       "desc": "Controls whether frag messages should be printed into console and notification area.",
       "remarks": "Requires cl_loadfragfiles and cl_parsefrags variables to be set to 1.",
       "type": "boolean",
@@ -1474,6 +1681,7 @@
       ]
     },
     "con_funchars_mode": {
+      "group-id": "5",
       "desc": "Orange text, LEDs and special chars with [Ctrl] key - kind of MQWCL behaviour when set to 1",
       "type": "boolean",
       "values": [
@@ -1482,6 +1690,7 @@
       ]
     },
     "con_hide_chat_input": {
+      "group-id": "5",
       "desc": "Hides the input of own chat text in the console.",
       "remarks": "cl_chatmode must be 1 or 2",
       "type": "boolean",
@@ -1491,6 +1700,7 @@
       ]
     },
     "con_highlight": {
+      "group-id": "5",
       "desc": "Console highlighting mode. Will highlight a line in the console which contains your nickname.",
       "remarks": "See con_highlight_mark.",
       "type": "enum",
@@ -1502,6 +1712,7 @@
       ]
     },
     "con_highlight_mark": {
+      "group-id": "5",
       "desc": "Specifies the text that will be used to highlight lines with con_highlight 2 and 3.",
       "type": "string",
       "values": [
@@ -1509,6 +1720,7 @@
       ]
     },
     "con_notify": {
+      "group-id": "5",
       "desc": "Toggles the display of the notification area",
       "remarks": "Notification area is the place where chat and game messages are displayed",
       "type": "boolean",
@@ -1518,6 +1730,7 @@
       ]
     },
     "con_notifylines": {
+      "group-id": "5",
       "desc": "This variable sets the number of notify lines (default 4, max 20) to be used at the top of the screen.",
       "remarks": "...",
       "type": "integer",
@@ -1528,10 +1741,12 @@
       ]
     },
     "con_notifytime": {
+      "group-id": "5",
       "desc": "How long console messages stay on screen.",
       "type": "float"
     },
     "con_particles_alpha": {
+      "group-id": "31",
       "desc": "Sets the transparency of con_particles_images.",
       "type": "float",
       "values": [
@@ -1539,6 +1754,7 @@
       ]
     },
     "con_particles_images": {
+      "group-id": "22",
       "desc": "Set the number of images you have in /textures/conpart.png.",
       "type": "integer",
       "values": [
@@ -1546,15 +1762,18 @@
       ]
     },
     "con_prompt_charcode": {
+      "group-id": "5",
       "desc": "ASCII code of prompt character.",
       "remarks": "Value must be between 32 and 255",
       "type": "integer"
     },
     "con_shift": {
+      "group-id": "5",
       "desc": "Adjusts vertical offset of background of the console.",
       "type": "float"
     },
     "con_tilde_mode": {
+      "group-id": "5",
       "desc": "When enabled, allows you to use the tilde key also in the console and when typing messages.",
       "remarks": "To exit the console with con_tilde_mode 1, use Escape\n",
       "type": "enum",
@@ -1565,6 +1784,7 @@
       ]
     },
     "con_timestamps": {
+      "group-id": "5",
       "desc": "Toggles time stamps before mm1 or spectator messages. Does not apply to messages with cl_fakename.",
       "type": "enum",
       "values": [
@@ -1574,6 +1794,7 @@
       ]
     },
     "con_wordwrap": {
+      "group-id": "5",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable word wrapping." },
@@ -1581,6 +1802,7 @@
       ]
     },
     "coop": {
+      "group-id": "43",
       "desc": "Whether the next \"map\" command should start a coop (cooperative) game.\nOnly works when deathmatch var is 0, otherwise coop will be forced off and a deathmatch game will start.\n\nYou need a file, spprogs.dat, in your quake/qw/ folder for coop games to work.",
       "type": "boolean",
       "values": [
@@ -1589,6 +1811,7 @@
       ]
     },
     "crosshair": {
+      "group-id": "6",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Crosshair off." },
@@ -1602,6 +1825,7 @@
       ]
     },
     "crosshairalpha": {
+      "group-id": "6",
       "desc": "This command regulates crosshair transparency, you can use any value from \"0\" \nto \"1\".",
       "type": "boolean",
       "values": [
@@ -1610,18 +1834,22 @@
       ]
     },
     "crosshaircolor": {
+      "group-id": "6",
       "desc": "This variable defines the color of the crosshair.",
       "type": "string"
     },
     "crosshairimage": {
+      "group-id": "6",
       "desc": "To load the crosshair use \"crosshairimage image_name\" where\n\u0027image_name\u0027 is the name of the crosshair image you put in the above directory.\nExample, if I have c:\\quake\\ezQuake\\crosshairs\\cross.png I\u0027d use\n\"crosshairimage cross\" to load it.",
       "type": "string"
     },
     "crosshairsize": {
+      "group-id": "6",
       "desc": "Basically crosshairsize scales the size of the crosshair. \nExample:\ncrosshairsize 0.5 halves the size and crosshair 2 doubles it.",
       "type": "float"
     },
     "cvar_viewdefault": {
+      "group-id": "5",
       "desc": "When you type a cvar name into console (like \u0027gl_gamma\u0027 or \u0027r_rocketlight\u0027), the client will tell you the default value of the cvar.",
       "type": "boolean",
       "values": [
@@ -1630,6 +1858,7 @@
       ]
     },
     "cvar_viewhelp": {
+      "group-id": "5",
       "desc": "Automatically prints manual page when a variable name is typed in the console.",
       "type": "boolean",
       "values": [
@@ -1638,6 +1867,7 @@
       ]
     },
     "cvar_viewlatched": {
+      "group-id": "5",
       "desc": "When you type a variable name in the console, you\u0027ll be able to see it\u0027s latched value if this is turned on.",
       "remarks": "Latched values are used for example for renderer settings. Variable value is latched until the renderer is restarted, in that moment the latched value becomes the actuall value of the variable.",
       "type": "boolean",
@@ -1647,6 +1877,7 @@
       ]
     },
     "d_mipcap": {
+      "group-id": "30",
       "type": "enum",
       "values": [
         { "name": "0", "description": "High texture detail." },
@@ -1656,6 +1887,7 @@
       ]
     },
     "d_mipscale": {
+      "group-id": "30",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Full object detail" },
@@ -1665,6 +1897,7 @@
       ]
     },
     "d_subdiv16": {
+      "group-id": "30",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Precise texture mapping (slower, more accurate)." },
@@ -1672,15 +1905,18 @@
       ]
     },
     "deathmatch": {
+      "group-id": "43",
       "desc": "Chooses between basic multiplayer gameplay modes; 1 = weapons disappear after pickup (used in 4on4), 2 = weapons stay after pickup, ammo/armor does not (not used), 3 = weapons stay after pickup (used in 1on1), 4 = arena mode (players have all weapons and full health/armor)",
       "type": "integer"
     },
     "default_fov": {
+      "group-id": "53",
       "desc": "Very useful in TeamFortress, and other mods that reset your fov when you spawn to 90. \nBasically, when the server sends you \"fov 90\", your fov is set to default_fov.",
       "remarks": "-",
       "type": "float"
     },
     "demo_autotrack": {
+      "group-id": "7",
       "desc": "Enables server-side autotrack to be accepted",
       "remarks": "Server-side autotrack is recorded in MVD demos and in QTV stream allowing all the observers of the match observe the same player at the same time",
       "type": "boolean",
@@ -1690,6 +1926,7 @@
       ]
     },
     "demo_benchmarkdumps": {
+      "group-id": "7",
       "desc": "Allows you to automatically dump timedemo benchmark results into $log_dir/timedemo.log file. The output is in XML markup format and contains info about your operating system, hardware configuration, client version, rendering, screen resolution and the result FPS.",
       "remarks": "See timedemo command description for more info. Note: The result file is not a well-formed XML file.",
       "type": "boolean",
@@ -1699,18 +1936,22 @@
       ]
     },
     "demo_browser_democolor": {
+      "group-id": "25",
       "desc": "Color of the demo entries in the demo browser",
       "type": "string"
     },
     "demo_browser_dircolor": {
+      "group-id": "25",
       "desc": "Color of the dir entries in the demo browser",
       "type": "string"
     },
     "demo_browser_interline": {
+      "group-id": "25",
       "desc": "Size of the space between entries in the demo browser",
       "type": "integer"
     },
     "demo_browser_scrollnames": {
+      "group-id": "25",
       "desc": "Toggle scrolling of the filenames in the demo browser",
       "type": "boolean",
       "values": [
@@ -1719,10 +1960,12 @@
       ]
     },
     "demo_browser_selectedcolor": {
+      "group-id": "25",
       "desc": "Color of the selected entries in the demo browser",
       "type": "string"
     },
     "demo_browser_showdate": {
+      "group-id": "25",
       "desc": "Toggle the date column in the demo browser",
       "type": "boolean",
       "values": [
@@ -1731,6 +1974,7 @@
       ]
     },
     "demo_browser_showsize": {
+      "group-id": "25",
       "desc": "Toggle the file size column in the demo browser",
       "type": "boolean",
       "values": [
@@ -1739,6 +1983,7 @@
       ]
     },
     "demo_browser_showstatus": {
+      "group-id": "25",
       "desc": "Toggle the display of the status bar in the demo browser",
       "type": "boolean",
       "values": [
@@ -1747,6 +1992,7 @@
       ]
     },
     "demo_browser_showtime": {
+      "group-id": "25",
       "desc": "Toggle the time column in the demo browser",
       "type": "boolean",
       "values": [
@@ -1755,10 +2001,12 @@
       ]
     },
     "demo_browser_sortmode": {
+      "group-id": "25",
       "desc": "Sorting mode in the demo browser. Each number represents one column. Their order represents the priority of the sorting.",
       "type": "string"
     },
     "demo_browser_stripnames": {
+      "group-id": "25",
       "desc": "Toggle stripping of the filenames in the demo browser",
       "type": "boolean",
       "values": [
@@ -1767,22 +2015,27 @@
       ]
     },
     "demo_browser_zipcolor": {
+      "group-id": "25",
       "desc": "Color of the zip entries in the demo browser",
       "type": "string"
     },
     "demo_capture_codec": {
+      "group-id": "7",
       "desc": "Determines what codes should be used for captured video stream compression. E.g. XVID, DIVX, ...",
       "type": "float"
     },
     "demo_capture_dir": {
+      "group-id": "7",
       "desc": "Change the default capture directory.",
       "type": "string"
     },
     "demo_capture_fps": {
+      "group-id": "7",
       "desc": "Change the default capture fps.",
       "type": "float"
     },
     "demo_capture_mp3": {
+      "group-id": "7",
       "desc": "When set to 1 .avi capturing captures sound compressed in MP3 format.",
       "remarks": "See demo_capture_mp3_kbps too.",
       "type": "boolean",
@@ -1792,26 +2045,32 @@
       ]
     },
     "demo_capture_mp3_kbps": {
+      "group-id": "7",
       "desc": "Sets bitrate for captured sound stream when demo_capture_mp3 is set to 1.",
       "type": "float"
     },
     "demo_capture_quiet": {
+      "group-id": "7",
       "desc": "Stops sound being played during demo capture",
       "type": "boolean"
     },
     "demo_capture_steadycam": {
+      "group-id": "7",
       "desc": "Changes behaviour of keyboard/mouse input when capturing.",
       "type": "float"
     },
     "demo_capture_vid_maxlen": {
+      "group-id": "7",
       "desc": "If set, multiple files will be created.  This variable determines length in seconds of each file",
       "type": "integer"
     },
     "demo_dir": {
+      "group-id": "7",
       "desc": "Change the demos and autorecord directory.",
       "type": "string"
     },
     "demo_format": {
+      "group-id": "7",
       "desc": "Specifies the demo file format used when recording demo with Match tools.",
       "remarks": "See qwdtools_dir, qizmo_dir, match_auto_record.",
       "type": "string",
@@ -1822,6 +2081,7 @@
       ]
     },
     "demo_getpings": {
+      "group-id": "7",
       "desc": "This toggles whether the client should always record pings into the demo or only\nwhen the player died and show(team)scores are being shown (QWCL default).",
       "type": "boolean",
       "values": [
@@ -1830,6 +2090,7 @@
       ]
     },
     "demo_playlist_loop": {
+      "group-id": "40",
       "desc": "will toggle playlist looping",
       "type": "boolean",
       "values": [
@@ -1838,10 +2099,12 @@
       ]
     },
     "demo_playlist_track_name": {
+      "group-id": "40",
       "desc": "will set the default track name in the demo playlist for mvd demos \nexample: jogi, will always track the player jogi or versions of it (jogihoogi, angryjogi, etc)",
       "type": "string"
     },
     "developer": {
+      "group-id": "2",
       "desc": "Enables debug mode which prints more messages into the console than for normal user",
       "type": "boolean",
       "values": [
@@ -1850,13 +2113,16 @@
       ]
     },
     "download_map_url": {
+      "group-id": "43",
       "type": "string"
     },
     "enemybothskin": {
+      "group-id": "44",
       "desc": "Overrides the enemy quad pent skin so you can define the skin which applies to enemys with both the quad and pent powerups.",
       "type": "string"
     },
     "enemybottomcolor": {
+      "group-id": "44",
       "desc": "Determines the color of the pants of the enemies you see. Overrides player\u0027s skin settings.",
       "remarks": "To be able to use RGB 24bit colors, look for r_enemyskincolor variable.",
       "type": "integer",
@@ -1865,6 +2131,7 @@
       ]
     },
     "enemyforceskins": {
+      "group-id": "44",
       "desc": "Allows you to set different skin for every enemy player even if they all have same skin names set or use names of skins that you do not have in your Quake dir",
       "remarks": "Read \"Player skins\" manual page for more info on skin rules.",
       "type": "enum",
@@ -1876,18 +2143,22 @@
       ]
     },
     "enemypentskin": {
+      "group-id": "44",
       "desc": "Overrides the enemy pent skin so you can define the skin which applies to enemy pents.",
       "type": "string"
     },
     "enemyquadskin": {
+      "group-id": "44",
       "desc": "Overrides the enemy quad skin so you can define the skin which applies to enemy quads.",
       "type": "string"
     },
     "enemyskin": {
+      "group-id": "44",
       "desc": "Overrides the enemies skin so you can define the skin which applies to enemies.",
       "type": "string"
     },
     "enemytopcolor": {
+      "group-id": "44",
       "desc": "Determines the color of the shirt of the enemies you see. Overrides player\u0027s skin settings.",
       "remarks": "To be able to use RGB 24bit colors, look for r_enemyskincolor variable.",
       "type": "integer",
@@ -1896,42 +2167,55 @@
       ]
     },
     "file_browser_archive_color": {
+      "group-id": "17",
       "type": "string"
     },
     "file_browser_dir_color": {
+      "group-id": "17",
       "type": "string"
     },
     "file_browser_file_color": {
+      "group-id": "17",
       "type": "string"
     },
     "file_browser_interline": {
+      "group-id": "17",
       "type": ""
     },
     "file_browser_scrollnames": {
+      "group-id": "17",
       "type": ""
     },
     "file_browser_selected_color": {
+      "group-id": "17",
       "type": "string"
     },
     "file_browser_show_date": {
+      "group-id": "17",
       "type": ""
     },
     "file_browser_show_size": {
+      "group-id": "17",
       "type": ""
     },
     "file_browser_show_status": {
+      "group-id": "17",
       "type": ""
     },
     "file_browser_show_time": {
+      "group-id": "17",
       "type": ""
     },
     "file_browser_sort_mode": {
+      "group-id": "17",
       "type": ""
     },
     "file_browser_strip_names": {
+      "group-id": "17",
       "type": ""
     },
     "filterban": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Only IP addresses on the Ban list will be allowed onto the server." },
@@ -1939,23 +2223,28 @@
       ]
     },
     "floodprotmsg": {
+      "group-id": "33",
       "desc": "Sets the message displayed after flood protection is invoked.\nExample: floodprotmsg \"Shut up whiner!\"",
       "type": "float"
     },
     "fov": {
+      "group-id": "53",
       "desc": "This variable defines your field of vision, which determines how close your vision field is to the objects.",
       "remarks": "The default value is 90, however many players prefer using a higher FOV.  Note that this would typically be scaled up when using a monitor with widescreen aspect ratio.",
       "type": "float"
     },
     "frag_log_type": {
+      "group-id": "43",
       "type": ""
     },
     "fraglimit": {
+      "group-id": "43",
       "desc": "Amount of frags any player has to reach before the match is over",
       "remarks": "When set to 0, there won\u0027t be any limit",
       "type": "integer"
     },
     "freelook": {
+      "group-id": "10",
       "remarks": "direction up or down.",
       "type": "boolean",
       "values": [
@@ -1964,6 +2253,7 @@
       ]
     },
     "fs_cache": {
+      "group-id": "48",
       "desc": "Enables Quake File System caching of files lists",
       "type": "boolean",
       "values": [
@@ -1972,10 +2262,12 @@
       ]
     },
     "gl_affinemodels": {
+      "group-id": "35",
       "desc": "Makes texture rendering quality better if set to 1.\nNote: 3dfx thing, not sure. //fuh check this.",
       "type": "float"
     },
     "gl_alphafont": {
+      "group-id": "5",
       "desc": "When turned on allows the alpha transparency layer support for the console font.",
       "type": "boolean",
       "values": [
@@ -1984,6 +2276,7 @@
       ]
     },
     "gl_anisotropy": {
+      "group-id": "50",
       "desc": "Anisotropic filtering. Basically improved texture quality.",
       "remarks": "Depends on your Graphics card capabilities and settings. Make sure you have enabled \"Application controled\" in your Graphics card settings for Anisotropic filtering option.",
       "type": "integer",
@@ -1992,6 +2285,7 @@
       ]
     },
     "gl_bounceparticles": {
+      "group-id": "36",
       "remarks": "Bouncing particles look nicer, but may eat up CPU.",
       "type": "boolean",
       "values": [
@@ -2000,13 +2294,16 @@
       ]
     },
     "gl_brush_polygonoffset": {
+      "group-id": "35",
       "type": "float"
     },
     "gl_buildingsparks": {
+      "group-id": "35",
       "desc": "Buildings that are destroyed in TF will continue to throw sparks until they disapear.",
       "type": "float"
     },
     "gl_caustics": {
+      "group-id": "51",
       "desc": "Turns reflections on walls covered with liquids (water, lava, slime) when set to 1.\nMulti-texturing is required for this variable.",
       "type": "boolean",
       "values": [
@@ -2015,6 +2312,7 @@
       ]
     },
     "gl_clear": {
+      "group-id": "35",
       "desc": "This variable will toggle the clearing of the screen between each frame. This\ncan be helpful when specing a game and flying out of the map or during map \ndevelopment when the map maker must fly outside of the map to look has his map\nfrom the outside. Enabling this command will clear the areas which are not \nrendered outside of the map thus preventing the flickering effect when images \nrepeat themselves repeatedly. However it causes problems when playing and \ngoing through the surfaces of a liquid (for example when diving into liquid), as\nyou will see a red flash where the liquid texture would normally be repeated.",
       "type": "boolean",
       "values": [
@@ -2023,10 +2321,12 @@
       ]
     },
     "gl_clearColor": {
+      "group-id": "35",
       "desc": "Sets clear color (gl_clear 1)",
       "type": "string"
     },
     "gl_clipparticles": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2034,6 +2334,7 @@
       ]
     },
     "gl_colorlights": {
+      "group-id": "15",
       "desc": "Switch on/off colour of lighting from glowing items (quad, pent, flags in TF, etc)",
       "remarks": "This implementation does not give a speed increase when gl_colorlights is set to 0, but it does not require a map restart for changes to take effect",
       "type": "boolean",
@@ -2043,18 +2344,22 @@
       ]
     },
     "gl_consolefont": {
+      "group-id": "5",
       "desc": "Changes your console font.\nPut all your charset images in qw/textures/charsets/*.png (and *.tga) and use /loadcharset XXX to load XXX.png (or tga). \"/gl_consolefont original\" will restore the 8bit font in your gfx.wad (this is default).\nNote: loadcharset is an alias for gl_consolefont.",
       "type": "string"
     },
     "gl_contrast": {
+      "group-id": "40",
       "desc": "Change contrast.",
       "type": "float"
     },
     "gl_coronas": {
+      "group-id": "15",
       "desc": "Adds coronas to some effects:Explosions - Basically just a bright flash since the default explosions didn\u0027t feel powerful enough.\nMuzzleflashes.\nLightning.\nFire - Torches have glows.\nRocket Lights.",
       "type": "float"
     },
     "gl_coronas_tele": {
+      "group-id": "15",
       "desc": "Allows you to turn on/off blue light when spawning.",
       "type": "boolean",
       "values": [
@@ -2063,10 +2368,12 @@
       ]
     },
     "gl_cshiftpercent": {
+      "group-id": "39",
       "desc": "This variable sets the percentage value for palette shifting effects (damage flash, powerup blend). (needs gl_polyblend 1)",
       "type": "float"
     },
     "gl_cull": {
+      "group-id": "35",
       "desc": "This variable toggles the use of internal OpenGL functions for removing covered \nobjects. When this variable is set to \"1\" the game will depend on the OpenGL \ndriver to use it\u0027s culling functions to remove certain objects from the \ncalculations because they are covered up and would not be seen anyways. It is a \ngood idea to leave this toggle enabled because it will increase rendering \nperformance.",
       "type": "boolean",
       "values": [
@@ -2075,10 +2382,12 @@
       ]
     },
     "gl_cutf_tesla_effect": {
+      "group-id": "35",
       "desc": "When a shambler is preparing to throw lightning, or a tesla coil (TF) is charging to fire, a particle effect is generated.",
       "type": "float"
     },
     "gl_detail": {
+      "group-id": "8",
       "desc": "Turns on/off fine detailed textures.",
       "type": "boolean",
       "values": [
@@ -2087,13 +2396,16 @@
       ]
     },
     "gl_detpacklights": {
+      "group-id": "35",
       "desc": "A little green light appears on the detpack, and when the timer reaches 5, the light changes to red. gl_coronas must be turned on for this to work.",
       "type": "float"
     },
     "gl_ext_arb_texture_non_power_of_two": {
+      "group-id": "50",
       "type": ""
     },
     "gl_ext_texture_compression": {
+      "group-id": "50",
       "desc": "Enable reducing memory held by textures on cards that support it (but textures loaded slower and may have less quality).",
       "type": "boolean",
       "values": [
@@ -2102,6 +2414,7 @@
       ]
     },
     "gl_externalTextures_bmodels": {
+      "group-id": "50",
       "remarks": "non-world .bsp models (any .bsp that isn\u0027t the actual map.  Ex. health and ammo boxes).",
       "type": "boolean",
       "values": [
@@ -2110,6 +2423,7 @@
       ]
     },
     "gl_externalTextures_world": {
+      "group-id": "50",
       "remarks": "world .bsp model (i.e. the actual map).",
       "type": "boolean",
       "values": [
@@ -2118,10 +2432,12 @@
       ]
     },
     "gl_extratrails": {
+      "group-id": "35",
       "desc": "Misc trails that appear on objects that frequently move, such as TF grenades, caltrops, etc.\nRailguns in TF also leave behind unique trails.",
       "type": "float"
     },
     "gl_fb_bmodels": {
+      "group-id": "15",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Might give you a couple more fps." },
@@ -2129,6 +2445,7 @@
       ]
     },
     "gl_fb_models": {
+      "group-id": "15",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Might also give you more fps." },
@@ -2136,6 +2453,7 @@
       ]
     },
     "gl_finish": {
+      "group-id": "35",
       "desc": "This variable toggles the calling of the gl_finish() OpenGL function after each \nrendered frame.",
       "type": "boolean",
       "values": [
@@ -2144,6 +2462,7 @@
       ]
     },
     "gl_flashblend": {
+      "group-id": "15",
       "desc": "This variable affects when glow bubbles are displayed in the client. You can change the color of the rocket glow by r_rocketLightColor, the color of explosions by r_explosionLightColor, and the color of flag carriers by r_flagColor.",
       "type": "enum",
       "values": [
@@ -2153,41 +2472,51 @@
       ]
     },
     "gl_fog": {
+      "group-id": "51",
       "desc": "Turns fog effect on and off (GL-Only). See /gl_fogstart /gl_fogend /gl_fogsky and /fog too.",
       "type": "float"
     },
     "gl_fogblue": {
+      "group-id": "51",
       "desc": "Blue factor in the color of the fog",
       "type": "float"
     },
     "gl_fogend": {
+      "group-id": "51",
       "desc": "Sets ending distance for rendering the fog. When fog is turned on, you cannot see behind this distance limit. See /gl_fog and /gl_fogstart too.",
       "type": "float"
     },
     "gl_foggreen": {
+      "group-id": "51",
       "desc": "Green factor in the color of the fog",
       "type": "float"
     },
     "gl_fogred": {
+      "group-id": "51",
       "desc": "Red factor in the color of the fog",
       "type": "float"
     },
     "gl_fogsky": {
+      "group-id": "51",
       "desc": "When turned on, fog effect affects sky too. We suggest turning this on otherwise fog looks ridiculous and unrealistic.",
       "type": "float"
     },
     "gl_fogstart": {
+      "group-id": "51",
       "desc": "Sets starting distance for rendering the fog. The greater the number is, the better visibility in game is and the fog is \"thinner\".",
       "type": "float"
     },
     "gl_gamma": {
+      "group-id": "40",
       "desc": "Change GL gamma.",
       "type": "float"
     },
     "gl_gammacorrection": {
+      "group-id": "35",
       "type": ""
     },
     "gl_hwblend": {
+      "group-id": "39",
       "remarks": "Note: 1 can be slow on wintNT/2K.",
       "type": "boolean",
       "values": [
@@ -2196,14 +2525,17 @@
       ]
     },
     "gl_inferno_speed": {
+      "group-id": "35",
       "desc": "Changes speed of gl_inferno missile trail.",
       "type": "float"
     },
     "gl_inferno_trail": {
+      "group-id": "35",
       "desc": "Changes type of gl_inferno missile trail.",
       "type": "float"
     },
     "gl_lerpimages": {
+      "group-id": "50",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Faster loading maps (not more fps)." },
@@ -2211,14 +2543,17 @@
       ]
     },
     "gl_lighting_colour": {
+      "group-id": "15",
       "desc": "Alias models are effected by coloured lights around them.",
       "type": "float"
     },
     "gl_lighting_vertex": {
+      "group-id": "15",
       "desc": "Alias models no longer have the same level of light on all sides. This may not work correctly if coloured lighting is disabled.",
       "type": "float"
     },
     "gl_lightmode": {
+      "group-id": "15",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Makes the map lighter, but fullbrights don\u0027t look as good. (0% overbrights)" },
@@ -2226,6 +2561,7 @@
       ]
     },
     "gl_lightning": {
+      "group-id": "35",
       "type": "boolean",
       "values": [
         { "name": "0", "description": "Turns off particle lightning beams" },
@@ -2233,6 +2569,7 @@
       ]
     },
     "gl_lightning_color": {
+      "group-id": "35",
       "desc": "The RGB color of particle lightning beam and sparks.",
       "type": "string",
       "values": [
@@ -2240,18 +2577,22 @@
       ]
     },
     "gl_lightning_size": {
+      "group-id": "35",
       "desc": "Adjusts size of ligtning particle beam.",
       "type": "float"
     },
     "gl_lightning_sparks": {
+      "group-id": "35",
       "desc": "Sparks fly from walls when hit by lightning gun.",
       "type": "float"
     },
     "gl_lightning_sparks_size": {
+      "group-id": "35",
       "desc": "Size of lightning sparks.",
       "type": "integer"
     },
     "gl_loadlitfiles": {
+      "group-id": "15",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable lit files." },
@@ -2259,6 +2600,7 @@
       ]
     },
     "gl_luma_level": {
+      "group-id": "50",
       "desc": "Some luma textures have black (in RGB format its 0,0,0) non-transparent pixels. This can make them transparent.",
       "remarks": "Setting this to 0 will disable the functionality. For some commonly used texture packs value 1 is necessary.",
       "type": "integer",
@@ -2267,14 +2609,17 @@
       ]
     },
     "gl_lumaTextures": {
+      "group-id": "50",
       "desc": "Turns using of luma textures (named *_luma) ON when set to 1 and allowed by server.",
       "type": "float"
     },
     "gl_max_size": {
+      "group-id": "50",
       "desc": "This variable determines the detail level for loaded textures. When set to \"1\",\nthe objects and walls will be textured with 1x1 pixel textures.",
       "type": "float"
     },
     "gl_maxtmu2": {
+      "group-id": "35",
       "desc": "Allow only two texturing units. Sometimes usefull for buggy ATI cards. If you don\u0027t need this, don\u0027t use it. Lowers the performance.",
       "type": "boolean",
       "values": [
@@ -2283,39 +2628,50 @@
       ]
     },
     "gl_miptexLevel": {
+      "group-id": "50",
       "desc": "It is essentially a GL \u0027equivalent\u0027\nto d_mipcap in software.  It has no affect when loading external 24bit textures.",
       "type": "float"
     },
     "gl_modulate": {
+      "group-id": "35",
       "type": ""
     },
     "gl_motion_blur": {
+      "group-id": "8",
       "type": ""
     },
     "gl_motion_blur_dead": {
+      "group-id": "8",
       "type": "float"
     },
     "gl_motion_blur_fps": {
+      "group-id": "8",
       "type": ""
     },
     "gl_motion_blur_hurt": {
+      "group-id": "8",
       "type": "float"
     },
     "gl_motion_blur_norm": {
+      "group-id": "8",
       "type": "float"
     },
     "gl_motiontrails": {
+      "group-id": "35",
       "desc": "When enabled, flags and keys leave behind a kind of after-image.\nFiends also leave trails when they pounce.",
       "type": "float"
     },
     "gl_motiontrails_wtf": {
+      "group-id": "35",
       "desc": "Same as gl_motiontrails but works for all players and creatures.",
       "type": "float"
     },
     "gl_multisamples": {
+      "group-id": "52",
       "type": ""
     },
     "gl_nailtrail": {
+      "group-id": "35",
       "desc": "Adds a white trail onto nails as they fly around.\nThis feature wont work on servers not running with sv_nailhack set to 1.",
       "type": "boolean",
       "values": [
@@ -2324,6 +2680,7 @@
       ]
     },
     "gl_nailtrail_plasma": {
+      "group-id": "35",
       "desc": "Adds plasma trail to nails.",
       "remarks": "Need gl_nailtrail 1.",
       "type": "boolean",
@@ -2333,6 +2690,7 @@
       ]
     },
     "gl_nailtrail_turb": {
+      "group-id": "35",
       "desc": "Switches between two type of bubbles nails leave behind in water.",
       "remarks": "gl_turb_trails 1 needs to be set.",
       "type": "enum",
@@ -2342,6 +2700,7 @@
       ]
     },
     "gl_no24bit": {
+      "group-id": "50",
       "desc": "Disables support of alternate 24bit textures. Requires a vid_restart to take effect.",
       "type": "boolean",
       "values": [
@@ -2350,6 +2709,7 @@
       ]
     },
     "gl_nocolors": {
+      "group-id": "35",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Normal." },
@@ -2357,14 +2717,17 @@
       ]
     },
     "gl_outline": {
+      "group-id": "35",
       "desc": "If set, draws outline on models to create rotoscope effect.",
       "type": "boolean"
     },
     "gl_outline_width": {
+      "group-id": "35",
       "desc": "Determines outline width when gl_outline enabled.  Limits of 0.1 to 3.0",
       "type": "float"
     },
     "gl_part_blobs": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2372,6 +2735,7 @@
       ]
     },
     "gl_part_blood": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2379,14 +2743,17 @@
       ]
     },
     "gl_part_detpackexplosion_fire_color": {
+      "group-id": "36",
       "desc": "Change color of the detpack explosion fire (TF).",
       "type": "string"
     },
     "gl_part_detpackexplosion_ray_color": {
+      "group-id": "36",
       "desc": "Change the color of the detpack explosion rays (Team Fortress).",
       "type": "string"
     },
     "gl_part_explosions": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2394,6 +2761,7 @@
       ]
     },
     "gl_part_gunshots": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2401,6 +2769,7 @@
       ]
     },
     "gl_part_inferno": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2408,6 +2777,7 @@
       ]
     },
     "gl_part_lavasplash": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2415,6 +2785,7 @@
       ]
     },
     "gl_part_spikes": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2422,6 +2793,7 @@
       ]
     },
     "gl_part_telesplash": {
+      "group-id": "36",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Use classic quake teleport particles" },
@@ -2430,6 +2802,7 @@
       ]
     },
     "gl_part_tracer1_color": {
+      "group-id": "36",
       "desc": "Changes the color of the tracer1 trail, which allows you to customize the rockettrail color (see remarks).",
       "remarks": "If you set r_rockettrail 6 and gl_part_trails 1, this variable will change your rockettrail color",
       "type": "string",
@@ -2438,12 +2811,15 @@
       ]
     },
     "gl_part_tracer1_size": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_part_tracer1_time": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_part_tracer2_color": {
+      "group-id": "36",
       "desc": "Changes the color of the tracer2 trail, which allows you to customize the rockettrail color (see remarks).",
       "remarks": "If you set r_rockettrail 7 and gl_part_trails 1, this variable will change your rockettrail color",
       "type": "string",
@@ -2452,12 +2828,15 @@
       ]
     },
     "gl_part_tracer2_size": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_part_tracer2_time": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_part_trails": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2465,38 +2844,48 @@
       ]
     },
     "gl_particle_blobs": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_blood": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_blood_color": {
+      "group-id": "36",
       "desc": "Changes colour of blood.",
       "type": "float"
     },
     "gl_particle_blood_type": {
+      "group-id": "36",
       "desc": "Chooses among types of blood particles.",
       "type": "float"
     },
     "gl_particle_deatheffect": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_explosions": {
+      "group-id": "36",
       "desc": "Turns particle alternatives to each r_explosiontype on or off.",
       "type": "float"
     },
     "gl_particle_fasttrails": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_fire": {
+      "group-id": "36",
       "desc": "Replaces torches with a particle flame effect. Includes people being burnt by the pyro in TF.",
       "type": "float"
     },
     "gl_particle_firecolor": {
+      "group-id": "36",
       "desc": "Color of the fire particle",
       "type": "string"
     },
     "gl_particle_fulldetail": {
+      "group-id": "36",
       "desc": "Allows full detail depth for gl_particle_* effects",
       "type": "boolean",
       "values": [
@@ -2505,26 +2894,33 @@
       ]
     },
     "gl_particle_gibtrails": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_gunshots": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_gunshots_type": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_muzzleflash": {
+      "group-id": "36",
       "desc": "Adds particle effect when firing a weapon.",
       "type": "float"
     },
     "gl_particle_shockwaves": {
+      "group-id": "36",
       "desc": "0 - Turns off explosion shockwaves.\n1 - Turns on explosion shockwaves.",
       "type": "float"
     },
     "gl_particle_shockwaves_flat": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_sparks": {
+      "group-id": "36",
       "desc": "Trails appear more beam-like and don\u0027t look stupid when they bounce. This applies for wizards and knights only.",
       "type": "boolean",
       "values": [
@@ -2533,33 +2929,42 @@
       ]
     },
     "gl_particle_spikes": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_spikes_type": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_style": {
+      "group-id": "36",
       "type": ""
     },
     "gl_particle_trail_detail": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_trail_lenght": {
+      "group-id": "36",
       "desc": "X - Multiplies the length of the trail on particle trails.",
       "type": "float"
     },
     "gl_particle_trail_time": {
+      "group-id": "36",
       "desc": "X - Multiplies the length of time the particle bounces around for.",
       "type": "float"
     },
     "gl_particle_trail_type": {
+      "group-id": "36",
       "type": "float"
     },
     "gl_particle_trail_width": {
+      "group-id": "36",
       "desc": "Changes width of trail particle e.g.: wall hitted by nail, explosion particles trail, etc.",
       "type": "float"
     },
     "gl_picmip": {
+      "group-id": "50",
       "desc": "This variable determines the the level of detail for textures used on walls. You\ncan use this variable to lower the texture detail used on walls thus increasing\nthe game\u0027s performance.",
       "remarks": "X = etc..",
       "type": "enum",
@@ -2570,6 +2975,7 @@
       ]
     },
     "gl_playermip": {
+      "group-id": "50",
       "desc": "Determines the level of detail of player models. This variable is useful if you are \nexperience game slowdown during multiplayer games when there are lots of players on \nyour screen by shrinking the texture detail, but this will make the player models more blurry.",
       "remarks": "X = etc.",
       "type": "enum",
@@ -2580,6 +2986,7 @@
       ]
     },
     "gl_polyblend": {
+      "group-id": "39",
       "desc": "Controls a short burst of screen tinting on various events. Variables to look at are: gl_cshiftpercent  (controls overall palette shifting) v_damagechisft v_quadcshift  v_pentcshift v_ringcshift v_suitcshift.",
       "type": "boolean",
       "values": [
@@ -2588,6 +2995,7 @@
       ]
     },
     "gl_powerupshells": {
+      "group-id": "8",
       "desc": "Enables a flashing layer over players carrying powerups",
       "type": "boolean",
       "values": [
@@ -2596,30 +3004,38 @@
       ]
     },
     "gl_powerupshells_base1level": {
+      "group-id": "8",
       "type": "float"
     },
     "gl_powerupshells_base2level": {
+      "group-id": "8",
       "type": "float"
     },
     "gl_powerupshells_effect1level": {
+      "group-id": "8",
       "type": "float"
     },
     "gl_powerupshells_effect2level": {
+      "group-id": "8",
       "type": "float"
     },
     "gl_powerupshells_size": {
+      "group-id": "8",
       "desc": "Size of the powerupshells effect layer",
       "type": "integer"
     },
     "gl_powerupshells_style": {
+      "group-id": "8",
       "desc": "Style of the powerupshells effect layer",
       "type": "integer"
     },
     "gl_rl_globe": {
+      "group-id": "15",
       "desc": "Helps customize rocket light independant of gl_flashblend.\n0 - treated as feature off.\n1 - rocket light looks like with gl_flashblend 2, but no dynamic lighting.\n2 - rocket light looks like with gl_flashblend 0 or 1.\n3 - rocket light looks like with gl_flashblend 2, with dynamic lighting, exactly the same.",
       "type": "integer"
     },
     "gl_scaleModelTextures": {
+      "group-id": "50",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable scale model textures." },
@@ -2627,6 +3043,7 @@
       ]
     },
     "gl_scaleTurbTextures": {
+      "group-id": "50",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable gl_picmip/gl_max_size/gl_miptexLevel affect turb textures (lava, water, slime, teleports)." },
@@ -2634,6 +3051,7 @@
       ]
     },
     "gl_shaftlight": {
+      "group-id": "15",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Dark shaft." },
@@ -2641,6 +3059,7 @@
       ]
     },
     "gl_simpleitems": {
+      "group-id": "8",
       "desc": "Instead of 3D item models in the game display 2D images representing them.",
       "type": "boolean",
       "values": [
@@ -2649,12 +3068,15 @@
       ]
     },
     "gl_simpleitems_orientation": {
+      "group-id": "8",
       "type": ""
     },
     "gl_simpleitems_size": {
+      "group-id": "8",
       "type": ""
     },
     "gl_smoothfont": {
+      "group-id": "5",
       "desc": "Smoothens out the font (which = good). But in some cases the font wasn\u0027t designed to be smoothened (sometimes the case of custom console fonts etc).",
       "type": "boolean",
       "values": [
@@ -2663,6 +3085,7 @@
       ]
     },
     "gl_smoothmodels": {
+      "group-id": "35",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not smooth the textures on models." },
@@ -2670,6 +3093,7 @@
       ]
     },
     "gl_solidparticles": {
+      "group-id": "36",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -2677,18 +3101,22 @@
       ]
     },
     "gl_squareparticles": {
+      "group-id": "36",
       "desc": "Toggles between circle and square particles",
       "type": ""
     },
     "gl_strings": {
+      "group-id": "22",
       "desc": "Read-only variable with info about your OpenGL renderer",
       "type": "string"
     },
     "gl_subdivide_size": {
+      "group-id": "50",
       "desc": "This variable sets the division value for the sky brushes. The higher the value \nthe better the performance, but the smoothness of the sky suffers.",
       "type": "float"
     },
     "gl_surface_lava": {
+      "group-id": "51",
       "desc": "Adds boiling bubbles over the lava.",
       "type": "enum",
       "values": [
@@ -2700,6 +3128,7 @@
       ]
     },
     "gl_surface_slime": {
+      "group-id": "51",
       "desc": "Adds bubbles and fumes of slime over the slime.",
       "type": "enum",
       "values": [
@@ -2711,6 +3140,7 @@
       ]
     },
     "gl_textureless": {
+      "group-id": "50",
       "desc": "True textureless map textures, but preserving original colors.\nFor custom colors - look for r_drawflat.",
       "remarks": "The beauty of this is that u can toggle in realtime for any map.\nSame as with r_drawflat.",
       "type": "boolean",
@@ -2720,6 +3150,7 @@
       ]
     },
     "gl_texturemode": {
+      "group-id": "50",
       "remarks": "GL_NEAREST* modes are often used with gl_miptexlevel 3",
       "type": "string",
       "values": [
@@ -2732,11 +3163,13 @@
       ]
     },
     "gl_texturemode2d": {
+      "group-id": "50",
       "desc": "Texture mode used for objects in the head up display, such as font, image of armor, player\u0027s face or crosshair.",
       "remarks": "See gl_texturemode for possible values.",
       "type": "string"
     },
     "gl_triplebuffer": {
+      "group-id": "35",
       "desc": "Triple buffering of head up display graphics. If you have problems with screen graphics, turn this on.",
       "remarks": "This has nothing to do with 3D rendering, it will not increase graphics \"lag\" or anything like that. It only affects 2D head up display graphics.",
       "type": "boolean",
@@ -2746,10 +3179,12 @@
       ]
     },
     "gl_turb_trails": {
+      "group-id": "51",
       "desc": "This gives rockets/grenades/nails and other things an alternate underwater trail.\nVery nice to have nailgun fights underwater...",
       "type": "float"
     },
     "gl_turbalpha": {
+      "group-id": "51",
       "desc": "This variable determines the level of opacity for liquids, which requires\nthe use of maps that were VISed with transparent water. When using maps that\nhave not been VISed in such a way, you have to use \"r_novis 1\". If \"r_novis\" is\nset to \"1\" or when using a map VISed with transparent water and using setting\n\"gl_turbalpha\" to a value lower than \"1\", the player will be able to see objects \nand walls through liquids if the server allows that. This is a very nice feature \nto have in the game, for more information refer to the \"r_novis\" command. You \ncan use any value between \"0\" and \"1\" for \"gl_turbalpha\", here are some \nExamples:",
       "type": "enum",
       "values": [
@@ -2761,6 +3196,7 @@
       ]
     },
     "gl_turbfog": {
+      "group-id": "51",
       "desc": "Controls amount of fog when inside liquid (water, lava, slime).\nDensity is controlled by choosing a value from 0 to 1 and from 1 to 2.",
       "remarks": "Works only when multitexturing is enabled.",
       "type": "enum",
@@ -2771,6 +3207,7 @@
       ]
     },
     "gl_turbfog_color_lava": {
+      "group-id": "51",
       "desc": "Color of fog in lava.",
       "type": "string",
       "values": [
@@ -2778,6 +3215,7 @@
       ]
     },
     "gl_turbfog_color_slime": {
+      "group-id": "51",
       "desc": "Color of fog in slime.",
       "type": "string",
       "values": [
@@ -2785,6 +3223,7 @@
       ]
     },
     "gl_turbfog_color_water": {
+      "group-id": "51",
       "desc": "Color of fog in water.",
       "type": "string",
       "values": [
@@ -2792,6 +3231,7 @@
       ]
     },
     "gl_turbfogDensity": {
+      "group-id": "51",
       "desc": "Control of density of liquid (water, lava, slime...) fog",
       "type": "float",
       "values": [
@@ -2799,19 +3239,23 @@
       ]
     },
     "gl_turbripple": {
+      "group-id": "51",
       "desc": "Put your life vests on, waves are coming! Creates an effect of waves on liquids.",
       "remarks": "Enabled only for viewing demos and observing games.",
       "type": "float"
     },
     "gl_weather_rain": {
+      "group-id": "51",
       "desc": "Turns on rain out of doors, the density of rain is equal to whatever gl_weather_rain is set to.\nIf you set gl_weather_rain_fast to 1, you can turn off all splashes, if you set it to 2, you will turn off only the water splashes.\nWorks on all non-iD maps except death32c, dakyne and some others.",
       "type": "float"
     },
     "gl_weather_rain_fast": {
+      "group-id": "51",
       "desc": "Adjusts speed of rain.",
       "type": "float"
     },
     "gl_ztrick": {
+      "group-id": "31",
       "desc": "This variables toggles the use of a trick to prevent the clearning of the \nz-buffer between frames. When this variable is set to \"1\", the game will not \nclear the z-buffer between frames. This will result in increased performance \nbut might cause problems for some display hardware.",
       "type": "boolean",
       "values": [
@@ -2820,6 +3264,7 @@
       ]
     },
     "help_files_dircolor": {
+      "group-id": "25",
       "desc": "The RGB color of directories in the help browser.",
       "type": "string",
       "values": [
@@ -2827,6 +3272,7 @@
       ]
     },
     "help_files_filecolor": {
+      "group-id": "25",
       "desc": "The RGB color for files in the help browser.",
       "type": "string",
       "values": [
@@ -2834,10 +3280,12 @@
       ]
     },
     "help_files_interline": {
+      "group-id": "25",
       "desc": "Adjust interlining of file list in /help filebrowser.",
       "type": "float"
     },
     "help_files_scrollnames": {
+      "group-id": "25",
       "desc": "Should the filenames in the help browser get scrolled if they don\u0027t fit when the file is selected?",
       "type": "boolean",
       "values": [
@@ -2846,6 +3294,7 @@
       ]
     },
     "help_files_selectedcolor": {
+      "group-id": "25",
       "desc": "The RGB color of a selected file in the help browser.",
       "type": "string",
       "values": [
@@ -2853,367 +3302,460 @@
       ]
     },
     "help_files_showdate": {
+      "group-id": "25",
       "desc": "Shows column displaying file last modification date in /help file browser.",
       "type": "float"
     },
     "help_files_showsize": {
+      "group-id": "25",
       "desc": "Shows column displaying file size in /help file browser.",
       "type": "float"
     },
     "help_files_showstatus": {
+      "group-id": "25",
       "desc": "Show quick info about selected help file in /help file browser.",
       "type": "float"
     },
     "help_files_showtime": {
+      "group-id": "25",
       "desc": "Shows column displaying file last modification time in /help file browser.",
       "type": "float"
     },
     "help_files_sortmode": {
+      "group-id": "25",
       "desc": "Switches sorting methods of files /help file browser.",
       "type": "float"
     },
     "help_files_stripnames": {
+      "group-id": "25",
       "desc": "Strips filenames of help files.",
       "type": "float"
     },
     "hostname": {
+      "group-id": "43",
       "desc": "Server variable, changes the name of the server displayed in server browsers and server lists.",
       "type": "string"
     },
     "hud_ammo_align": {
+      "group-id": "19",
       "desc": "Sets align of current ammo value",
       "type": "string"
     },
     "hud_ammo_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of current ammo value",
       "type": "string"
     },
     "hud_ammo_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of current ammo value",
       "type": "string"
     },
     "hud_ammo_digits": {
+      "group-id": "19",
       "desc": "Sets number of digits for current ammo value",
       "type": "float"
     },
     "hud_ammo_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for current ammo value",
       "type": "float"
     },
     "hud_ammo_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the ammo HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_ammo_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ammo_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_ammo_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for current ammo value",
       "type": "string"
     },
     "hud_ammo_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of current ammo value",
       "type": "float"
     },
     "hud_ammo_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of current ammo value",
       "type": "float"
     },
     "hud_ammo_scale": {
+      "group-id": "19",
       "desc": "Sets size of current ammo value",
       "type": "float"
     },
     "hud_ammo_show": {
+      "group-id": "19",
       "desc": "Switches showing of current ammo value",
       "type": "float"
     },
     "hud_ammo_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of current ammo value",
       "type": "float"
     },
     "hud_ammo1_align": {
+      "group-id": "19",
       "desc": "Sets align of number of shells for both horizontal and vertical direction.",
       "type": "string"
     },
     "hud_ammo1_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of number of shells",
       "type": "string"
     },
     "hud_ammo1_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of number of shells",
       "type": "string"
     },
     "hud_ammo1_digits": {
+      "group-id": "19",
       "desc": "Sets number of digits for number of shells",
       "type": "float"
     },
     "hud_ammo1_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for number of shells",
       "type": "float"
     },
     "hud_ammo1_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the ammo1 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_ammo1_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ammo1_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_ammo1_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for number of shells",
       "type": "string"
     },
     "hud_ammo1_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of number of shells",
       "type": "float"
     },
     "hud_ammo1_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of number of shells",
       "type": "float"
     },
     "hud_ammo1_scale": {
+      "group-id": "19",
       "desc": "Sets size of number of shells",
       "type": "float"
     },
     "hud_ammo1_show": {
+      "group-id": "19",
       "desc": "Switches showing of number of shells",
       "type": "float"
     },
     "hud_ammo1_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of number of shells",
       "type": "float"
     },
     "hud_ammo2_align": {
+      "group-id": "19",
       "desc": "Sets align of number of nails",
       "type": "string"
     },
     "hud_ammo2_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of number of nails",
       "type": "string"
     },
     "hud_ammo2_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of number of nails",
       "type": "string"
     },
     "hud_ammo2_digits": {
+      "group-id": "19",
       "desc": "Sets number of digits for number of nails",
       "type": "float"
     },
     "hud_ammo2_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for number of nails",
       "type": "float"
     },
     "hud_ammo2_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the ammo2 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_ammo2_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ammo2_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_ammo2_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for number of nails",
       "type": "string"
     },
     "hud_ammo2_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of number of nails",
       "type": "float"
     },
     "hud_ammo2_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of number of nails",
       "type": "float"
     },
     "hud_ammo2_scale": {
+      "group-id": "19",
       "desc": "Sets size of number of nails",
       "type": "float"
     },
     "hud_ammo2_show": {
+      "group-id": "19",
       "desc": "Switches showing of number of nails",
       "type": "float"
     },
     "hud_ammo2_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of number of nails",
       "type": "float"
     },
     "hud_ammo3_align": {
+      "group-id": "19",
       "desc": "Sets align of number of rockets",
       "type": "string"
     },
     "hud_ammo3_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of number of rockets",
       "type": "string"
     },
     "hud_ammo3_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of number of rockets",
       "type": "string"
     },
     "hud_ammo3_digits": {
+      "group-id": "19",
       "desc": "Sets number of digits for",
       "type": "float"
     },
     "hud_ammo3_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for",
       "type": "float"
     },
     "hud_ammo3_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the ammo3 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_ammo3_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ammo3_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_ammo3_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for",
       "type": "string"
     },
     "hud_ammo3_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of number of rockets",
       "type": "float"
     },
     "hud_ammo3_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of number of rockets",
       "type": "float"
     },
     "hud_ammo3_scale": {
+      "group-id": "19",
       "desc": "Sets size of number of rockets",
       "type": "float"
     },
     "hud_ammo3_show": {
+      "group-id": "19",
       "desc": "Switches showing of number of rockets",
       "type": "float"
     },
     "hud_ammo3_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of number of rockets",
       "type": "float"
     },
     "hud_ammo4_align": {
+      "group-id": "19",
       "desc": "Sets align of number of cells",
       "type": "string"
     },
     "hud_ammo4_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of number of cells",
       "type": "string"
     },
     "hud_ammo4_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of number of cells",
       "type": "string"
     },
     "hud_ammo4_digits": {
+      "group-id": "19",
       "desc": "Sets number of digits for number of cells",
       "type": "float"
     },
     "hud_ammo4_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for number of cells",
       "type": "float"
     },
     "hud_ammo4_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the ammo4 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_ammo4_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ammo4_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_ammo4_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for number of cells",
       "type": "string"
     },
     "hud_ammo4_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of number of cells",
       "type": "float"
     },
     "hud_ammo4_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of number of cells",
       "type": "float"
     },
     "hud_ammo4_scale": {
+      "group-id": "19",
       "desc": "Sets size of number of cells",
       "type": "float"
     },
     "hud_ammo4_show": {
+      "group-id": "19",
       "desc": "Switches showing of number of cells",
       "type": "float"
     },
     "hud_ammo4_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of number of cells",
       "type": "float"
     },
     "hud_armor_align": {
+      "group-id": "19",
       "desc": "Sets align of armor level",
       "type": "string"
     },
     "hud_armor_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of armor level",
       "type": "string"
     },
     "hud_armor_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of armor level",
       "type": "string"
     },
     "hud_armor_digits": {
+      "group-id": "19",
       "desc": "Sets number of digits for armor level",
       "type": "float"
     },
     "hud_armor_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for armor level",
       "type": "float"
     },
     "hud_armor_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the armor HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_armor_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_armor_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_armor_pent_666": {
+      "group-id": "19",
       "type": ""
     },
     "hud_armor_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for armor level",
       "type": "string"
     },
     "hud_armor_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of armor level",
       "type": "float"
     },
     "hud_armor_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of armor level",
       "type": "float"
     },
     "hud_armor_scale": {
+      "group-id": "19",
       "desc": "Sets size of armor level",
       "type": "float"
     },
     "hud_armor_show": {
+      "group-id": "19",
       "desc": "Switches showing of armor level",
       "type": "float"
     },
     "hud_armor_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of armor level",
       "type": "float"
     },
     "hud_armordamage_align": {
+      "group-id": "19",
       "desc": "Sets armordamage HUD element alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -3222,6 +3764,7 @@
       ]
     },
     "hud_armordamage_align_x": {
+      "group-id": "19",
       "desc": "Sets armordamage HUD element horizontal alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -3230,6 +3773,7 @@
       ]
     },
     "hud_armordamage_align_y": {
+      "group-id": "19",
       "desc": "Sets armordamage HUD element vertical alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -3238,10 +3782,12 @@
       ]
     },
     "hud_armordamage_digits": {
+      "group-id": "19",
       "desc": "Sets highest possible number of digits displayed in HUD element armordamage.",
       "type": "float"
     },
     "hud_armordamage_duration": {
+      "group-id": "19",
       "desc": "Sets how long armordamage should be visible after last damage to armor has been done.",
       "type": "float",
       "values": [
@@ -3249,6 +3795,7 @@
       ]
     },
     "hud_armordamage_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for this HUD element.",
       "type": "float",
       "values": [
@@ -3256,17 +3803,21 @@
       ]
     },
     "hud_armordamage_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the armordamage HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_armordamage_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_armordamage_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_armordamage_place": {
+      "group-id": "19",
       "desc": "Sets placement for this HUD element. You can align some elements relative to other elements.",
       "remarks": "First you have to decide, if the element that you are locating now (element B) is to be positioned inside another element (element A) or outside it. See HUD manual for more info.",
       "type": "string",
@@ -3275,14 +3826,17 @@
       ]
     },
     "hud_armordamage_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of this HUD element.",
       "type": "float"
     },
     "hud_armordamage_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of this HUD element.",
       "type": "float"
     },
     "hud_armordamage_scale": {
+      "group-id": "19",
       "desc": "Sets overall size of this HUD element.",
       "type": "float",
       "values": [
@@ -3290,6 +3844,7 @@
       ]
     },
     "hud_armordamage_show": {
+      "group-id": "19",
       "desc": "Toggles visibility of this HUD element.",
       "type": "boolean",
       "values": [
@@ -3298,6 +3853,7 @@
       ]
     },
     "hud_armordamage_style": {
+      "group-id": "19",
       "desc": "Toggles between different numbers styles.",
       "type": "boolean",
       "values": [
@@ -3306,134 +3862,175 @@
       ]
     },
     "hud_bar_armor_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_bar_armor_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_bar_armor_color_ga": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_color_noarmor": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_color_ra": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_color_unnatural": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_color_ya": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_direction": {
+      "group-id": "19",
       "desc": "Direction of colored part inside HUD element that designates amount of armor.",
       "remarks": "0 - left-\u003eright\n1 - right-\u003eleft\n2 - down -\u003e up\n3 - up -\u003e down",
       "type": "integer"
     },
     "hud_bar_armor_frame": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_height": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_bar_armor_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_bar_armor_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_armor_width": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_bar_health_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_bar_health_color_mega": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_color_nohealth": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_color_normal": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_color_twomega": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_color_unnatural": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_direction": {
+      "group-id": "19",
       "desc": "Direction of colored part inside HUD element that designates amount of health.",
       "remarks": "0 - left-\u003eright\n1 - right-\u003eleft\n2 - down -\u003e up\n3 - up -\u003e down",
       "type": "integer"
     },
     "hud_bar_health_frame": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_height": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_bar_health_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_bar_health_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_bar_health_width": {
+      "group-id": "19",
       "type": ""
     },
     "hud_clock_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of clock",
       "type": "string"
     },
     "hud_clock_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of clock",
       "type": "string"
     },
     "hud_clock_big": {
+      "group-id": "19",
       "desc": "Switches unsing larger version of clock",
       "type": "float"
     },
     "hud_clock_blink": {
+      "group-id": "19",
       "desc": "Switches blinking colon of clock",
       "type": "float"
     },
     "hud_clock_format": {
+      "group-id": "19",
       "desc": "Controls in what format the clock is displayed",
       "type": "enum",
       "values": [
@@ -3444,53 +4041,66 @@
       ]
     },
     "hud_clock_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for clock",
       "type": "float"
     },
     "hud_clock_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the clock HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_clock_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_clock_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_clock_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for clock",
       "type": "string"
     },
     "hud_clock_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of clock",
       "type": "float"
     },
     "hud_clock_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of clock",
       "type": "float"
     },
     "hud_clock_scale": {
+      "group-id": "19",
       "desc": "Size of the clock HUD element",
       "type": "float"
     },
     "hud_clock_show": {
+      "group-id": "19",
       "desc": "Switches showing of clock",
       "type": "float"
     },
     "hud_clock_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of clock",
       "type": "float"
     },
     "hud_democlock_align_x": {
+      "group-id": "19",
       "desc": "Vertical alignment of the democlock HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_democlock_align_y": {
+      "group-id": "19",
       "desc": "Vertical alignment of the democlock HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_democlock_big": {
+      "group-id": "19",
       "desc": "Enables larger version of the democlock.",
       "type": "boolean",
       "values": [
@@ -3499,6 +4109,7 @@
       ]
     },
     "hud_democlock_blink": {
+      "group-id": "19",
       "desc": "Enables democlock colon blinking",
       "type": "boolean",
       "values": [
@@ -3507,37 +4118,46 @@
       ]
     },
     "hud_democlock_frame": {
+      "group-id": "19",
       "desc": "Opacity of the background of the democlock HUD element",
       "type": "float"
     },
     "hud_democlock_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the democlock HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_democlock_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_democlock_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_democlock_place": {
+      "group-id": "19",
       "desc": "Placement of the democlock HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
       "type": "string"
     },
     "hud_democlock_pos_x": {
+      "group-id": "19",
       "desc": "Horizontal relative position of the democlock HUD element",
       "type": "integer"
     },
     "hud_democlock_pos_y": {
+      "group-id": "19",
       "desc": "Vertical relative position of the democlock HUD element",
       "type": "integer"
     },
     "hud_democlock_scale": {
+      "group-id": "19",
       "desc": "Size of the democlock HUD element",
       "type": "float"
     },
     "hud_democlock_show": {
+      "group-id": "19",
       "desc": "Visibility of the democlock HUD element",
       "type": "boolean",
       "values": [
@@ -3546,10 +4166,12 @@
       ]
     },
     "hud_democlock_style": {
+      "group-id": "19",
       "desc": "Toggles democlock render styles",
       "type": "integer"
     },
     "hud_digits_trim": {
+      "group-id": "19",
       "desc": "Changes how large numbers are treated in Head Up Display",
       "remarks": "Applies to all HUD elements with \u0027digits\u0027 property.",
       "type": "enum",
@@ -3560,6 +4182,7 @@
       ]
     },
     "hud_editor_allowalign": {
+      "group-id": "19",
       "desc": "Should aligning be allowed when using the HUD editor?",
       "remarks": "This can also be toggled when in the HUD editor by using the F3 button.",
       "type": "boolean",
@@ -3569,6 +4192,7 @@
       ]
     },
     "hud_editor_allowmove": {
+      "group-id": "19",
       "desc": "Allow moving HUD elements when in HUD editor mode.",
       "remarks": "This can also be toggled when in the HUD editor by using the F1 button.",
       "type": "boolean",
@@ -3578,6 +4202,7 @@
       ]
     },
     "hud_editor_allowplace": {
+      "group-id": "19",
       "desc": "Allow placing HUD elements in HUD editor mode.",
       "remarks": "This can also be toggled when in the HUD editor by using the F4 button.",
       "type": "boolean",
@@ -3587,6 +4212,7 @@
       ]
     },
     "hud_editor_allowresize": {
+      "group-id": "19",
       "desc": "Allow resizing HUD elements in HUD editor mode",
       "remarks": "This can also be toggled when in the HUD editor by using the F2 button.",
       "type": "boolean",
@@ -3596,104 +4222,130 @@
       ]
     },
     "hud_face_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of player face",
       "type": "string"
     },
     "hud_face_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of player face",
       "type": "string"
     },
     "hud_face_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for player face",
       "type": "float"
     },
     "hud_face_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the face HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_face_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_face_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_face_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for player face",
       "type": "string"
     },
     "hud_face_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of player face",
       "type": "float"
     },
     "hud_face_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of player face",
       "type": "float"
     },
     "hud_face_scale": {
+      "group-id": "19",
       "desc": "Sets size of player face",
       "type": "float"
     },
     "hud_face_show": {
+      "group-id": "19",
       "desc": "Switches showing of player face",
       "type": "float"
     },
     "hud_fps_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of fps counter",
       "type": "string"
     },
     "hud_fps_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of fps counter",
       "type": "string"
     },
     "hud_fps_decimals": {
+      "group-id": "29",
       "desc": "How many decimal number should the FPS HUD element contain",
       "remarks": "Code says always three decimals",
       "type": "integer"
     },
     "hud_fps_drop": {
+      "group-id": "19",
       "desc": "Sets the value which will trigger displaying the fps (requires hud_fps_style 2 or 3). For example, with value hud_fps_drop 70, the fps will only be displayed if it drops to 70 or below. For fps values greater than 70, the fps will not be displayed.",
       "type": "float"
     },
     "hud_fps_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for fps counter",
       "type": "float"
     },
     "hud_fps_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the fps HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_fps_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_fps_min_reset_interval": {
+      "group-id": "8",
       "type": ""
     },
     "hud_fps_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_fps_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for fps counter",
       "type": "string"
     },
     "hud_fps_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of fps counter",
       "type": "float"
     },
     "hud_fps_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of fps counter",
       "type": "float"
     },
     "hud_fps_show": {
+      "group-id": "19",
       "desc": "Switches showing of fps counter",
       "type": "float"
     },
     "hud_fps_show_min": {
+      "group-id": "19",
       "desc": "Switches showing of fps counter",
       "type": "float"
     },
     "hud_fps_style": {
+      "group-id": "19",
       "desc": "Alters how and when the fps is drawn. Please see hud_fps_drop for styles 2 and 3.",
       "type": "enum",
       "values": [
@@ -3704,18 +4356,22 @@
       ]
     },
     "hud_fps_title": {
+      "group-id": "19",
       "desc": "Switches displaying the text \"fps\" of fps counter",
       "type": "float"
     },
     "hud_frags_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of frags bar",
       "type": "string"
     },
     "hud_frags_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of frags bar",
       "type": "string"
     },
     "hud_frags_bignum": {
+      "group-id": "19",
       "desc": "Changes the scale of the fragcount number.",
       "type": "float",
       "values": [
@@ -3723,22 +4379,27 @@
       ]
     },
     "hud_frags_cell_height": {
+      "group-id": "19",
       "desc": "Sets cell height of frags bar",
       "type": "float"
     },
     "hud_frags_cell_width": {
+      "group-id": "19",
       "desc": "Sets cell width of frags bar",
       "type": "float"
     },
     "hud_frags_colors_alpha": {
+      "group-id": "19",
       "desc": "Sets the opacity of the players colors for the frags hud element.",
       "type": "float"
     },
     "hud_frags_cols": {
+      "group-id": "19",
       "desc": "Sets number of columns of frags bar",
       "type": "float"
     },
     "hud_frags_extra_spec_info": {
+      "group-id": "19",
       "desc": "Enables to see what people have rocket launchers, powerups and how much health and armor they have using icons next to the frags. Works while watching MVD demo.",
       "type": "string",
       "values": [
@@ -3755,6 +4416,7 @@
       ]
     },
     "hud_frags_fliptext": {
+      "group-id": "19",
       "desc": "Toggles alignment of players nick and team name in frags HUD element.",
       "remarks": "Use \u0027frags shownames 1\u0027 and/or \u0027frags showteams 1\u0027 to show names and team names of players.",
       "type": "boolean",
@@ -3764,28 +4426,35 @@
       ]
     },
     "hud_frags_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for frags bar",
       "type": "float"
     },
     "hud_frags_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the frags HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_frags_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_frags_maxname": {
+      "group-id": "19",
       "desc": "The max number of characters to use for displaying the names in the frags element.",
       "type": "integer"
     },
     "hud_frags_notintp": {
+      "group-id": "19",
       "type": ""
     },
     "hud_frags_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_frags_padtext": {
+      "group-id": "19",
       "desc": "Toggles text padding in \u0027frags\u0027 HUD element.",
       "remarks": "Use \u0027frags shownames 1\u0027 and/or \u0027frags showteams 1\u0027.",
       "type": "boolean",
@@ -3795,26 +4464,32 @@
       ]
     },
     "hud_frags_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for frags bar",
       "type": "string"
     },
     "hud_frags_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of frags bar",
       "type": "float"
     },
     "hud_frags_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of frags bar",
       "type": "float"
     },
     "hud_frags_rows": {
+      "group-id": "19",
       "desc": "Sets number of rows in frags bar",
       "type": "float"
     },
     "hud_frags_show": {
+      "group-id": "19",
       "desc": "Switches showing of frags bar",
       "type": "float"
     },
     "hud_frags_shownames": {
+      "group-id": "19",
       "desc": "Draws players names next to frag counts in \u0027frags\u0027 HUD element.",
       "type": "boolean",
       "values": [
@@ -3823,6 +4498,7 @@
       ]
     },
     "hud_frags_showself_always": {
+      "group-id": "19",
       "desc": "Forces the client to show the part of frags table where you are.",
       "type": "boolean",
       "values": [
@@ -3831,6 +4507,7 @@
       ]
     },
     "hud_frags_showteams": {
+      "group-id": "19",
       "desc": "Draws players\u0027 team tags next to frag counts in \u0027frags\u0027 HUD element.",
       "type": "boolean",
       "values": [
@@ -3839,18 +4516,22 @@
       ]
     },
     "hud_frags_space_x": {
+      "group-id": "19",
       "desc": "Sets vertical spacing of frags bar",
       "type": "float"
     },
     "hud_frags_space_y": {
+      "group-id": "19",
       "desc": "Sets horizontal spacing of frags bar",
       "type": "float"
     },
     "hud_frags_strip": {
+      "group-id": "19",
       "desc": "Switches stripped version of frags bar",
       "type": "float"
     },
     "hud_frags_style": {
+      "group-id": "19",
       "desc": "Sets drawing style of \u0027frags\u0027 HUD element.",
       "type": "enum",
       "values": [
@@ -3866,22 +4547,27 @@
       ]
     },
     "hud_frags_teamsort": {
+      "group-id": "19",
       "desc": "Switches sorting by teams in frags bar",
       "type": "float"
     },
     "hud_frags_vertical": {
+      "group-id": "19",
       "desc": "Switches vertical rendering of frags bar",
       "type": "float"
     },
     "hud_gameclock_align_x": {
+      "group-id": "19",
       "desc": "Vertical alignment of the gameclock HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_gameclock_align_y": {
+      "group-id": "19",
       "desc": "Vertical alignment of the gameclock HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_gameclock_big": {
+      "group-id": "19",
       "desc": "Draw the text of the gameclock using big numbers.",
       "type": "boolean",
       "values": [
@@ -3890,6 +4576,7 @@
       ]
     },
     "hud_gameclock_blink": {
+      "group-id": "19",
       "desc": "Blink the colon on the gameclock hud element every second.",
       "type": "boolean",
       "values": [
@@ -3898,6 +4585,7 @@
       ]
     },
     "hud_gameclock_countdown": {
+      "group-id": "19",
       "desc": "Changes the direction of the game clock (gameclock HUD element)",
       "type": "boolean",
       "values": [
@@ -3906,42 +4594,52 @@
       ]
     },
     "hud_gameclock_frame": {
+      "group-id": "19",
       "desc": "Opacity of the background of the gameclock HUD element",
       "type": "float"
     },
     "hud_gameclock_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gameclock HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gameclock_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gameclock_offset": {
+      "group-id": "19",
       "desc": "Allows using gameclock in custom mods that don\u0027t support standard KT-like clock synchronization",
       "remarks": "Some Capture The Flag or Team Fortress mods can take a use of this.",
       "type": "integer"
     },
     "hud_gameclock_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gameclock_place": {
+      "group-id": "19",
       "desc": "Placement of the gameclock HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
       "type": "string"
     },
     "hud_gameclock_pos_x": {
+      "group-id": "19",
       "desc": "Horizontal relative position of the gameclock HUD element",
       "type": "integer"
     },
     "hud_gameclock_pos_y": {
+      "group-id": "19",
       "desc": "Vertical relative position of the gameclock HUD element",
       "type": "integer"
     },
     "hud_gameclock_scale": {
+      "group-id": "19",
       "desc": "Size of the gameclock HUD element",
       "type": "float"
     },
     "hud_gameclock_show": {
+      "group-id": "19",
       "desc": "Visibility of the gameclock HUD element",
       "type": "boolean",
       "values": [
@@ -3950,6 +4648,7 @@
       ]
     },
     "hud_gameclock_style": {
+      "group-id": "19",
       "desc": "Sets the style of the gameclock hud element.",
       "type": "enum",
       "values": [
@@ -3958,616 +4657,772 @@
       ]
     },
     "hud_group1_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 1",
       "type": "string"
     },
     "hud_group1_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 1",
       "type": "string"
     },
     "hud_group1_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 1",
       "type": "float"
     },
     "hud_group1_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group1 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group1_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 1",
       "type": "float"
     },
     "hud_group1_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group1_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 1",
       "type": "string"
     },
     "hud_group1_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group1_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group1 HUD element",
       "type": "float"
     },
     "hud_group1_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group1 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group1_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 1",
       "type": "string"
     },
     "hud_group1_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 1",
       "type": "string"
     },
     "hud_group1_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 1",
       "type": "float"
     },
     "hud_group1_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 1",
       "type": "float"
     },
     "hud_group1_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 1",
       "type": "float"
     },
     "hud_group1_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 1",
       "type": "float"
     },
     "hud_group2_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 2",
       "type": "string"
     },
     "hud_group2_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 2",
       "type": "string"
     },
     "hud_group2_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 2",
       "type": "float"
     },
     "hud_group2_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group2 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group2_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 2",
       "type": "float"
     },
     "hud_group2_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group2_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 2",
       "type": "string"
     },
     "hud_group2_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group2_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group2 HUD element",
       "type": "float"
     },
     "hud_group2_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group2 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group2_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 2",
       "type": "string"
     },
     "hud_group2_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 2",
       "type": "string"
     },
     "hud_group2_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 2",
       "type": "float"
     },
     "hud_group2_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 2",
       "type": "float"
     },
     "hud_group2_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 2",
       "type": "float"
     },
     "hud_group2_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 2",
       "type": "float"
     },
     "hud_group3_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 3",
       "type": "string"
     },
     "hud_group3_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 3",
       "type": "string"
     },
     "hud_group3_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 3",
       "type": "float"
     },
     "hud_group3_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group3 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group3_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 3",
       "type": "float"
     },
     "hud_group3_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group3_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 3",
       "type": "string"
     },
     "hud_group3_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group3_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group3 HUD element",
       "type": "float"
     },
     "hud_group3_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group3 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group3_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 3",
       "type": "string"
     },
     "hud_group3_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 3",
       "type": "string"
     },
     "hud_group3_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 3",
       "type": "float"
     },
     "hud_group3_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 3",
       "type": "float"
     },
     "hud_group3_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 3",
       "type": "float"
     },
     "hud_group3_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 3",
       "type": "float"
     },
     "hud_group4_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 4",
       "type": "string"
     },
     "hud_group4_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 4",
       "type": "string"
     },
     "hud_group4_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 4",
       "type": "float"
     },
     "hud_group4_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group4 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group4_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 4",
       "type": "float"
     },
     "hud_group4_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group4_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 4",
       "type": "string"
     },
     "hud_group4_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group4_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group4 HUD element",
       "type": "float"
     },
     "hud_group4_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group4 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group4_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 4",
       "type": "string"
     },
     "hud_group4_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 4",
       "type": "string"
     },
     "hud_group4_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 4",
       "type": "float"
     },
     "hud_group4_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 4",
       "type": "float"
     },
     "hud_group4_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 4",
       "type": "float"
     },
     "hud_group4_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 4",
       "type": "float"
     },
     "hud_group5_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 5",
       "type": "string"
     },
     "hud_group5_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 5",
       "type": "string"
     },
     "hud_group5_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 5",
       "type": "float"
     },
     "hud_group5_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group5 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group5_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 5",
       "type": "float"
     },
     "hud_group5_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group5_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 5",
       "type": "string"
     },
     "hud_group5_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group5_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group5 HUD element",
       "type": "float"
     },
     "hud_group5_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group5 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group5_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 5",
       "type": "string"
     },
     "hud_group5_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 5",
       "type": "string"
     },
     "hud_group5_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 5",
       "type": "float"
     },
     "hud_group5_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 5",
       "type": "float"
     },
     "hud_group5_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 5",
       "type": "float"
     },
     "hud_group5_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 5",
       "type": "float"
     },
     "hud_group6_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 6",
       "type": "string"
     },
     "hud_group6_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 6",
       "type": "string"
     },
     "hud_group6_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 6",
       "type": "float"
     },
     "hud_group6_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group6 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group6_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 6",
       "type": "float"
     },
     "hud_group6_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group6_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 6",
       "type": "string"
     },
     "hud_group6_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group6_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group6 HUD element",
       "type": "float"
     },
     "hud_group6_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group6 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group6_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 6",
       "type": "string"
     },
     "hud_group6_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 6",
       "type": "string"
     },
     "hud_group6_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 6",
       "type": "float"
     },
     "hud_group6_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 6",
       "type": "float"
     },
     "hud_group6_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 6",
       "type": "float"
     },
     "hud_group6_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 6",
       "type": "float"
     },
     "hud_group7_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 7",
       "type": "string"
     },
     "hud_group7_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 7",
       "type": "string"
     },
     "hud_group7_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 7",
       "type": "float"
     },
     "hud_group7_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group7 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group7_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 7",
       "type": "float"
     },
     "hud_group7_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group7_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 7",
       "type": "string"
     },
     "hud_group7_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group7_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group7 HUD element",
       "type": "float"
     },
     "hud_group7_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group7 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group7_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 7",
       "type": "string"
     },
     "hud_group7_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 7",
       "type": "string"
     },
     "hud_group7_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 7",
       "type": "float"
     },
     "hud_group7_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 7",
       "type": "float"
     },
     "hud_group7_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 7",
       "type": "float"
     },
     "hud_group7_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 7",
       "type": "float"
     },
     "hud_group8_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 8",
       "type": "string"
     },
     "hud_group8_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 8",
       "type": "string"
     },
     "hud_group8_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 8",
       "type": "float"
     },
     "hud_group8_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group8 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group8_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 8",
       "type": "float"
     },
     "hud_group8_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group8_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 8",
       "type": "string"
     },
     "hud_group8_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group8_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group8 HUD element",
       "type": "float"
     },
     "hud_group8_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group8 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group8_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 8",
       "type": "string"
     },
     "hud_group8_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 8",
       "type": "string"
     },
     "hud_group8_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 8",
       "type": "float"
     },
     "hud_group8_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 8",
       "type": "float"
     },
     "hud_group8_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 8",
       "type": "float"
     },
     "hud_group8_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 8",
       "type": "float"
     },
     "hud_group9_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grouping object 9",
       "type": "string"
     },
     "hud_group9_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grouping object 9",
       "type": "string"
     },
     "hud_group9_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grouping object 9",
       "type": "float"
     },
     "hud_group9_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the group9 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_group9_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of grouping object 9",
       "type": "float"
     },
     "hud_group9_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_group9_name": {
+      "group-id": "19",
       "desc": "Sets name of grouping object 9",
       "type": "string"
     },
     "hud_group9_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group9_pic_alpha": {
+      "group-id": "19",
       "desc": "Transparency level of the background image of the group9 HUD element",
       "type": "float"
     },
     "hud_group9_pic_scalemode": {
+      "group-id": "19",
       "desc": "Changes the style how the background picture is aligned and stretched for the group9 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
       "type": "integer"
     },
     "hud_group9_picture": {
+      "group-id": "19",
       "desc": "Sets background picture of grouping object 9",
       "type": "string"
     },
     "hud_group9_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grouping object 9",
       "type": "string"
     },
     "hud_group9_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grouping object 9",
       "type": "float"
     },
     "hud_group9_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grouping object 9",
       "type": "float"
     },
     "hud_group9_show": {
+      "group-id": "19",
       "desc": "Switches showing of grouping object 9",
       "type": "float"
     },
     "hud_group9_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of grouping object 9",
       "type": "float"
     },
     "hud_gun_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of current weapon icon",
       "type": "string"
     },
     "hud_gun_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of current weapon icon",
       "type": "string"
     },
     "hud_gun_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for current weapon icon",
       "type": "float"
     },
     "hud_gun_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gun HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gun_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gun_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gun_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for current weapon icon",
       "type": "string"
     },
     "hud_gun_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of current weapon icon",
       "type": "float"
     },
     "hud_gun_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of current weapon icon",
       "type": "float"
     },
     "hud_gun_scale": {
+      "group-id": "19",
       "desc": "Sets size of current weapon icon",
       "type": "float"
     },
     "hud_gun_show": {
+      "group-id": "19",
       "desc": "Switches showing of current weapon icon",
       "type": "float"
     },
     "hud_gun_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of the current weapon\u0027s icon",
       "type": "enum",
       "values": [
@@ -4580,53 +5435,66 @@
       ]
     },
     "hud_gun_wide": {
+      "group-id": "19",
       "desc": "Switches between wide and short version of current weapon icon",
       "type": "float"
     },
     "hud_gun2_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of shotgun icon",
       "type": "string"
     },
     "hud_gun2_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of shotgun icon",
       "type": "string"
     },
     "hud_gun2_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for shotgun icon",
       "type": "float"
     },
     "hud_gun2_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gun2 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gun2_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gun2_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gun2_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for shotgun icon",
       "type": "string"
     },
     "hud_gun2_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of shotgun icon",
       "type": "float"
     },
     "hud_gun2_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of shotgun icon",
       "type": "float"
     },
     "hud_gun2_scale": {
+      "group-id": "19",
       "desc": "Sets size of shotgun icon",
       "type": "float"
     },
     "hud_gun2_show": {
+      "group-id": "19",
       "desc": "Switches showing of shotgun icon",
       "type": "float"
     },
     "hud_gun2_style": {
+      "group-id": "19",
       "desc": "Switches the graphical style of the shotgun icon",
       "type": "enum",
       "values": [
@@ -4642,49 +5510,61 @@
       ]
     },
     "hud_gun3_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of super shotgun icon",
       "type": "string"
     },
     "hud_gun3_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of super shotgun icon",
       "type": "string"
     },
     "hud_gun3_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for super shotgun icon",
       "type": "float"
     },
     "hud_gun3_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gun3 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gun3_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gun3_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gun3_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for super shotgun icon",
       "type": "string"
     },
     "hud_gun3_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of super shotgun icon",
       "type": "float"
     },
     "hud_gun3_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of super shotgun icon",
       "type": "float"
     },
     "hud_gun3_scale": {
+      "group-id": "19",
       "desc": "Sets size of super shotgun icon",
       "type": "float"
     },
     "hud_gun3_show": {
+      "group-id": "19",
       "desc": "Switches showing of super shotgun icon",
       "type": "float"
     },
     "hud_gun3_style": {
+      "group-id": "19",
       "desc": "Switches the graphical style of the super shotgun icon",
       "type": "enum",
       "values": [
@@ -4700,49 +5580,61 @@
       ]
     },
     "hud_gun4_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of nailgun icon",
       "type": "string"
     },
     "hud_gun4_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of nailgun icon",
       "type": "string"
     },
     "hud_gun4_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for nailgun icon",
       "type": "float"
     },
     "hud_gun4_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gun4 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gun4_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gun4_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gun4_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for nailgun icon",
       "type": "string"
     },
     "hud_gun4_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of nailgun icon",
       "type": "float"
     },
     "hud_gun4_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of nailgun icon",
       "type": "float"
     },
     "hud_gun4_scale": {
+      "group-id": "19",
       "desc": "Sets size of nailgun icon",
       "type": "float"
     },
     "hud_gun4_show": {
+      "group-id": "19",
       "desc": "Switches showing of nailgun icon",
       "type": "float"
     },
     "hud_gun4_style": {
+      "group-id": "19",
       "desc": "Switches the graphical style of the nailgun icon",
       "type": "enum",
       "values": [
@@ -4758,49 +5650,61 @@
       ]
     },
     "hud_gun5_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of super nailgun icon",
       "type": "string"
     },
     "hud_gun5_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of super nailgun icon",
       "type": "string"
     },
     "hud_gun5_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for super nailgun icon",
       "type": "float"
     },
     "hud_gun5_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gun5 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gun5_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gun5_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gun5_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for super nailgun icon",
       "type": "string"
     },
     "hud_gun5_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of super nailgun icon",
       "type": "float"
     },
     "hud_gun5_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of super nailgun icon",
       "type": "float"
     },
     "hud_gun5_scale": {
+      "group-id": "19",
       "desc": "Sets size of super nailgun icon",
       "type": "float"
     },
     "hud_gun5_show": {
+      "group-id": "19",
       "desc": "Switches showing of super nailgun icon",
       "type": "float"
     },
     "hud_gun5_style": {
+      "group-id": "19",
       "desc": "Switches the graphical style of the super nailgun icon",
       "type": "enum",
       "values": [
@@ -4816,49 +5720,61 @@
       ]
     },
     "hud_gun6_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of grenade launcher icon",
       "type": "string"
     },
     "hud_gun6_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of grenade launcher icon",
       "type": "string"
     },
     "hud_gun6_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for grenade launcher icon",
       "type": "float"
     },
     "hud_gun6_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gun6 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gun6_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gun6_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gun6_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for grenade launcher icon",
       "type": "string"
     },
     "hud_gun6_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of grenade launcher icon",
       "type": "float"
     },
     "hud_gun6_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of grenade launcher icon",
       "type": "float"
     },
     "hud_gun6_scale": {
+      "group-id": "19",
       "desc": "Sets size of grenade launcher icon",
       "type": "float"
     },
     "hud_gun6_show": {
+      "group-id": "19",
       "desc": "Switches showing of grenade launcher icon",
       "type": "float"
     },
     "hud_gun6_style": {
+      "group-id": "19",
       "desc": "Switches the graphical style of the grenade launcher icon",
       "type": "enum",
       "values": [
@@ -4874,49 +5790,61 @@
       ]
     },
     "hud_gun7_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of rocket launcher icon",
       "type": "string"
     },
     "hud_gun7_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of rocket launcher icon",
       "type": "string"
     },
     "hud_gun7_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for rocket launcher icon",
       "type": "float"
     },
     "hud_gun7_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gun7 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gun7_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gun7_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gun7_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for rocket launcher icon",
       "type": "string"
     },
     "hud_gun7_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of rocket launcher icon",
       "type": "float"
     },
     "hud_gun7_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of rocket launcher icon",
       "type": "float"
     },
     "hud_gun7_scale": {
+      "group-id": "19",
       "desc": "Sets size of rocket launcher icon",
       "type": "float"
     },
     "hud_gun7_show": {
+      "group-id": "19",
       "desc": "Switches showing of rocket launcher icon",
       "type": "float"
     },
     "hud_gun7_style": {
+      "group-id": "19",
       "desc": "Switches the graphical style of the rocket launcher icon",
       "type": "enum",
       "values": [
@@ -4932,49 +5860,61 @@
       ]
     },
     "hud_gun8_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of lightning gun icon",
       "type": "string"
     },
     "hud_gun8_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of lightning gun icon",
       "type": "string"
     },
     "hud_gun8_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for lightning gun icon",
       "type": "float"
     },
     "hud_gun8_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the gun8 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_gun8_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_gun8_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_gun8_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for lightning gun icon",
       "type": "string"
     },
     "hud_gun8_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of lightning gun icon",
       "type": "float"
     },
     "hud_gun8_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of lightning gun icon",
       "type": "float"
     },
     "hud_gun8_scale": {
+      "group-id": "19",
       "desc": "Sets size of lightning gun icon",
       "type": "float"
     },
     "hud_gun8_show": {
+      "group-id": "19",
       "desc": "Switches showing of lightning gun icon",
       "type": "float"
     },
     "hud_gun8_style": {
+      "group-id": "19",
       "desc": "Switches the graphical style of the lightning gun icon",
       "type": "enum",
       "values": [
@@ -4990,65 +5930,81 @@
       ]
     },
     "hud_gun8_wide": {
+      "group-id": "19",
       "desc": "Switches wide and short of version of lightning gun icon",
       "type": "float"
     },
     "hud_health_align": {
+      "group-id": "19",
       "desc": "Sets align of health level",
       "type": "string"
     },
     "hud_health_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of health level",
       "type": "string"
     },
     "hud_health_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of health level",
       "type": "string"
     },
     "hud_health_digits": {
+      "group-id": "19",
       "desc": "Sets number of digits for health level",
       "type": "float"
     },
     "hud_health_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for health level",
       "type": "float"
     },
     "hud_health_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the health HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_health_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_health_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_health_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for health level",
       "type": "string"
     },
     "hud_health_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of health level",
       "type": "float"
     },
     "hud_health_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of health level",
       "type": "float"
     },
     "hud_health_scale": {
+      "group-id": "19",
       "desc": "Sets size of health level",
       "type": "float"
     },
     "hud_health_show": {
+      "group-id": "19",
       "desc": "Switches showing of health level",
       "type": "float"
     },
     "hud_health_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of health level",
       "type": "float"
     },
     "hud_healthdamage_align": {
+      "group-id": "19",
       "desc": "Sets healthdamage HUD element alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -5057,6 +6013,7 @@
       ]
     },
     "hud_healthdamage_align_x": {
+      "group-id": "19",
       "desc": "Sets healthdamage HUD element horizontal alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -5065,6 +6022,7 @@
       ]
     },
     "hud_healthdamage_align_y": {
+      "group-id": "19",
       "desc": "Sets healthdamage HUD element vertical alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -5073,10 +6031,12 @@
       ]
     },
     "hud_healthdamage_digits": {
+      "group-id": "19",
       "desc": "Sets highest possible number of digits displayed in HUD element healthdamage.",
       "type": "float"
     },
     "hud_healthdamage_duration": {
+      "group-id": "19",
       "desc": "Sets how long healthdamage should be visible after last damage to health has been done.",
       "type": "float",
       "values": [
@@ -5084,6 +6044,7 @@
       ]
     },
     "hud_healthdamage_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for this HUD element.",
       "type": "float",
       "values": [
@@ -5091,17 +6052,21 @@
       ]
     },
     "hud_healthdamage_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the healthdamage HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_healthdamage_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_healthdamage_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_healthdamage_place": {
+      "group-id": "19",
       "desc": "Sets placement for this HUD element. You can align some elements relative to other elements.",
       "remarks": "First you have to decide, if the element that you are locating now (element B) is to be positioned inside another element (element A) or outside it. See HUD manual for more info.",
       "type": "string",
@@ -5110,14 +6075,17 @@
       ]
     },
     "hud_healthdamage_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of this HUD element.",
       "type": "float"
     },
     "hud_healthdamage_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of this HUD element.",
       "type": "float"
     },
     "hud_healthdamage_scale": {
+      "group-id": "19",
       "desc": "Sets overall size of this HUD element.",
       "type": "float",
       "values": [
@@ -5125,6 +6093,7 @@
       ]
     },
     "hud_healthdamage_show": {
+      "group-id": "19",
       "desc": "Toggles visibility of this HUD element.",
       "type": "boolean",
       "values": [
@@ -5133,6 +6102,7 @@
       ]
     },
     "hud_healthdamage_style": {
+      "group-id": "19",
       "desc": "Toggles between different numbers styles.",
       "type": "boolean",
       "values": [
@@ -5141,483 +6111,611 @@
       ]
     },
     "hud_iammo_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of current ammo icon",
       "type": "string"
     },
     "hud_iammo_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of current ammo icon",
       "type": "string"
     },
     "hud_iammo_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for current ammo icon",
       "type": "float"
     },
     "hud_iammo_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the iammo HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_iammo_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_iammo_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_iammo_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for current ammo icon",
       "type": "string"
     },
     "hud_iammo_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of current ammo icon",
       "type": "float"
     },
     "hud_iammo_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of current ammo icon",
       "type": "float"
     },
     "hud_iammo_scale": {
+      "group-id": "19",
       "desc": "Sets size of current ammo icon",
       "type": "float"
     },
     "hud_iammo_show": {
+      "group-id": "19",
       "desc": "Switches showing of current ammo icon",
       "type": "float"
     },
     "hud_iammo_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of current ammo icon",
       "type": "float"
     },
     "hud_iammo1_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of shells icon",
       "type": "string"
     },
     "hud_iammo1_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of shells icon",
       "type": "string"
     },
     "hud_iammo1_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for shells icon",
       "type": "float"
     },
     "hud_iammo1_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the iammo1 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_iammo1_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_iammo1_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_iammo1_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for shells icon",
       "type": "string"
     },
     "hud_iammo1_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of shells icon",
       "type": "float"
     },
     "hud_iammo1_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of shells icon",
       "type": "float"
     },
     "hud_iammo1_scale": {
+      "group-id": "19",
       "desc": "Sets size of shells icon",
       "type": "float"
     },
     "hud_iammo1_show": {
+      "group-id": "19",
       "desc": "Switches showing of shells icon",
       "type": "float"
     },
     "hud_iammo1_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of shells icon",
       "type": "float"
     },
     "hud_iammo2_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of nails icon",
       "type": "string"
     },
     "hud_iammo2_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of nails icon",
       "type": "string"
     },
     "hud_iammo2_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for nails icon",
       "type": "float"
     },
     "hud_iammo2_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the iammo2 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_iammo2_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_iammo2_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_iammo2_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for nails icon",
       "type": "string"
     },
     "hud_iammo2_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of nails icon",
       "type": "float"
     },
     "hud_iammo2_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of nails icon",
       "type": "float"
     },
     "hud_iammo2_scale": {
+      "group-id": "19",
       "desc": "Sets size of nails icon",
       "type": "float"
     },
     "hud_iammo2_show": {
+      "group-id": "19",
       "desc": "Switches showing of nails icon",
       "type": "float"
     },
     "hud_iammo2_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of nails icon",
       "type": "float"
     },
     "hud_iammo3_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of rockets icon",
       "type": "string"
     },
     "hud_iammo3_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of rockets icon",
       "type": "string"
     },
     "hud_iammo3_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for rockets icon",
       "type": "float"
     },
     "hud_iammo3_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the iammo3 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_iammo3_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_iammo3_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_iammo3_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for rockets icon",
       "type": "string"
     },
     "hud_iammo3_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of rockets icon",
       "type": "float"
     },
     "hud_iammo3_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of rockets icon",
       "type": "float"
     },
     "hud_iammo3_scale": {
+      "group-id": "19",
       "desc": "Sets size of rockets icon",
       "type": "float"
     },
     "hud_iammo3_show": {
+      "group-id": "19",
       "desc": "Switches showing of rockets icon",
       "type": "float"
     },
     "hud_iammo3_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of rockets icon",
       "type": "float"
     },
     "hud_iammo4_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of cells icon",
       "type": "string"
     },
     "hud_iammo4_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of cells icon",
       "type": "string"
     },
     "hud_iammo4_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for cells icon",
       "type": "float"
     },
     "hud_iammo4_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the iammo4 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_iammo4_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_iammo4_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_iammo4_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for cells icon",
       "type": "string"
     },
     "hud_iammo4_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of cells icon",
       "type": "float"
     },
     "hud_iammo4_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of cells icon",
       "type": "float"
     },
     "hud_iammo4_scale": {
+      "group-id": "19",
       "desc": "Sets size of cells icon",
       "type": "float"
     },
     "hud_iammo4_show": {
+      "group-id": "19",
       "desc": "Switches showing of cells icon",
       "type": "float"
     },
     "hud_iammo4_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of cells icon",
       "type": "float"
     },
     "hud_iarmor_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of armor icon",
       "type": "string"
     },
     "hud_iarmor_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of armor icon",
       "type": "string"
     },
     "hud_iarmor_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for armor icon",
       "type": "float"
     },
     "hud_iarmor_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the iarmor HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_iarmor_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_iarmor_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_iarmor_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for armor icon",
       "type": "string"
     },
     "hud_iarmor_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of armor icon",
       "type": "float"
     },
     "hud_iarmor_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of armor icon",
       "type": "float"
     },
     "hud_iarmor_scale": {
+      "group-id": "19",
       "desc": "Sets size of armor icon",
       "type": "float"
     },
     "hud_iarmor_show": {
+      "group-id": "19",
       "desc": "Switches showing of armor icon",
       "type": "float"
     },
     "hud_iarmor_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of armor icon",
       "type": "float"
     },
     "hud_itemsclock_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_itemsclock_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_itemsclock_frame": {
+      "group-id": "19",
       "type": ""
     },
     "hud_itemsclock_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_itemsclock_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_itemsclock_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_itemsclock_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_itemsclock_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_itemsclock_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_itemsclock_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_itemsclock_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_itemsclock_timelimit": {
+      "group-id": "19",
       "type": ""
     },
     "hud_key1_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of silver key",
       "type": "string"
     },
     "hud_key1_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of silver key",
       "type": "string"
     },
     "hud_key1_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for silver key",
       "type": "float"
     },
     "hud_key1_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the key1 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_key1_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_key1_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_key1_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for silver key",
       "type": "string"
     },
     "hud_key1_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of silver key",
       "type": "float"
     },
     "hud_key1_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of silver key",
       "type": "float"
     },
     "hud_key1_scale": {
+      "group-id": "19",
       "desc": "Sets size of silver key",
       "type": "float"
     },
     "hud_key1_show": {
+      "group-id": "19",
       "desc": "Switches showing of silver key",
       "type": "float"
     },
     "hud_key1_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of silver key",
       "type": "float"
     },
     "hud_key2_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of gold key",
       "type": "string"
     },
     "hud_key2_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of gold key",
       "type": "string"
     },
     "hud_key2_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for gold key",
       "type": "float"
     },
     "hud_key2_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the key2 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_key2_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_key2_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_key2_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for gold key",
       "type": "string"
     },
     "hud_key2_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of gold key",
       "type": "float"
     },
     "hud_key2_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of gold key",
       "type": "float"
     },
     "hud_key2_scale": {
+      "group-id": "19",
       "desc": "Sets size of gold key",
       "type": "float"
     },
     "hud_key2_show": {
+      "group-id": "19",
       "desc": "Switches showing of gold key",
       "type": "float"
     },
     "hud_key2_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of gold key",
       "type": "float"
     },
     "hud_keys_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_keys_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_keys_frame": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_keys_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_keys_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_keys_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_keys_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_keys_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_keys_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_keys_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_keys_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_mouserate_align_x": {
+      "group-id": "28",
       "desc": "Vertical alignment of the mouserate HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_mouserate_align_y": {
+      "group-id": "28",
       "desc": "Vertical alignment of the mouserate HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_mouserate_frame": {
+      "group-id": "28",
       "desc": "Opacity of the background of the mouserate HUD element",
       "type": "float"
     },
     "hud_mouserate_frame_color": {
+      "group-id": "28",
       "desc": "Defines the color of the background of the mouserate HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_mouserate_order": {
+      "group-id": "28",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_mouserate_place": {
+      "group-id": "28",
       "desc": "Placement of the mouserate HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
       "type": "string"
     },
     "hud_mouserate_pos_x": {
+      "group-id": "28",
       "desc": "Horizontal relative position of the mouserate HUD element",
       "type": "integer"
     },
     "hud_mouserate_pos_y": {
+      "group-id": "28",
       "desc": "Vertical relative position of the mouserate HUD element",
       "type": "integer"
     },
     "hud_mouserate_show": {
+      "group-id": "28",
       "desc": "Visibility of the mouserate HUD element",
       "type": "boolean",
       "values": [
@@ -5626,6 +6724,7 @@
       ]
     },
     "hud_mp3_time_align_x": {
+      "group-id": "19",
       "desc": "Sets mp3_time HUD element horizontal alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -5634,6 +6733,7 @@
       ]
     },
     "hud_mp3_time_align_y": {
+      "group-id": "19",
       "desc": "Sets mp3_time HUD element vertical alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -5642,6 +6742,7 @@
       ]
     },
     "hud_mp3_time_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for this HUD element.",
       "type": "float",
       "values": [
@@ -5649,13 +6750,16 @@
       ]
     },
     "hud_mp3_time_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the mp3_time HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_mp3_time_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_mp3_time_on_scoreboard": {
+      "group-id": "19",
       "desc": "Toggles whether HUD element \u0027mp3_time\u0027 will be drawn even if scoreboard is displayed.",
       "type": "boolean",
       "values": [
@@ -5664,10 +6768,12 @@
       ]
     },
     "hud_mp3_time_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_mp3_time_place": {
+      "group-id": "19",
       "desc": "Sets placement for this HUD element. You can align some elements relative to other elements.",
       "remarks": "First you have to decide, if the element that you are locating now (element B) is to be positioned inside another element (element A) or outside it. See HUD manual for more info.",
       "type": "string",
@@ -5676,14 +6782,17 @@
       ]
     },
     "hud_mp3_time_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of this HUD element.",
       "type": "float"
     },
     "hud_mp3_time_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of this HUD element.",
       "type": "float"
     },
     "hud_mp3_time_show": {
+      "group-id": "19",
       "desc": "Toggles visibility of this HUD element.",
       "type": "boolean",
       "values": [
@@ -5692,6 +6801,7 @@
       ]
     },
     "hud_mp3_time_style": {
+      "group-id": "19",
       "desc": "Changes displayed informations for \u0027mp3_time\u0027 HUD element.",
       "remarks": "Note that display of seconds is disabled in ruleset smackdown.",
       "type": "enum",
@@ -5707,6 +6817,7 @@
       ]
     },
     "hud_mp3_title_align_x": {
+      "group-id": "19",
       "desc": "Sets mp3_title HUD element horizontal alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -5715,6 +6826,7 @@
       ]
     },
     "hud_mp3_title_align_y": {
+      "group-id": "19",
       "desc": "Sets mp3_title HUD element vertical alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -5723,6 +6835,7 @@
       ]
     },
     "hud_mp3_title_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for this HUD element.",
       "type": "float",
       "values": [
@@ -5730,10 +6843,12 @@
       ]
     },
     "hud_mp3_title_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the mp3_title HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_mp3_title_height": {
+      "group-id": "19",
       "desc": "Sets height of \u0027mp3_title\u0027 HUD element.",
       "type": "integer",
       "values": [
@@ -5741,9 +6856,11 @@
       ]
     },
     "hud_mp3_title_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_mp3_title_on_scoreboard": {
+      "group-id": "19",
       "desc": "Toggles whether HUD element \u0027mp3_title\u0027 will be drawn even if scoreboard is displayed.",
       "type": "boolean",
       "values": [
@@ -5752,10 +6869,12 @@
       ]
     },
     "hud_mp3_title_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_mp3_title_place": {
+      "group-id": "19",
       "desc": "Sets placement for this HUD element. You can align some elements relative to other elements.",
       "remarks": "First you have to decide, if the element that you are locating now (element B) is to be positioned inside another element (element A) or outside it. See HUD manual for more info.",
       "type": "string",
@@ -5764,14 +6883,17 @@
       ]
     },
     "hud_mp3_title_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of this HUD element.",
       "type": "float"
     },
     "hud_mp3_title_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of this HUD element.",
       "type": "float"
     },
     "hud_mp3_title_scroll": {
+      "group-id": "19",
       "desc": "Toggles scrolling of mp3_title text.",
       "type": "boolean",
       "values": [
@@ -5780,6 +6902,7 @@
       ]
     },
     "hud_mp3_title_scroll_delay": {
+      "group-id": "19",
       "desc": "Sets speed of text scrolling in mp3_title HUD element.",
       "remarks": "Use \u0027hud mp3_title scroll 1\u0027.",
       "type": "float",
@@ -5788,6 +6911,7 @@
       ]
     },
     "hud_mp3_title_show": {
+      "group-id": "19",
       "desc": "Toggles visibility of this HUD element.",
       "type": "boolean",
       "values": [
@@ -5796,6 +6920,7 @@
       ]
     },
     "hud_mp3_title_style": {
+      "group-id": "19",
       "desc": "Sets format of text of \u0027mp3_title\u0027 HUD element.",
       "type": "enum",
       "values": [
@@ -5805,6 +6930,7 @@
       ]
     },
     "hud_mp3_title_width": {
+      "group-id": "19",
       "desc": "Sets width of mp3_title HUD element.",
       "type": "integer",
       "values": [
@@ -5812,6 +6938,7 @@
       ]
     },
     "hud_mp3_title_wordwrap": {
+      "group-id": "19",
       "desc": "Toggles word wrapping inside mp3_title element.",
       "remarks": "See \u0027mp3_title height\u0027.",
       "type": "boolean",
@@ -5821,352 +6948,450 @@
       ]
     },
     "hud_net_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of net statistics",
       "type": "string"
     },
     "hud_net_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of net statistics",
       "type": "string"
     },
     "hud_net_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for net statistics",
       "type": "float"
     },
     "hud_net_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the net HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_net_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_net_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_net_period": {
+      "group-id": "19",
       "desc": "Sets period for updating net statistics",
       "type": "float"
     },
     "hud_net_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for net statistics",
       "type": "string"
     },
     "hud_net_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of net statistics",
       "type": "float"
     },
     "hud_net_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of net statistics",
       "type": "float"
     },
     "hud_net_show": {
+      "group-id": "19",
       "desc": "Switches showing of net statistics",
       "type": "float"
     },
     "hud_netgraph_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of everything about net",
       "type": "string"
     },
     "hud_netgraph_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of everything about net",
       "type": "string"
     },
     "hud_netgraph_alpha": {
+      "group-id": "19",
       "desc": "Sets transparency level of everything about net",
       "type": "float"
     },
     "hud_netgraph_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for everything about net",
       "type": "float"
     },
     "hud_netgraph_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the netgraph HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_netgraph_full": {
+      "group-id": "19",
       "desc": "When turned on, netgraph is more detailed this way, but looks ugly; in GL this can be fixed with a lower alpha value like \"0.4\"",
       "type": "float"
     },
     "hud_netgraph_height": {
+      "group-id": "19",
       "desc": "Sets vertical size of everything about net",
       "type": "float"
     },
     "hud_netgraph_inframes": {
+      "group-id": "19",
       "desc": "setting this to \"1\" lets you measure your latency in an alternate way every level of netgraph will mean one frame of delay, between sending it to server and getting answer. On local/lan server you\u0027ll always get one frame of delay, even with low FPS.",
       "type": "float"
     },
     "hud_netgraph_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_lostscale": {
+      "group-id": "19",
       "desc": "lets you cut down those red, yellow, blue and gray bars, which are always full-height; possible values are the range from 0 to 1",
       "type": "float"
     },
     "hud_netgraph_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_netgraph_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for everything about net",
       "type": "string"
     },
     "hud_netgraph_ploss": {
+      "group-id": "19",
       "desc": "print packet loss or not everything about net",
       "type": "float"
     },
     "hud_netgraph_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of everything about net",
       "type": "float"
     },
     "hud_netgraph_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of everything about net",
       "type": "float"
     },
     "hud_netgraph_scale": {
+      "group-id": "19",
       "desc": "Sets size of everything about net",
       "type": "float"
     },
     "hud_netgraph_show": {
+      "group-id": "19",
       "desc": "Switches showing of everything about net",
       "type": "float"
     },
     "hud_netgraph_swap_x": {
+      "group-id": "19",
       "desc": "reverse horizontally, like for placing at left edge of the screen",
       "type": "float"
     },
     "hud_netgraph_swap_y": {
+      "group-id": "19",
       "desc": "reverse vertically, like for top edge",
       "type": "float"
     },
     "hud_netgraph_width": {
+      "group-id": "19",
       "desc": "Sets horizontal size of everything about net",
       "type": "float"
     },
     "hud_netproblem_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_netproblem_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_netproblem_frame": {
+      "group-id": "19",
       "type": ""
     },
     "hud_netproblem_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_netproblem_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_netproblem_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_netproblem_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_netproblem_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_netproblem_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_netproblem_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_netproblem_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_notify_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_notify_cols": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_frame": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_notify_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_notify_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_rows": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_notify_time": {
+      "group-id": "19",
       "type": ""
     },
     "hud_ownfrags_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_ownfrags_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_ownfrags_frame": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ownfrags_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_ownfrags_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ownfrags_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_ownfrags_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_ownfrags_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_ownfrags_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_ownfrags_scale": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ownfrags_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_ownfrags_timeout": {
+      "group-id": "19",
       "type": ""
     },
     "hud_pent_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of pentagram icon",
       "type": "string"
     },
     "hud_pent_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of pentagram icon",
       "type": "string"
     },
     "hud_pent_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for pentagram icon",
       "type": "float"
     },
     "hud_pent_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the pent HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_pent_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_pent_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_pent_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for pentagram icon",
       "type": "string"
     },
     "hud_pent_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of pentagram icon",
       "type": "float"
     },
     "hud_pent_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of pentagram icon",
       "type": "float"
     },
     "hud_pent_scale": {
+      "group-id": "19",
       "desc": "Sets size of pentagram icon",
       "type": "float"
     },
     "hud_pent_show": {
+      "group-id": "19",
       "desc": "Switches showing of pentagram icon",
       "type": "float"
     },
     "hud_pent_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of pentagram icon",
       "type": "float"
     },
     "hud_ping_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of small net statistics",
       "type": "string"
     },
     "hud_ping_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of small net statistics",
       "type": "string"
     },
     "hud_ping_blink": {
+      "group-id": "19",
       "desc": "Enable yellow blinking dot, which shows when your ping is recalculated",
       "type": "float"
     },
     "hud_ping_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for small net statistics",
       "type": "float"
     },
     "hud_ping_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the ping HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_ping_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ping_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_ping_period": {
+      "group-id": "19",
       "desc": "period of time between updates (minimum value is your frame time)",
       "type": "float"
     },
     "hud_ping_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for small net statistics",
       "type": "string"
     },
     "hud_ping_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of small net statistics",
       "type": "float"
     },
     "hud_ping_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of small net statistics",
       "type": "float"
     },
     "hud_ping_show": {
+      "group-id": "19",
       "desc": "Switches showing of small net statistics",
       "type": "float"
     },
     "hud_ping_show_dev": {
+      "group-id": "19",
       "desc": "Switches showing of small net statistics",
       "type": "float"
     },
     "hud_ping_show_max": {
+      "group-id": "19",
       "desc": "Switches showing of small net statistics",
       "type": "float"
     },
     "hud_ping_show_min": {
+      "group-id": "19",
       "desc": "Switches showing of small net statistics",
       "type": "float"
     },
     "hud_ping_show_pl": {
+      "group-id": "19",
       "desc": "Switches showing of small net statistics",
       "type": "float"
     },
     "hud_ping_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_planmode": {
+      "group-id": "19",
       "desc": "Toggles special hud-editing mode where all hud elements are being displayed.",
       "type": "boolean",
       "values": [
@@ -6175,61 +7400,76 @@
       ]
     },
     "hud_quad_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of quad icon",
       "type": "string"
     },
     "hud_quad_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of quad icon",
       "type": "string"
     },
     "hud_quad_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for quad icon",
       "type": "float"
     },
     "hud_quad_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the quad HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_quad_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_quad_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_quad_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for quad icon",
       "type": "string"
     },
     "hud_quad_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of quad icon",
       "type": "float"
     },
     "hud_quad_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of quad icon",
       "type": "float"
     },
     "hud_quad_scale": {
+      "group-id": "19",
       "desc": "Sets size of quad icon",
       "type": "float"
     },
     "hud_quad_show": {
+      "group-id": "19",
       "desc": "Switches showing of quad icon",
       "type": "float"
     },
     "hud_quad_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of quad icon",
       "type": "float"
     },
     "hud_radar_align_x": {
+      "group-id": "19",
       "desc": "Vertical alignment of the radar HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_radar_align_y": {
+      "group-id": "19",
       "desc": "Vertical alignment of the radar HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_radar_autosize": {
+      "group-id": "19",
       "desc": "Automatically size the Radar hud item to show the radar picture at the resolution it was created for.",
       "type": "boolean",
       "values": [
@@ -6238,6 +7478,7 @@
       ]
     },
     "hud_radar_fade_players": {
+      "group-id": "19",
       "desc": "Fade players (make them more transparent) as they lose health/armor.",
       "type": "boolean",
       "values": [
@@ -6246,19 +7487,23 @@
       ]
     },
     "hud_radar_frame": {
+      "group-id": "19",
       "desc": "Opacity of the background of the radar HUD element",
       "type": "float"
     },
     "hud_radar_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the radar HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_radar_height": {
+      "group-id": "19",
       "desc": "Sets the height of the radar hud item.",
       "remarks": "Note that if hud_radar_autosize is set, this value will be ignored.",
       "type": "integer"
     },
     "hud_radar_highlight": {
+      "group-id": "19",
       "desc": "Show a highlight around the currently tracked player on the radar or not.",
       "remarks": "Change the color of the higlight using the hud_radar_highlight_color variable.",
       "type": "enum",
@@ -6276,6 +7521,7 @@
       ]
     },
     "hud_radar_highlight_color": {
+      "group-id": "19",
       "desc": "Sets the RGBA color of the highlight of the tracked player for the radar HUD element.",
       "type": "string",
       "values": [
@@ -6283,9 +7529,11 @@
       ]
     },
     "hud_radar_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_radar_itemfilter": {
+      "group-id": "19",
       "desc": "Decides what items should be shown on the radar. Such as ammo, health packs, backpacks and powerups",
       "remarks": "Any character/whitespace can be used as a delimiter. Make sure you enter the value between quotes if you use whitespaces.",
       "type": "string",
@@ -6294,6 +7542,7 @@
       ]
     },
     "hud_radar_onlytp": {
+      "group-id": "19",
       "desc": "Decides whetever the radar hud item should be shown only when in teamplay mode, or demo playback.",
       "remarks": "The radar will NOT be visible when playing as a normal player no matter what you set this to, this only applies to spectators/during demo playback.",
       "type": "enum",
@@ -6305,6 +7554,7 @@
       ]
     },
     "hud_radar_opacity": {
+      "group-id": "19",
       "desc": "The opacity of the radar.",
       "type": "float",
       "values": [
@@ -6312,10 +7562,12 @@
       ]
     },
     "hud_radar_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_radar_otherfilter": {
+      "group-id": "19",
       "desc": "Decides what \"other\" things, such as projectiles (rockets, nails, shaft beam), gibs, and explosions, that should be shown on the radar.",
       "remarks": "Any character/whitespace can be used as a delimiter. Make sure you enter the value between quotes if you use whitespaces.",
       "type": "string",
@@ -6324,23 +7576,28 @@
       ]
     },
     "hud_radar_place": {
+      "group-id": "19",
       "desc": "Placement of the radar HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
       "type": "string"
     },
     "hud_radar_player_size": {
+      "group-id": "19",
       "desc": "The radius in of the players on the radar. ",
       "remarks": "If show_height is turned on, then this ofcourse depends on what height the player is located at.",
       "type": "float"
     },
     "hud_radar_pos_x": {
+      "group-id": "19",
       "desc": "Horizontal relative position of the radar HUD element",
       "type": "integer"
     },
     "hud_radar_pos_y": {
+      "group-id": "19",
       "desc": "Vertical relative position of the radar HUD element",
       "type": "integer"
     },
     "hud_radar_show": {
+      "group-id": "19",
       "desc": "Visibility of the radar HUD element",
       "type": "boolean",
       "values": [
@@ -6349,6 +7606,7 @@
       ]
     },
     "hud_radar_show_height": {
+      "group-id": "19",
       "desc": "Should the players become bigger as they move to higher points on the map or not?",
       "type": "boolean",
       "values": [
@@ -6357,6 +7615,7 @@
       ]
     },
     "hud_radar_show_hold": {
+      "group-id": "19",
       "desc": "This will show the name of all the important items on the map (RL, LG, GL, SNG, Quad, Pent, Ring, Suit, Mega, Armors). A circle is drawn around the items, the team who has the highest weight inside this area is considered to be holding that particular item. See the teamholdinfo hud item.",
       "remarks": "It is not recommended to have this visible at all times. Instead it\u0027s meant for a  quick glance to know which item is named what when using the Teamholdbarinfo hud item. For instance if the map has two YA\u0027s, one is named YA and the other YA2. Use this feature to see which is which.",
       "type": "boolean",
@@ -6366,6 +7625,7 @@
       ]
     },
     "hud_radar_show_names": {
+      "group-id": "19",
       "desc": "Show the names of the players on the radar.",
       "type": "boolean",
       "values": [
@@ -6374,6 +7634,7 @@
       ]
     },
     "hud_radar_show_powerups": {
+      "group-id": "19",
       "desc": "Highlight players with powerups on the radar hud item with a colored circle around them, depending on what type of powerup.",
       "type": "boolean",
       "values": [
@@ -6382,11 +7643,13 @@
       ]
     },
     "hud_radar_show_stats": {
+      "group-id": "19",
       "desc": "Decides what type of stats should be shown on the radar.",
       "remarks": "The team stats are calculated depending on how strong a player is. A strong player with a good weapon raises the weight for a certain area more than a weak one. The team with the highest weight for a certain area is considered to hold that area.",
       "type": "enum"
     },
     "hud_radar_weaponfilter": {
+      "group-id": "19",
       "desc": "Decides which weapons that should be shown on the radar.",
       "remarks": "Any character/whitespace can be used as a delimiter. Make sure you enter the value between quotes if you use whitespaces.",
       "type": "string",
@@ -6395,522 +7658,669 @@
       ]
     },
     "hud_radar_width": {
+      "group-id": "19",
       "desc": "The width of the radar hud item.",
       "remarks": "Note that if hud_radar_autosize is set, this value will be ignored.",
       "type": "integer"
     },
     "hud_ring_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of ring icon",
       "type": "string"
     },
     "hud_ring_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of ring icon",
       "type": "string"
     },
     "hud_ring_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for ring icon",
       "type": "float"
     },
     "hud_ring_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the ring HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_ring_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_ring_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_ring_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for ring icon",
       "type": "string"
     },
     "hud_ring_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of ring icon",
       "type": "float"
     },
     "hud_ring_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of ring icon",
       "type": "float"
     },
     "hud_ring_scale": {
+      "group-id": "19",
       "desc": "Sets size of ring icon",
       "type": "float"
     },
     "hud_ring_show": {
+      "group-id": "19",
       "desc": "Switches showing of ring icon",
       "type": "float"
     },
     "hud_ring_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of ring icon",
       "type": "float"
     },
     "hud_score_bar_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_bar_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_bar_format_big": {
+      "group-id": "19",
       "desc": "Format string for score_bar HUD element.",
       "remarks": "%d - score difference between you and enemy.\n%D - score difference between you and enemy, red chars.\n%t - team score.\n%T - your (team) score, red chars.\n%e - enemy (team) score.\n%E - enemy (team) score, red chars.\n%d - score (team) difference.\n%D - score (team) difference, red chars.\n%p - your (team) position on scoreboard.\n%z - score difference between you and enemy, unsigned. Red chars used for negative difference.\n%z - score difference between you and enemy, unsigned. Red chars used for positive difference.",
       "type": "string"
     },
     "hud_score_bar_format_small": {
+      "group-id": "19",
       "desc": "Format string for score_bar HUD element.",
       "remarks": "%d - score difference between you and enemy.\n%D - score difference between you and enemy, always signed.\n%t - your (team) score.\n%T - your (team) name.\n%e - enemy (team) score.\n%E - enemy (team) name.\n%d - score difference.\n%D - score difference, always signed.\n%p - Your (team) position on scoreboard.\n\nAlso, you could use color codes.",
       "type": "string"
     },
     "hud_score_bar_frame": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_bar_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_bar_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_bar_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_bar_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_bar_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_bar_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_bar_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_bar_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_bar_style": {
+      "group-id": "19",
       "desc": "Style of score_bar HUD element.",
       "remarks": "0 - use small chars (conchars)\n1 - use big chars (num* and anum* images)",
       "type": "integer"
     },
     "hud_score_difference_align": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_difference_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_difference_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_difference_colorize": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_difference_digits": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_difference_frame": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_difference_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_difference_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_difference_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_difference_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_difference_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_difference_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_difference_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_difference_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_difference_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_align": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_enemy_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_enemy_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_enemy_colorize": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_digits": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_frame": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_enemy_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_enemy_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_enemy_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_align": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_position_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_position_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_position_colorize": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_digits": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_frame": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_position_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_position_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_position_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_position_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_align": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_team_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_team_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_team_colorize": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_digits": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_frame": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_team_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_score_team_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_score_team_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_score_team_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_sigil1_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of sigil 1 icon (rune)",
       "type": "string"
     },
     "hud_sigil1_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of sigil 1 icon (rune)",
       "type": "string"
     },
     "hud_sigil1_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for sigil 1 icon (rune)",
       "type": "float"
     },
     "hud_sigil1_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the sigil1 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_sigil1_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_sigil1_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_sigil1_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for sigil 1 icon (rune)",
       "type": "string"
     },
     "hud_sigil1_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of sigil 1 icon (rune)",
       "type": "float"
     },
     "hud_sigil1_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of sigil 1 icon (rune)",
       "type": "float"
     },
     "hud_sigil1_scale": {
+      "group-id": "19",
       "desc": "Sets size of sigil 1 icon (rune)",
       "type": "float"
     },
     "hud_sigil1_show": {
+      "group-id": "19",
       "desc": "Switches showing of sigil 1 icon (rune)",
       "type": "float"
     },
     "hud_sigil1_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of sigil 1 icon (rune)",
       "type": "float"
     },
     "hud_sigil2_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of sigil 2 icon",
       "type": "string"
     },
     "hud_sigil2_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of sigil 2 icon",
       "type": "string"
     },
     "hud_sigil2_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for sigil 2 icon",
       "type": "float"
     },
     "hud_sigil2_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the sigil2 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_sigil2_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_sigil2_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_sigil2_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for sigil 2 icon",
       "type": "string"
     },
     "hud_sigil2_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of sigil 2 icon",
       "type": "float"
     },
     "hud_sigil2_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of sigil 2 icon",
       "type": "float"
     },
     "hud_sigil2_scale": {
+      "group-id": "19",
       "desc": "Sets size of sigil 2 icon",
       "type": "float"
     },
     "hud_sigil2_show": {
+      "group-id": "19",
       "desc": "Switches showing of sigil 2 icon",
       "type": "float"
     },
     "hud_sigil2_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of sigil 2 icon",
       "type": "float"
     },
     "hud_sigil3_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of sigil 3 icon",
       "type": "string"
     },
     "hud_sigil3_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of sigil 3 icon",
       "type": "string"
     },
     "hud_sigil3_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for sigil 3 icon",
       "type": "float"
     },
     "hud_sigil3_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the sigil3 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_sigil3_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_sigil3_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_sigil3_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for sigil 3 icon",
       "type": "string"
     },
     "hud_sigil3_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of sigil 3 icon",
       "type": "float"
     },
     "hud_sigil3_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of sigil 3 icon",
       "type": "float"
     },
     "hud_sigil3_scale": {
+      "group-id": "19",
       "desc": "Sets size of sigil 3 icon",
       "type": "float"
     },
     "hud_sigil3_show": {
+      "group-id": "19",
       "desc": "Switches showing of sigil 3 icon",
       "type": "float"
     },
     "hud_sigil3_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of sigil 3 icon",
       "type": "float"
     },
     "hud_sigil4_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of sigil 4 icon",
       "type": "string"
     },
     "hud_sigil4_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of sigil 4 icon",
       "type": "string"
     },
     "hud_sigil4_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for sigil 4 icon",
       "type": "float"
     },
     "hud_sigil4_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the sigil4 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_sigil4_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_sigil4_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_sigil4_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for sigil 4 icon",
       "type": "string"
     },
     "hud_sigil4_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of sigil 4 icon",
       "type": "float"
     },
     "hud_sigil4_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of sigil 4 icon",
       "type": "float"
     },
     "hud_sigil4_scale": {
+      "group-id": "19",
       "desc": "Sets size of sigil 4 icon",
       "type": "float"
     },
     "hud_sigil4_show": {
+      "group-id": "19",
       "desc": "Switches showing of sigil 4 icon",
       "type": "float"
     },
     "hud_sigil4_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of sigil 4 icon",
       "type": "float"
     },
     "hud_speed_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of your current speed",
       "type": "string"
     },
     "hud_speed_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of your current speed",
       "type": "string"
     },
     "hud_speed_color_fast": {
+      "group-id": "19",
       "desc": "Sets the color of the speed hud item when the player is moving at a \"fast\" speed (above 500).",
       "remarks": "Use the quake pallete colors to set this (0-255).",
       "type": "integer"
     },
     "hud_speed_color_fastest": {
+      "group-id": "19",
       "desc": "Sets the color of the speed hud item when the player is moving at a really \"fast\" speed (above 1000).",
       "remarks": "Use the quake pallete colors to set this (0-255).",
       "type": "integer"
     },
     "hud_speed_color_insane": {
+      "group-id": "19",
       "desc": "Sets the color of the speed hud item when the player is moving at a crazy speed (above 1500... I think).",
       "remarks": "Use the quake pallete colors to set this (0-255).",
       "type": "integer"
     },
     "hud_speed_color_normal": {
+      "group-id": "19",
       "desc": "Sets the color of the speed hud item when the player is moving at a \"normal\" speed (below 500).",
       "remarks": "Use the quake pallete colors to set this (0-255).",
       "type": "integer"
     },
     "hud_speed_color_stopped": {
+      "group-id": "19",
       "desc": "The color that the fill part of the speed hud item has when the player isn\u0027t moving. Default is green.",
       "remarks": "Use the quake pallete colors to set this (0-255).",
       "type": "integer"
     },
     "hud_speed_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for your current speed",
       "type": "float"
     },
     "hud_speed_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the speed HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_speed_height": {
+      "group-id": "19",
       "desc": "Sets the height of the speed hud item.",
       "type": "integer"
     },
     "hud_speed_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_speed_opacity": {
+      "group-id": "19",
       "desc": "Sets the opacity of the speed hud item.",
       "type": "float",
       "values": [
@@ -6918,29 +8328,36 @@
       ]
     },
     "hud_speed_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_speed_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for your current speed",
       "type": "string"
     },
     "hud_speed_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of your current speed",
       "type": "float"
     },
     "hud_speed_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of your current speed",
       "type": "float"
     },
     "hud_speed_show": {
+      "group-id": "19",
       "desc": "Switches showing of your current speed",
       "type": "float"
     },
     "hud_speed_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_speed_text_align": {
+      "group-id": "19",
       "desc": "Sets how the text on the speed hud item should be aligned.",
       "type": "enum",
       "values": [
@@ -6951,10 +8368,12 @@
       ]
     },
     "hud_speed_tick_spacing": {
+      "group-id": "19",
       "desc": "Sets the \"tick spacing\" for the speed  hud item.",
       "type": "float"
     },
     "hud_speed_vertical": {
+      "group-id": "19",
       "desc": "Sets whetever the speed hud item should be drawn vertically or horizontally.",
       "remarks": "Also see hud_speed_vertical_text to choose if the text should be drawn vertically also.",
       "type": "boolean",
@@ -6964,6 +8383,7 @@
       ]
     },
     "hud_speed_vertical_text": {
+      "group-id": "19",
       "desc": "Sets whetever the text on the speed hud item should be drawn vertically when the hud item itself is being drawn vertically.",
       "remarks": "This has no effect if the hud item isn\u0027t drawn vertically.",
       "type": "boolean",
@@ -6973,58 +8393,71 @@
       ]
     },
     "hud_speed_width": {
+      "group-id": "19",
       "desc": "Sets the width of the speed hud item.",
       "type": "integer"
     },
     "hud_speed_xyz": {
+      "group-id": "19",
       "desc": "Sets This toggles whether the speed is measured over the XY axis (xyz 0) or the XYZ axis (xyz 1)",
       "type": "float"
     },
     "hud_speed2_align_x": {
+      "group-id": "19",
       "desc": "Vertical alignment of the speed2 HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_speed2_align_y": {
+      "group-id": "19",
       "desc": "Vertical alignment of the speed2 HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_speed2_color_fast": {
+      "group-id": "19",
       "desc": "Sets the color of the speed2 hud item when the speed is above the wrap speed.",
       "remarks": "Use the quake pallete colors 0-255.\nSee hud_radar2_wrapspeed also.",
       "type": "integer"
     },
     "hud_speed2_color_fastest": {
+      "group-id": "19",
       "desc": "Sets the color of the speed2 hud item when the speed is above 2x wrap speed.",
       "remarks": "Use the quake pallete colors 0-255.\nSee hud_radar2_wrapspeed also.",
       "type": "integer"
     },
     "hud_speed2_color_insane": {
+      "group-id": "19",
       "desc": "Sets the color of the speed2 hud item when the speed is above 3x wrap speed.",
       "remarks": "Use the quake pallete colors 0-255.\nSee hud_radar2_wrapspeed also.",
       "type": "integer"
     },
     "hud_speed2_color_normal": {
+      "group-id": "19",
       "desc": "Sets the color of the speed2 hud item when the speed is between 1 and the wrap speed.",
       "remarks": "Use the quake pallete colors 0-255.\nSee hud_radar2_wrapspeed also.",
       "type": "integer"
     },
     "hud_speed2_color_stopped": {
+      "group-id": "19",
       "desc": "Sets the color of the speed2 hud item when the speed is 0. Default is green.",
       "remarks": "Use the quake pallete colors 0-255.",
       "type": "integer"
     },
     "hud_speed2_frame": {
+      "group-id": "19",
       "desc": "Opacity of the background of the speed2 HUD element",
       "type": "float"
     },
     "hud_speed2_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the speed2 HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_speed2_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_speed2_opacity": {
+      "group-id": "19",
       "desc": "Sets the opacity of the speed2 hud item. ",
       "type": "float",
       "values": [
@@ -7032,10 +8465,12 @@
       ]
     },
     "hud_speed2_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_speed2_orientation": {
+      "group-id": "19",
       "desc": "The orientation of the speed2 hud item. This can be set to, up, down, left and right. That is, the direction that the hud item will be pointing in.",
       "type": "enum",
       "values": [
@@ -7046,18 +8481,22 @@
       ]
     },
     "hud_speed2_place": {
+      "group-id": "19",
       "desc": "Placement of the speed2 HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
       "type": "string"
     },
     "hud_speed2_pos_x": {
+      "group-id": "19",
       "desc": "Horizontal relative position of the speed2 HUD element",
       "type": "integer"
     },
     "hud_speed2_pos_y": {
+      "group-id": "19",
       "desc": "Vertical relative position of the speed2 HUD element",
       "type": "integer"
     },
     "hud_speed2_radius": {
+      "group-id": "19",
       "desc": "Sets the radius of the half circle. The width and height is based on this.",
       "type": "float",
       "values": [
@@ -7065,6 +8504,7 @@
       ]
     },
     "hud_speed2_show": {
+      "group-id": "19",
       "desc": "Visibility of the speed2 HUD element",
       "type": "boolean",
       "values": [
@@ -7073,6 +8513,7 @@
       ]
     },
     "hud_speed2_wrapspeed": {
+      "group-id": "19",
       "desc": "Sets the speed when the speed needle will reset to the original position, and the next color is shown (to indicate faster speed).",
       "type": "integer",
       "values": [
@@ -7080,6 +8521,7 @@
       ]
     },
     "hud_speed2_xyz": {
+      "group-id": "19",
       "desc": "Base the speed calculation on up/down movement also. ",
       "type": "boolean",
       "values": [
@@ -7088,53 +8530,66 @@
       ]
     },
     "hud_suit_align_x": {
+      "group-id": "19",
       "desc": "Sets horizontal align of suit icon",
       "type": "string"
     },
     "hud_suit_align_y": {
+      "group-id": "19",
       "desc": "Sets vertical align of suit icon",
       "type": "string"
     },
     "hud_suit_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for suit icon",
       "type": "float"
     },
     "hud_suit_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the suit HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_suit_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_suit_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_suit_place": {
+      "group-id": "19",
       "desc": "Sets relative positioning for suit icon",
       "type": "string"
     },
     "hud_suit_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of suit icon",
       "type": "float"
     },
     "hud_suit_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of suit icon",
       "type": "float"
     },
     "hud_suit_scale": {
+      "group-id": "19",
       "desc": "Sets size of suit icon",
       "type": "float"
     },
     "hud_suit_show": {
+      "group-id": "19",
       "desc": "Switches showing of suit icon",
       "type": "float"
     },
     "hud_suit_style": {
+      "group-id": "19",
       "desc": "Switches graphical style of suit icon",
       "type": "float"
     },
     "hud_teamfrags_align_x": {
+      "group-id": "19",
       "desc": "Sets teamfrags HUD element horizontal alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -7143,6 +8598,7 @@
       ]
     },
     "hud_teamfrags_align_y": {
+      "group-id": "19",
       "desc": "Sets teamfrags HUD element vertical alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -7151,6 +8607,7 @@
       ]
     },
     "hud_teamfrags_bignum": {
+      "group-id": "19",
       "desc": "Changes the scale of the fragcount number.",
       "type": "float",
       "values": [
@@ -7158,6 +8615,7 @@
       ]
     },
     "hud_teamfrags_cell_height": {
+      "group-id": "19",
       "desc": "Sets cell height for cells in \u0027teamfrags\u0027 HUD element.",
       "type": "integer",
       "values": [
@@ -7165,6 +8623,7 @@
       ]
     },
     "hud_teamfrags_cell_width": {
+      "group-id": "19",
       "desc": "Sets cell width for cells in \u0027teamfrags\u0027 HUD element.",
       "type": "integer",
       "values": [
@@ -7172,10 +8631,12 @@
       ]
     },
     "hud_teamfrags_colors_alpha": {
+      "group-id": "19",
       "desc": "Sets the opacity of the teams colors for the teamfrags hud element.",
       "type": "float"
     },
     "hud_teamfrags_cols": {
+      "group-id": "19",
       "desc": "Sets number of columns used to draw table in \u0027teamfrags\u0027 HUD element.",
       "type": "integer",
       "values": [
@@ -7183,6 +8644,7 @@
       ]
     },
     "hud_teamfrags_extra_spec_info": {
+      "group-id": "19",
       "desc": "Enables to see what people have rocket launchers, powerups and how much health and armor they have using icons next to the frags. Works while watching MVD demo.",
       "type": "enum",
       "values": [
@@ -7204,6 +8666,7 @@
       ]
     },
     "hud_teamfrags_fliptext": {
+      "group-id": "19",
       "desc": "Toggles alignment of team names in \u0027teamfrags\u0027 HUD element.",
       "remarks": "Use \u0027teamfrags shownames 1\u0027 to show names of teams.",
       "type": "boolean",
@@ -7213,6 +8676,7 @@
       ]
     },
     "hud_teamfrags_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for this HUD element.",
       "type": "float",
       "values": [
@@ -7220,17 +8684,21 @@
       ]
     },
     "hud_teamfrags_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the teamfrags HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_teamfrags_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_teamfrags_maxname": {
+      "group-id": "19",
       "desc": "The max number of characters to use for displaying the teamnames in the teamfrags element.",
       "type": "integer"
     },
     "hud_teamfrags_onlytp": {
+      "group-id": "19",
       "desc": "Decides whetever the teamfrags hud item should be shown only when in teamplay mode.",
       "type": "boolean",
       "values": [
@@ -7239,10 +8707,12 @@
       ]
     },
     "hud_teamfrags_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_teamfrags_padtext": {
+      "group-id": "19",
       "desc": "Toggles text padding in \u0027frags\u0027 HUD element.",
       "remarks": "Use \u0027teamfrags shownames 1\u0027.",
       "type": "boolean",
@@ -7252,6 +8722,7 @@
       ]
     },
     "hud_teamfrags_place": {
+      "group-id": "19",
       "desc": "Sets placement for this HUD element. You can align some elements relative to other elements.",
       "remarks": "First you have to decide, if the element that you are locating now (element B) is to be positioned inside another element (element A) or outside it. See HUD manual for more info.",
       "type": "string",
@@ -7260,14 +8731,17 @@
       ]
     },
     "hud_teamfrags_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of this HUD element.",
       "type": "float"
     },
     "hud_teamfrags_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of this HUD element.",
       "type": "float"
     },
     "hud_teamfrags_rows": {
+      "group-id": "19",
       "desc": "Sets number of rows used to draw table in \u0027teamfrags\u0027 HUD element.",
       "type": "integer",
       "values": [
@@ -7275,6 +8749,7 @@
       ]
     },
     "hud_teamfrags_show": {
+      "group-id": "19",
       "desc": "Toggles visibility of this HUD element.",
       "type": "boolean",
       "values": [
@@ -7283,6 +8758,7 @@
       ]
     },
     "hud_teamfrags_shownames": {
+      "group-id": "19",
       "desc": "Draws players\u0027 team tags next to frag counts in \u0027teamfrags\u0027 HUD element.",
       "type": "boolean",
       "values": [
@@ -7291,6 +8767,7 @@
       ]
     },
     "hud_teamfrags_space_x": {
+      "group-id": "19",
       "desc": "Sets horizontal spacing for teamfrags fields.",
       "type": "integer",
       "values": [
@@ -7298,6 +8775,7 @@
       ]
     },
     "hud_teamfrags_space_y": {
+      "group-id": "19",
       "desc": "Sets vertical spacing for teamfrags fields.",
       "type": "integer",
       "values": [
@@ -7305,6 +8783,7 @@
       ]
     },
     "hud_teamfrags_strip": {
+      "group-id": "19",
       "desc": "Toggles stripped formatting of teamfrags fields.",
       "type": "boolean",
       "values": [
@@ -7313,6 +8792,7 @@
       ]
     },
     "hud_teamfrags_style": {
+      "group-id": "19",
       "desc": "Sets drawing style of \u0027teamfrags\u0027 HUD element.",
       "type": "enum",
       "values": [
@@ -7328,6 +8808,7 @@
       ]
     },
     "hud_teamfrags_vertical": {
+      "group-id": "19",
       "desc": "Toggles vertical ordering of teamfrags fields.",
       "type": "boolean",
       "values": [
@@ -7336,29 +8817,36 @@
       ]
     },
     "hud_teamholdbar_align_x": {
+      "group-id": "19",
       "desc": "Vertical alignment of the teamholdbar HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_teamholdbar_align_y": {
+      "group-id": "19",
       "desc": "Vertical alignment of the teamholdbar HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_teamholdbar_frame": {
+      "group-id": "19",
       "desc": "Opacity of the background of the teamholdbar HUD element",
       "type": "float"
     },
     "hud_teamholdbar_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the teamholdbar HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_teamholdbar_height": {
+      "group-id": "19",
       "desc": "Height of the teamholdbar HUD element in pixels. Some elements support relative heights, e.g. 25%",
       "type": "integer"
     },
     "hud_teamholdbar_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_teamholdbar_onlytp": {
+      "group-id": "19",
       "desc": "Decides whetever the teamholdbar hud item should be shown only when in teamplay mode, or demo playback.",
       "type": "enum",
       "values": [
@@ -7369,26 +8857,32 @@
       ]
     },
     "hud_teamholdbar_opacity": {
+      "group-id": "19",
       "desc": "Sets the opacity of the background for the teamholdbar.",
       "type": "float"
     },
     "hud_teamholdbar_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_teamholdbar_place": {
+      "group-id": "19",
       "desc": "Placement of the teamholdbar HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
       "type": "string"
     },
     "hud_teamholdbar_pos_x": {
+      "group-id": "19",
       "desc": "Horizontal relative position of the teamholdbar HUD element",
       "type": "integer"
     },
     "hud_teamholdbar_pos_y": {
+      "group-id": "19",
       "desc": "Vertical relative position of the teamholdbar HUD element",
       "type": "integer"
     },
     "hud_teamholdbar_show": {
+      "group-id": "19",
       "desc": "Visibility of the teamholdbar HUD element",
       "type": "boolean",
       "values": [
@@ -7397,6 +8891,7 @@
       ]
     },
     "hud_teamholdbar_show_text": {
+      "group-id": "19",
       "desc": "Shows the percent for each team on the teamholdbar.",
       "remarks": "vertical_text can be used when vertical mode is set to draw the text vertically also.",
       "type": "boolean",
@@ -7406,6 +8901,7 @@
       ]
     },
     "hud_teamholdbar_vertical": {
+      "group-id": "19",
       "desc": "Draw the teamholdbar vertically.",
       "remarks": "Use vertical_text to make the text vertical also.",
       "type": "boolean",
@@ -7415,6 +8911,7 @@
       ]
     },
     "hud_teamholdbar_vertical_text": {
+      "group-id": "19",
       "desc": "Draw the text vertically for the teamholdbar.",
       "type": "boolean",
       "values": [
@@ -7423,33 +8920,41 @@
       ]
     },
     "hud_teamholdbar_width": {
+      "group-id": "19",
       "desc": "Width of the teamholdbar HUD element in pixels. Some elements support relative width, e.g. 25%",
       "type": "integer"
     },
     "hud_teamholdinfo_align_x": {
+      "group-id": "19",
       "desc": "Vertical alignment of the teamholdinfo HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_teamholdinfo_align_y": {
+      "group-id": "19",
       "desc": "Vertical alignment of the teamholdinfo HUD element. See the HUD manual for more info.",
       "type": "string"
     },
     "hud_teamholdinfo_frame": {
+      "group-id": "19",
       "desc": "Opacity of the background of the teamholdinfo HUD element",
       "type": "float"
     },
     "hud_teamholdinfo_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the teamholdinfo HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_teamholdinfo_height": {
+      "group-id": "19",
       "desc": "Height of the teamholdinfo HUD element in pixels. Some elements support relative heights, e.g. 25%",
       "type": "integer"
     },
     "hud_teamholdinfo_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_teamholdinfo_itemfilter": {
+      "group-id": "19",
       "desc": "Decides what items should be shown in the list.",
       "remarks": "Any character/whitespace can be used as a delimiter. Make sure you enter the value between quotes if you use whitespaces.",
       "type": "string",
@@ -7458,6 +8963,7 @@
       ]
     },
     "hud_teamholdinfo_onlytp": {
+      "group-id": "19",
       "desc": "Decides whetever the teamholdinfo hud item should be shown only when in teamplay mode, or demo playback.",
       "type": "enum",
       "values": [
@@ -7468,26 +8974,32 @@
       ]
     },
     "hud_teamholdinfo_opacity": {
+      "group-id": "19",
       "desc": "Sets the background opacity for the teamholdinfo hud element.",
       "type": "float"
     },
     "hud_teamholdinfo_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_teamholdinfo_place": {
+      "group-id": "19",
       "desc": "Placement of the teamholdinfo HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
       "type": "string"
     },
     "hud_teamholdinfo_pos_x": {
+      "group-id": "19",
       "desc": "Horizontal relative position of the teamholdinfo HUD element",
       "type": "integer"
     },
     "hud_teamholdinfo_pos_y": {
+      "group-id": "19",
       "desc": "Vertical relative position of the teamholdinfo HUD element",
       "type": "integer"
     },
     "hud_teamholdinfo_show": {
+      "group-id": "19",
       "desc": "Visibility of the teamholdinfo HUD element",
       "type": "boolean",
       "values": [
@@ -7496,6 +9008,7 @@
       ]
     },
     "hud_teamholdinfo_style": {
+      "group-id": "19",
       "desc": "The style of the teamholdinfo hud item.",
       "type": "enum",
       "values": [
@@ -7504,63 +9017,82 @@
       ]
     },
     "hud_teamholdinfo_width": {
+      "group-id": "19",
       "desc": "Width of the teamholdinfo HUD element in pixels. Some elements support relative width, e.g. 25%",
       "type": "integer"
     },
     "hud_teaminfo_align_right": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_teaminfo_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_teaminfo_armor_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_frame": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_teaminfo_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_teaminfo_layout": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_teaminfo_loc_width": {
+      "group-id": "19",
       "desc": "Number of character spaces used to display the location information in hud_teaminfo.",
       "type": "integer"
     },
     "hud_teaminfo_low_health": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_name_width": {
+      "group-id": "19",
       "desc": "Number of character spaces used to display the player name in hud_teaminfo.",
       "type": "integer"
     },
     "hud_teaminfo_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_teaminfo_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_powerup_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_teaminfo_show": {
+      "group-id": "19",
       "desc": "Display information about your team and optionally enemies",
       "remarks": "Enemy information can be enabled through hud_teaminfo_show_enemies 1.",
       "type": "boolean",
@@ -7570,6 +9102,7 @@
       ]
     },
     "hud_teaminfo_show_enemies": {
+      "group-id": "19",
       "desc": "Show information about the enemy team(s) in the teaminfo window. Displays a header for each team consisting of the team name and the current team score.",
       "type": "boolean",
       "values": [
@@ -7578,6 +9111,7 @@
       ]
     },
     "hud_teaminfo_show_self": {
+      "group-id": "19",
       "desc": "Display your self (or player spectated) in the teaminfo list.",
       "type": "boolean",
       "values": [
@@ -7586,9 +9120,11 @@
       ]
     },
     "hud_teaminfo_weapon_style": {
+      "group-id": "19",
       "type": ""
     },
     "hud_tp_need": {
+      "group-id": "19",
       "desc": "Toggles connection of tp_need_* variables with hud elements.",
       "remarks": "E.g.: Use with \u0027tp_need_health 40\u0027 and your health indicator will display red numbers if your health is 40 or lower.",
       "type": "boolean",
@@ -7598,6 +9134,7 @@
       ]
     },
     "hud_tracking_align_x": {
+      "group-id": "19",
       "desc": "Sets tracking HUD element horizontal alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -7606,6 +9143,7 @@
       ]
     },
     "hud_tracking_align_y": {
+      "group-id": "19",
       "desc": "Sets tracking HUD element vertical alignment.",
       "remarks": "See HUD manual for more info.",
       "type": "string",
@@ -7614,6 +9152,7 @@
       ]
     },
     "hud_tracking_format": {
+      "group-id": "19",
       "desc": "Changes the format of descriptive text displayed when you are tracking someone as spectator or watching a demo where you can see player\u0027s team and name.",
       "type": "string",
       "values": [
@@ -7621,6 +9160,7 @@
       ]
     },
     "hud_tracking_frame": {
+      "group-id": "19",
       "desc": "Sets frame visibility and style for this HUD element.",
       "type": "float",
       "values": [
@@ -7628,17 +9168,21 @@
       ]
     },
     "hud_tracking_frame_color": {
+      "group-id": "19",
       "desc": "Defines the color of the background of the tracking HUD element. See HUD manual for more info.",
       "type": "string"
     },
     "hud_tracking_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_tracking_order": {
+      "group-id": "19",
       "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
       "type": "integer"
     },
     "hud_tracking_place": {
+      "group-id": "19",
       "desc": "Sets placement for this HUD element. You can align some elements relative to other elements.",
       "remarks": "First you have to decide, if the element that you are locating now (element B) is to be positioned inside another element (element A) or outside it. See HUD manual for more info.",
       "type": "string",
@@ -7647,17 +9191,21 @@
       ]
     },
     "hud_tracking_pos_x": {
+      "group-id": "19",
       "desc": "Sets horizontal position of this HUD element.",
       "type": "float"
     },
     "hud_tracking_pos_y": {
+      "group-id": "19",
       "desc": "Sets vertical position of this HUD element.",
       "type": "float"
     },
     "hud_tracking_scale": {
+      "group-id": "19",
       "type": ""
     },
     "hud_tracking_show": {
+      "group-id": "19",
       "desc": "Toggles visibility of this HUD element.",
       "type": "boolean",
       "values": [
@@ -7666,39 +9214,51 @@
       ]
     },
     "hud_vidlag_align_x": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_vidlag_align_y": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_vidlag_frame": {
+      "group-id": "19",
       "type": ""
     },
     "hud_vidlag_frame_color": {
+      "group-id": "19",
       "type": ""
     },
     "hud_vidlag_item_opacity": {
+      "group-id": "19",
       "type": "float"
     },
     "hud_vidlag_order": {
+      "group-id": "19",
       "type": ""
     },
     "hud_vidlag_place": {
+      "group-id": "19",
       "type": "string"
     },
     "hud_vidlag_pos_x": {
+      "group-id": "19",
       "type": ""
     },
     "hud_vidlag_pos_y": {
+      "group-id": "19",
       "type": ""
     },
     "hud_vidlag_show": {
+      "group-id": "19",
       "type": ""
     },
     "hud_vidlag_style": {
+      "group-id": "19",
       "type": ""
     },
     "ignore_flood": {
+      "group-id": "3",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Off." },
@@ -7707,10 +9267,12 @@
       ]
     },
     "ignore_flood_duration": {
+      "group-id": "3",
       "desc": "You can change the 4 second cooldown with the \u0027ignore_flood_duration\u0027 variable.",
       "type": "float"
     },
     "ignore_mode": {
+      "group-id": "3",
       "desc": "Someone is on your ignore list, you won\u0027t see any messagemode (/say hello) messages from them \n(even if they are a spec).",
       "type": "boolean",
       "values": [
@@ -7719,6 +9281,7 @@
       ]
     },
     "ignore_opponents": {
+      "group-id": "3",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Do not ignore opponent team." },
@@ -7727,6 +9290,7 @@
       ]
     },
     "ignore_qizmo_spec": {
+      "group-id": "3",
       "desc": "Ignores all Qizmo spectators (= observers). Very useful on big matches with 100 and more spectators.",
       "type": "boolean",
       "values": [
@@ -7735,6 +9299,7 @@
       ]
     },
     "ignore_qtv": {
+      "group-id": "3",
       "desc": "Ignore chat messages from the Quake-TV broadcast.",
       "type": "boolean",
       "values": [
@@ -7743,6 +9308,7 @@
       ]
     },
     "ignore_spec": {
+      "group-id": "3",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Off" },
@@ -7751,14 +9317,17 @@
       ]
     },
     "image_jpeg_quality_level": {
+      "group-id": "41",
       "desc": "You can set quality of jpeg screenshots with \u0027image_jpeg_quality_level x\u0027 \nwhere x is an integer from 0 to 100 inclusive. The larger x is, \nthe better the quality of a jpeg screenshot, but also the bigger the size.",
       "type": "float"
     },
     "image_png_compression_level": {
+      "group-id": "41",
       "desc": "You can set the amount of png compression with \u0027image_png_compression_level x\u0027 \nwhere x is an integer from 0 to 9 inclusive. 0 gives no compression and 9 gives \nmaximum compression (and slowest writing time).",
       "type": "float"
     },
     "in_builtinkeymap": {
+      "group-id": "1",
       "desc": "Allows you tu use old Quake keyboard mapping",
       "type": "boolean",
       "values": [
@@ -7767,6 +9336,7 @@
       ]
     },
     "in_di_buffered": {
+      "group-id": "28",
       "desc": "Direct Input: Use Immedia data instead of buffered mode of reading.",
       "remarks": "This setting has been added only because Direct Input allows such mode of use. It is not going to decrease input lag, make the mouse responsiveness better, or anything like that. Read the official documentation on Direct Input to know the difference between buffered and immediate mode of use.",
       "type": "boolean",
@@ -7776,11 +9346,13 @@
       ]
     },
     "in_di_bufsize": {
+      "group-id": "28",
       "desc": "Size of the direct input buffer",
       "remarks": "On some circumstances the default size does not have to be sufficient",
       "type": "integer"
     },
     "in_evdevice": {
+      "group-id": "28",
       "desc": "Specify device for evdev mouse. Should be absolute path like /dev/input/event0\nuse in_evdevlist command to get lost of devices",
       "remarks": "You should have read access to your device.\nsudo chmod 644 /dev/input/event* should help you if you have trouble",
       "type": "string",
@@ -7789,10 +9361,12 @@
       ]
     },
     "in_grab_windowed_mouse": {
+      "group-id": "11",
       "desc": "If set, will grab mouse input when not fullscreen",
       "type": "boolean"
     },
     "in_m_os_parameters": {
+      "group-id": "28",
       "desc": "Allows you to use your system mouse settings in the client",
       "type": "enum",
       "values": [
@@ -7803,6 +9377,7 @@
       ]
     },
     "in_m_smooth": {
+      "group-id": "28",
       "desc": "Enables advanced mouse smoothing. You have to be using Direct Input for this to work.",
       "type": "boolean",
       "values": [
@@ -7811,6 +9386,7 @@
       ]
     },
     "in_mmt": {
+      "group-id": "28",
       "desc": "Multithreaded mouse.\nFor most users in_mmt 1 + evdev gives the most smooth input",
       "remarks": "Linux only and evdev (in_mouse 3) only.",
       "type": "boolean",
@@ -7820,6 +9396,7 @@
       ]
     },
     "in_mouse": {
+      "group-id": "28",
       "desc": "Different types of mouse input\n[OBSOLETE in ezQuake 3.0]",
       "remarks": "Linux: You have to set in_evdevice to proper value (/dev/input/eventX). Use command in_evdevlist to get the lost of proper values. Also in_mmt makes your mouse more smooth.",
       "type": "enum",
@@ -7831,10 +9408,12 @@
       ]
     },
     "in_raw": {
+      "group-id": "11",
       "desc": "If set, ",
       "type": "boolean"
     },
     "in_raw_allbuttons": {
+      "group-id": "28",
       "desc": "Forces RAW Input handler to treat more incoming signals as mouse buttons. Helps if you cannot get some mouse buttons working in the game.",
       "type": "boolean",
       "values": [
@@ -7843,30 +9422,37 @@
       ]
     },
     "irc_server_address": {
+      "group-id": "12",
       "desc": "IP address of the IRC server to connect to on irc connect command.",
       "type": "string"
     },
     "irc_server_password": {
+      "group-id": "12",
       "desc": "Password for IRC server connection.",
       "type": "string"
     },
     "irc_server_port": {
+      "group-id": "12",
       "desc": "Port number for IRC server connection.",
       "type": "integer"
     },
     "irc_user_nick": {
+      "group-id": "12",
       "desc": "Your nickname used to log-in to the IRC server.",
       "type": "string"
     },
     "irc_user_realname": {
+      "group-id": "12",
       "desc": "Real name field used to log-in to the IRC server.",
       "type": "string"
     },
     "irc_user_username": {
+      "group-id": "12",
       "desc": "Username used to log-in to the IRC server.",
       "type": "string"
     },
     "joystick": {
+      "group-id": "28",
       "desc": "Toggles usage of joystick device.",
       "type": "boolean",
       "values": [
@@ -7875,17 +9461,21 @@
       ]
     },
     "keymap_name": {
+      "group-id": "1",
       "desc": "This holds the name of the current keymappings; it has (currently) only informational purposes. If no keymapping is active, it will contain the name \"Default\". If a keymapping will be active and no name has been set, \"Custom\" will be used as name. It can easily be set with \"keymap_name \u003clayoutname\u003e\"",
       "type": "float"
     },
     "localid": {
+      "group-id": "2",
       "type": "string"
     },
     "log_dir": {
+      "group-id": "5",
       "desc": "The logging dir.",
       "type": "string"
     },
     "log_readable": {
+      "group-id": "5",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Off." },
@@ -7893,6 +9483,7 @@
       ]
     },
     "lookspring": {
+      "group-id": "10",
       "desc": "This variable toggles the centering of the screen after the -klook command.",
       "type": "boolean",
       "values": [
@@ -7901,18 +9492,22 @@
       ]
     },
     "lookstrafe": {
+      "group-id": "10",
       "desc": "This variable toggles the automatic strafing when the +klook command is used.\nWhen set to \"1\" and the player used the +klook command, the keys that are bound \nto the +left and +right commands will now act as if they were bound to +moveleft \nand +moveright. This command was put it in order to allow keyboard player to \ncombine the +strafe and +klook commands into one.\nThis command also has effect on the mouse controls. When set to \"1\" moving the \nmouse left and right will make the player move left and right instead of making \nhim turn left and right.",
       "type": "float"
     },
     "m_accel": {
+      "group-id": "11",
       "desc": "Sets mouse acceleration like in q3.",
       "type": "float"
     },
     "m_filter": {
+      "group-id": "11",
       "desc": "This variable toggles mouse input filtering. When set to \"1\", the values which\nare received from the mouse\u0027s input will first be averaged together and then \nthat value will be used in the game. \nThe reason for this command is that some mice had problems with sending sporadic\ncoordinates which make the input from the mouse jerky, also when using a serial \nor PS/2 mouse, the Windows operating system will only sample mouse input every \n25ms, that is 40 times a second (for USB mice the sample rate is 125 Hz, that is\nevery 8 ms). When set to \"1\" this variable will smooth out the input but it will \ncause latency between the movement of the mouse and the actual response in the \ngame. When using a PS/2 mouse it is thus first recommended to try to increase \nthe sampling rate either by changing it via your mouse driver or by using the \nps2rate program which can be downloaded at ps2rate homepage . \nIf you are playing the game at frame rates above 40 FPS and if you can\u0027t \nincrease the sampling rate of your PS/2 rate or if you are playing with a serial \nmouse it is recommended that you enable this toggle.",
       "type": "float"
     },
     "m_forcewheel": {
+      "group-id": "28",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -7920,18 +9515,22 @@
       ]
     },
     "m_forward": {
+      "group-id": "11",
       "desc": "This variable controls how fast the player should move forward and back when the \nmouse is moved forward and back. This command has no effect if the +mlook \ncommand is in effect because when the mouse is moved forward and back the \nplayer looks up and down instead of moving forward and back. Some players might \nwant to set this variable to \"0\" if they happen not to use +mlook constantly and \nthey only want to use the mouse to turn the player. Setting this variable to \"0\"\nwill prevent the inadvertent movement of the player forward and back while \ntrying to make precise turns with the mouse.",
       "type": "float"
     },
     "m_pitch": {
+      "group-id": "11",
       "desc": "This variable sets the level of precision when the mouse is used to make the \nplayer look up and down while the +mlook command is in effect. By default this \nvariable is set in such a way that moving the mouse forward makes the player \nlook up and moving the mouse backward makes the player look down. Some people \nprefer to have this movement inverted just like it is inverted for airplane \ncontrols. If you wish to use this inverted mouse movement then you should set \nthis variable to a negative value (for example \"-0.022\"). It is a matter of \npreference which movement method is used by players. Also lowering the value \nfor this variable will increase the level of precision when the mouse is used \nto make the player look up and down. This variable can be used separately from \nthe sensitivity variable to provide greater control over the mouse sensitivity \nfor movement along the pitch. It is advisable to keep the value for this \nvariable constant at 0.022 or -0.022 and instead use the sensitivity variable \nto change the overall sensitivity of the mouse. Also, some script writers lower \nthe value for this variable along with a lowered value for the fov variable in \norder to provide more precision when the fov variable is used to zoom.",
       "type": "float"
     },
     "m_rate": {
+      "group-id": "28",
       "desc": "This variable should be set to your mouse rate (in Hz).\nNote: need -m_smooth and -dinput to commandline.",
       "type": "float"
     },
     "m_showrate": {
+      "group-id": "28",
       "remarks": "Note: need -m_smooth and -dinput to commandline.",
       "type": "boolean",
       "values": [
@@ -7940,18 +9539,22 @@
       ]
     },
     "m_side": {
+      "group-id": "11",
       "desc": "When the +strafe command is active or when \"lookspring\" is set to \"1\" this \nvariable is used to control the sensitivity when the mouse is moved left and \nright to make the player move left and right.",
       "type": "float"
     },
     "m_yaw": {
+      "group-id": "11",
       "desc": "This variable controls how fast the player turns left and right when the mouse \nis moved left and right. It is recommended that this variable be left alone and\ninstead the \"sensitivity\" variable is used to change the level of precision. \nIf you set this variable to a negative value you will reverse the mouse \nmovement. Some script writers use this variable to increase the level of \nprecision when the \"fov\" variable is used to zoom the screen.",
       "type": "float"
     },
     "mapname": {
+      "group-id": "2",
       "desc": "Contains the name of the current map",
       "type": "string"
     },
     "match_auto_logconsole": {
+      "group-id": "16",
       "desc": "When set to 1 or 2, a temp console log will automatically be created when a match starts (usually when the countdown starts).",
       "type": "enum",
       "values": [
@@ -7961,6 +9564,7 @@
       ]
     },
     "match_auto_logupload": {
+      "group-id": "16",
       "desc": "Automatically upload match console log to remote server specified in match_auto_logurl.",
       "type": "boolean",
       "values": [
@@ -7969,12 +9573,15 @@
       ]
     },
     "match_auto_logupload_token": {
+      "group-id": "16",
       "type": "string"
     },
     "match_auto_logurl": {
+      "group-id": "16",
       "type": "string"
     },
     "match_auto_minlength": {
+      "group-id": "16",
       "desc": "When using \u0027match_auto_record 2\u0027, temp demo\u0027s auto recorded won\u0027t be saved automatically if they are shorter than the number of seconds match_auto_minlength\u0027 is set to.",
       "remarks": "If a temp demo is too short to autosave, you can still save it manually with \"match_save\".",
       "type": "integer",
@@ -7983,6 +9590,7 @@
       ]
     },
     "match_auto_record": {
+      "group-id": "16",
       "desc": "When set to 1 or 2, a temp demo will automatically be recorded when a match starts (usually when the countdown starts).",
       "type": "enum",
       "values": [
@@ -7992,6 +9600,7 @@
       ]
     },
     "match_auto_spectating": {
+      "group-id": "16",
       "desc": "When set to 1, auto recording will also occur when in spectator mode.",
       "type": "boolean",
       "values": [
@@ -8000,6 +9609,7 @@
       ]
     },
     "match_auto_sshot": {
+      "group-id": "16",
       "desc": "Set to 1 to automatically take a screenshot of the final scoreboard when a match ends. If your console is down or you are in the menus, then the client will remove the console/menu for a split second so it can take a screenshot of the scoreboard without any interference.",
       "type": "boolean",
       "values": [
@@ -8008,6 +9618,7 @@
       ]
     },
     "match_auto_unminimize": {
+      "group-id": "16",
       "desc": "Bring client from minimized state on countdown start.",
       "remarks": "Only works on KT* servers.",
       "type": "boolean",
@@ -8017,6 +9628,7 @@
       ]
     },
     "match_challenge": {
+      "group-id": "16",
       "desc": "When enabled, sends announcements to duel ladder server about match start and match end. Can be activated by special startup *.qw file or by opening special qw: URL.",
       "type": "boolean",
       "values": [
@@ -8025,10 +9637,12 @@
       ]
     },
     "match_challenge_url": {
+      "group-id": "16",
       "desc": "Web address where POST requests announcing challenge match start and end will be sent.",
       "type": "string"
     },
     "match_format_2on2": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8037,6 +9651,7 @@
       ]
     },
     "match_format_3on3": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8045,6 +9660,7 @@
       ]
     },
     "match_format_4on4": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8053,6 +9669,7 @@
       ]
     },
     "match_format_arena": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8061,6 +9678,7 @@
       ]
     },
     "match_format_coop": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8069,6 +9687,7 @@
       ]
     },
     "match_format_duel": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8077,6 +9696,7 @@
       ]
     },
     "match_format_ffa": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8085,6 +9705,7 @@
       ]
     },
     "match_format_multiteam": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8093,6 +9714,7 @@
       ]
     },
     "match_format_race": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8101,6 +9723,7 @@
       ]
     },
     "match_format_solo": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8109,6 +9732,7 @@
       ]
     },
     "match_format_tdm": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8117,6 +9741,7 @@
       ]
     },
     "match_format_tf_clanwar": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8125,6 +9750,7 @@
       ]
     },
     "match_format_tf_duel": {
+      "group-id": "16",
       "desc": "Each match category has a name format variable associated with it. This variable is called match_format_\u003ccategory\u003e. For example, there is match_format_duel, match_format_2on2, etc, etc. All these variables can contain macro\u0027s that are expanded according to the macro list given below.  You can also use the \"match_format_macrolist\" command inside the client to display a list of the macros and their meaning.",
       "remarks": "See \u0027match_format_macrolist\u0027 command and Match tools manual for more info.",
       "type": "string",
@@ -8133,43 +9759,53 @@
       ]
     },
     "match_ladder_id": {
+      "group-id": "16",
       "desc": "Identification of the current duel ladder. Not used right now, always 1.",
       "type": ""
     },
     "match_name_and": {
+      "group-id": "16",
       "desc": "Used for separating names in %k and %l.",
       "type": "string"
     },
     "match_name_nick": {
+      "group-id": "16",
       "desc": "%n uses this if its not \"\", otherwise it uses your in game name.",
       "remarks": "See match_format_macrolist.",
       "type": "string"
     },
     "match_name_on": {
+      "group-id": "16",
       "desc": "Used for separating numbers in %a.",
       "type": "string"
     },
     "match_name_spec": {
+      "group-id": "16",
       "desc": "This is placed after your nick when using %n and are in spec mode. Eg. if you use \"match_name_nick foo\" and leave match_name_spec default, then %n will be \"foo(SPEC)\" in spec mode and \"foo\" when not in spec mode.",
       "remarks": "See match_format_macrolist.",
       "type": "string"
     },
     "match_name_versus": {
+      "group-id": "16",
       "desc": "Used for separating names in %b.",
       "type": "string"
     },
     "maxclients": {
+      "group-id": "43",
       "desc": "Highest number of players allowed on the server",
       "type": "integer"
     },
     "maxspectators": {
+      "group-id": "43",
       "desc": "Highest number of spectators allowed to connect to the server",
       "type": "integer"
     },
     "maxvip_spectators": {
+      "group-id": "43",
       "type": ""
     },
     "menu_advanced": {
+      "group-id": "17",
       "desc": "Shows/hides advanced options entries in the Options menu",
       "type": "boolean",
       "values": [
@@ -8178,6 +9814,7 @@
       ]
     },
     "menu_ingame": {
+      "group-id": "17",
       "desc": "Enables/disables ingame menu - menu that typically appears if you press Esc key during the game.",
       "type": "boolean",
       "values": [
@@ -8186,14 +9823,17 @@
       ]
     },
     "menu_marked_bgcolor": {
+      "group-id": "17",
       "desc": "The color of the selected entry in options menu.",
       "type": "string"
     },
     "menu_marked_fade": {
+      "group-id": "17",
       "desc": "Speed of menu entry highlight flashing. Zero disables the flashing effect.",
       "type": "float"
     },
     "mp3_player": {
+      "group-id": "18",
       "desc": "Selects the MP3 player that will be controlled within EzQuake.",
       "remarks": "Windows - winamp supported\nLinux - audacious, xmms2, xmms, mpd supported\nMac - None",
       "type": "string",
@@ -8206,6 +9846,7 @@
       ]
     },
     "mp3_scrolltitle": {
+      "group-id": "18",
       "desc": "Toggles scrolling of the song info in mp3 player control window.",
       "type": "boolean",
       "values": [
@@ -8214,6 +9855,7 @@
       ]
     },
     "mp3_showtime": {
+      "group-id": "18",
       "desc": "Toggles displaying song time information in mp3 player control window.",
       "type": "enum",
       "values": [
@@ -8223,10 +9865,12 @@
       ]
     },
     "mp3_winamp_dir": {
+      "group-id": "18",
       "desc": "Tells your client the path where it should look for your external music player.",
       "type": "string"
     },
     "msg": {
+      "group-id": "37",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Maximum reporting of messages." },
@@ -8237,6 +9881,7 @@
       ]
     },
     "msg_filter": {
+      "group-id": "3",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Filters nothing (default)" },
@@ -8246,9 +9891,11 @@
       ]
     },
     "mtu": {
+      "group-id": "37",
       "type": "string"
     },
     "mumble_enabled": {
+      "group-id": "32",
       "desc": "Turn on mumble positional audio support.",
       "remarks": "Requires mumble to be loaded before toggling this on.",
       "type": "boolean",
@@ -8258,6 +9905,7 @@
       ]
     },
     "mvd_autohud": {
+      "group-id": "20",
       "desc": "Will load different Head Up Display settings when watching MultiView Demos.",
       "type": "enum",
       "values": [
@@ -8267,6 +9915,7 @@
       ]
     },
     "mvd_autotrack": {
+      "group-id": "20",
       "desc": "Turns auto-tracking function ON / OFF. This feature can be used while watching MultiView Demo. The client will choose and switch to the best player point of view using appropriate algorithm.",
       "remarks": "You can change the switching algorithm properties using mvd_autotrack_1on1, mvd_autotrack_2on2, etc. variables. The setting no. 4. cannot be customized and is independent on other autotrack client settings, except of mvd_autotrack_lockteam",
       "type": "enum",
@@ -8279,42 +9928,51 @@
       ]
     },
     "mvd_autotrack_1on1": {
+      "group-id": "20",
       "desc": "Will be used if mvd_autotrack = 1 and a 1on1 game is played. Its an algorythm for selecting the best player.",
       "remarks": "For a full description read the manual.",
       "type": "string"
     },
     "mvd_autotrack_1on1_values": {
+      "group-id": "20",
       "desc": "Allows you to customize autotrack algoritm. See autotrack manual page for more info.",
       "type": "string"
     },
     "mvd_autotrack_2on2": {
+      "group-id": "20",
       "desc": "Will be used if mvd_autotrack = 1 and a 2on2 game is played. Its an algorythm for selecting the best player.",
       "remarks": "For a full description read the manual.",
       "type": "string"
     },
     "mvd_autotrack_2on2_values": {
+      "group-id": "20",
       "desc": "Allows you to customize autotrack algoritm. See autotrack manual page for more info.",
       "type": "string"
     },
     "mvd_autotrack_4on4": {
+      "group-id": "20",
       "desc": "Will be used if mvd_autotrack = 1 and a 4on4 game is played. Its an algorythm for selecting the best player.",
       "remarks": "For a full description read the manual.",
       "type": "string"
     },
     "mvd_autotrack_4on4_values": {
+      "group-id": "20",
       "desc": "Allows you to customize autotrack algoritm. See autotrack manual page for more info.",
       "type": "string"
     },
     "mvd_autotrack_custom": {
+      "group-id": "20",
       "desc": "Will be used if mvd_autotrack = 2.\n Its an algorythm for selecting the best player.",
       "remarks": "For a full description read the manual.",
       "type": "string"
     },
     "mvd_autotrack_custom_values": {
+      "group-id": "20",
       "desc": "Allows you to customize autotrack algoritm. See autotrack manual page for more info.",
       "type": "string"
     },
     "mvd_autotrack_instant": {
+      "group-id": "20",
       "desc": "Makes mvd_autotrack always find the best player and switch to him instantly.",
       "remarks": "In KTPro autotrack tracked player is changed only when some events happen. In instant mvd_autotrack tracked player is changed everytime a better player is found.",
       "type": "boolean",
@@ -8324,6 +9982,7 @@
       ]
     },
     "mvd_autotrack_lockteam": {
+      "group-id": "20",
       "desc": "If set to 1, autotrack will keep switching POVs only from players within the same team.",
       "type": "boolean",
       "values": [
@@ -8332,6 +9991,7 @@
       ]
     },
     "mvd_info": {
+      "group-id": "20",
       "desc": "When watching Multi View Demo (.mvd) you can show a table on the screen with full info about players\u0027 status.",
       "remarks": "See mvd_info_setup for setting up displayed informations.",
       "type": "boolean",
@@ -8341,9 +10001,11 @@
       ]
     },
     "mvd_info_setup": {
+      "group-id": "20",
       "type": "string"
     },
     "mvd_info_show_header": {
+      "group-id": "20",
       "desc": "Will show a line above the mvd_info table telling you wich column is armor/health/location etc.",
       "type": "boolean",
       "values": [
@@ -8352,16 +10014,19 @@
       ]
     },
     "mvd_info_x": {
+      "group-id": "20",
       "desc": "You can adjust horizontal placement of Players\u0027 info table",
       "remarks": "See scr_mvdinfo and scr_mvdinfo_setup description for more details.",
       "type": "float"
     },
     "mvd_info_y": {
+      "group-id": "20",
       "desc": "You can adjust vertical placement of Players\u0027 info table",
       "remarks": "See scr_mvdinfo and scr_mvdinfo_setup description for more details.",
       "type": "float"
     },
     "mvd_moreinfo": {
+      "group-id": "20",
       "desc": "When playing MultiView Demo (MVD), you can turn on more messages printed in the console, like those you might know from moreinfo command in ktpro. E.g.: Nabbe picked up quad.",
       "type": "boolean",
       "values": [
@@ -8370,66 +10035,81 @@
       ]
     },
     "mvd_multitrack_1": {
+      "group-id": "20",
       "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 1",
       "remarks": "For a full description read the manual.",
       "type": "string"
     },
     "mvd_multitrack_1_values": {
+      "group-id": "20",
       "desc": "Allows you to customize autotrack algoritm. See autotrack manual page for more info.",
       "type": "string"
     },
     "mvd_multitrack_2": {
+      "group-id": "20",
       "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 2",
       "remarks": "For a full description read the manual.",
       "type": "string"
     },
     "mvd_multitrack_2_values": {
+      "group-id": "20",
       "desc": "Allows you to customize autotrack algoritm. See autotrack manual page for more info.",
       "type": "string"
     },
     "mvd_multitrack_3": {
+      "group-id": "20",
       "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 3",
       "remarks": "For a full description read the manual.",
       "type": "string"
     },
     "mvd_multitrack_3_values": {
+      "group-id": "20",
       "desc": "Allows you to customize autotrack algoritm. See autotrack manual page for more info.",
       "type": "string"
     },
     "mvd_multitrack_4": {
+      "group-id": "20",
       "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 4",
       "remarks": "For a full description read the manual.",
       "type": "string"
     },
     "mvd_multitrack_4_values": {
+      "group-id": "20",
       "desc": "Allows you to customize autotrack algoritm. See autotrack manual page for more info.",
       "type": "string"
     },
     "mvd_pc_pent_1": {
+      "group-id": "20",
       "desc": "Describes the position and viewing angles of the p1 cam.\nx y z rot_x rot_y",
       "type": "string"
     },
     "mvd_pc_pent_2": {
+      "group-id": "20",
       "desc": "Describes the position and viewing angles of the p2 cam.\nx y z rot_x rot_y",
       "type": "string"
     },
     "mvd_pc_pent_3": {
+      "group-id": "20",
       "desc": "Describes the position and viewing angles of the p3 cam.\nx y z rot_x rot_y",
       "type": "string"
     },
     "mvd_pc_quad_1": {
+      "group-id": "20",
       "desc": "Describes the position and viewing angles of the q1 cam.\nx y z rot_x rot_y",
       "type": "string"
     },
     "mvd_pc_quad_2": {
+      "group-id": "20",
       "desc": "Describes the position and viewing angles of the q2 cam.\nx y z rot_x rot_y",
       "type": "string"
     },
     "mvd_pc_quad_3": {
+      "group-id": "20",
       "desc": "Describes the position and viewing angles of the q3 cam.\nx y z rot_x rot_y",
       "type": "string"
     },
     "mvd_pc_view_1": {
+      "group-id": "20",
       "desc": "Sets the powerup camera for viewport 1",
       "type": "string",
       "values": [
@@ -8442,6 +10122,7 @@
       ]
     },
     "mvd_pc_view_2": {
+      "group-id": "20",
       "desc": "Sets the powerup camera for viewport 2",
       "type": "string",
       "values": [
@@ -8454,6 +10135,7 @@
       ]
     },
     "mvd_pc_view_3": {
+      "group-id": "20",
       "desc": "Sets the powerup camera for viewport 3",
       "type": "string",
       "values": [
@@ -8466,6 +10148,7 @@
       ]
     },
     "mvd_pc_view_4": {
+      "group-id": "20",
       "desc": "Sets the powerup camera for viewport 4",
       "type": "string",
       "values": [
@@ -8478,6 +10161,7 @@
       ]
     },
     "mvd_powerup_cam": {
+      "group-id": "20",
       "desc": "Will enable powerupcams, cams will be enabled on every viewport 5 seconds before the powerup spawns.",
       "remarks": "For setting up the viewports cams look at \nmvd_pc_view_1-4\nand for setting the locations of the cams look at\nmvd_pc_quad_1-3\nmvd_pc_pent_1-3\n",
       "type": "boolean",
@@ -8487,6 +10171,7 @@
       ]
     },
     "mvd_status": {
+      "group-id": "20",
       "desc": "Shows information of the player you are currently tracking.\nInformation includes.\ntaken/dropped items and powerups\nlast 3 runs (including the current one) run is from powerup-took/spawn to powerup-end/death",
       "type": "boolean",
       "values": [
@@ -8495,14 +10180,17 @@
       ]
     },
     "mvd_status_x": {
+      "group-id": "20",
       "desc": "Adjusts the horizontal placement of mvd_status table",
       "type": "float"
     },
     "mvd_status_y": {
+      "group-id": "20",
       "desc": "Adjusts the vertical placement of mvd_status table",
       "type": "float"
     },
     "mvd_write_xml": {
+      "group-id": "24",
       "desc": "Enables dumping of XML stats from a MVD.",
       "type": "boolean",
       "values": [
@@ -8511,10 +10199,12 @@
       ]
     },
     "name": {
+      "group-id": "37",
       "desc": "Player\u0027s name.",
       "type": "string"
     },
     "noaim": {
+      "group-id": "37",
       "desc": "This variable toggles whether a server-sided aiming-help should be used when shooting rockets (not possible when the server variable \"sv_aim\" is set to \"0\").",
       "type": "boolean",
       "values": [
@@ -8523,6 +10213,7 @@
       ]
     },
     "noskins": {
+      "group-id": "44",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Enable skins." },
@@ -8531,14 +10222,17 @@
       ]
     },
     "not_auth_timeout": {
+      "group-id": "43",
       "type": ""
     },
     "password": {
+      "group-id": "43",
       "desc": "Password players have to use to connect to local server",
       "remarks": "Server-side",
       "type": "string"
     },
     "pausable": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable pause." },
@@ -8546,6 +10240,7 @@
       ]
     },
     "pm_airstep": {
+      "group-id": "43",
       "desc": "Airstep player-move-extension. Changes the physics of the game and allows to do jumps on stairs.",
       "remarks": "Server-side",
       "type": "boolean",
@@ -8555,19 +10250,23 @@
       ]
     },
     "pm_bunnyspeedcap": {
+      "group-id": "34",
       "desc": "This is experimental code intended to restore class balance in TF. If you set \nthis cvar to something like 1.5 or 2, a solider will not be able to bunnyhop as \nfast as a scout does :) Note that this cvar is optional and disabled by default, \nso it will in NO WAY affect gameplay unless you set it explicitly to anything \nbut 0.",
       "type": "float"
     },
     "pm_ktjump": {
+      "group-id": "34",
       "desc": "You can change value of ktjump.",
       "type": "float"
     },
     "pm_pground": {
+      "group-id": "34",
       "desc": "Enables \u0027persistent onground flag\u0027 physics tweak.  Its only use is that it makes pm_airstep work better.",
       "remarks": "This extension makes use of Z_EXT_PF_ONGROUND to ensure correct movement prediction by clients. Prediction errors shouldn\u0027t be very noticeable anyway even with old clients.",
       "type": "integer"
     },
     "pm_slidefix": {
+      "group-id": "34",
       "desc": "When set to 1, Upon decsension from a sloped surface, the player doesn\u0027t \"drop\" (which is a bug in QW), but smoothly slides, as it was in NQ.",
       "type": "boolean",
       "values": [
@@ -8576,10 +10275,12 @@
       ]
     },
     "pushlatency": {
+      "group-id": "21",
       "desc": "This variable is outdated and exists for compatibility with old configs.",
       "type": "integer"
     },
     "qconsole_log_say": {
+      "group-id": "43",
       "desc": "Log chat messages into the main server console log.",
       "type": "boolean",
       "values": [
@@ -8588,14 +10289,17 @@
       ]
     },
     "qizmo_dir": {
+      "group-id": "7",
       "desc": "Change the default qizmo directory.",
       "type": "string"
     },
     "qport": {
+      "group-id": "2",
       "desc": "Local port the client uses to connect to servers",
       "type": "integer"
     },
     "qtv_adjustbuffer": {
+      "group-id": "38",
       "desc": "Enables balancing of the buffer lenght of the QTV stream. When turned on, the size of the stream buffer (the delay from the actual action) will be auto-adjusted (by changing the playback speed when necessary) so that it stays on the same level most of the time.",
       "remarks": "When turned on, the speed of the playback may change sometimes - that\u0027s how the buffer lenght is balanced. But usually you want to have this turned on when you are watching a shoutcast-commentated game because you want to stay synchronized with the commentary.",
       "type": "boolean",
@@ -8605,6 +10309,7 @@
       ]
     },
     "qtv_adjusthighstart": {
+      "group-id": "38",
       "desc": "The level on which QTV buffer auto-adjusting will start. E.g. when set to 1.5, (and qtv_adjustbuffer is 1), QTV buffer auto-adjusting will start when buffer length reached 150% of it\u0027s normal length (determined by qtv_buffertime setting)",
       "type": "float",
       "values": [
@@ -8612,6 +10317,7 @@
       ]
     },
     "qtv_adjustlowstart": {
+      "group-id": "38",
       "desc": "The bottom level on which QTV buffer auto-adjusting will start. E.g. when set to 0.5, (and qtv_adjustbuffer is 1), QTV buffer auto-adjusting will start when buffer length reached 50% of it\u0027s normal length (determined by qtv_buffertime setting)",
       "type": "float",
       "values": [
@@ -8619,6 +10325,7 @@
       ]
     },
     "qtv_adjustmaxspeed": {
+      "group-id": "38",
       "desc": "The fastest possible playback speed when QTV buffer becomes excessive and auto-adjusting starts. The higher the speed is, the faster the QTV buffer length will go down to normal levels.",
       "remarks": "Works in conjunction with qtv_adjustbuffer 1",
       "type": "float",
@@ -8627,6 +10334,7 @@
       ]
     },
     "qtv_adjustminspeed": {
+      "group-id": "38",
       "desc": "The slowest possible playback speed when QTV buffer adjusting takes action. The slower the speed is, the faster the QTV buffer will fill up.",
       "remarks": "Not allowing to slow down enough, buffer level might still drop down to zero if there were longer network lag. This causes pausing during playback. Allowing to slow down too much is noticeable.",
       "type": "float",
@@ -8635,14 +10343,17 @@
       ]
     },
     "qtv_allow_pause": {
+      "group-id": "38",
       "desc": "Allows QTV streams to be affected by cl_demospeed.",
       "type": "boolean"
     },
     "qtv_api_url": {
+      "group-id": "38",
       "desc": "URL used by /qtv command to resolve servers to QTV addresses and vice versa",
       "type": "string"
     },
     "qtv_buffertime": {
+      "group-id": "38",
       "desc": "Defines how much the client buffers from the QTV stream",
       "remarks": "This determines the \"delay\" you will get from what is actually happening. For example if you want to synchronize shoutcast commentary with the QTV stream, this is the variable you need to change.",
       "type": "float",
@@ -8651,36 +10362,45 @@
       ]
     },
     "qtv_chatprefix": {
+      "group-id": "38",
       "desc": "String that will be added at the beginning of all messages send to a QTV chat.",
       "type": "string"
     },
     "qtv_event_changename": {
+      "group-id": "38",
       "desc": "Text pattern used when an user changes his name on a QTV stream",
       "type": "string"
     },
     "qtv_event_join": {
+      "group-id": "38",
       "desc": "Text pattern used when an user joins a QTV stream",
       "type": "string"
     },
     "qtv_event_leave": {
+      "group-id": "38",
       "desc": "Text pattern used when an user leaves a QTV stream",
       "type": "string"
     },
     "qtv_gamechatprefix": {
+      "group-id": "38",
       "desc": "String that will be added at the beginning of all messages send from QTV to the server where the broadcasted game is being played.",
       "type": "string"
     },
     "qtv_maxstreams": {
+      "group-id": "43",
       "type": ""
     },
     "qtv_password": {
+      "group-id": "43",
       "desc": "Password required for QTV to connect to the streamport.",
       "type": "string"
     },
     "qtv_pendingtimeout": {
+      "group-id": "43",
       "type": ""
     },
     "qtv_say_team": {
+      "group-id": "38",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "say_team will be blocked when sending to QTV" },
@@ -8688,6 +10408,7 @@
       ]
     },
     "qtv_skipchained": {
+      "group-id": "38",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "QTV chat messages will have prefix detailing userIDs and proxy addresses" },
@@ -8695,13 +10416,16 @@
       ]
     },
     "qtv_streamport": {
+      "group-id": "43",
       "desc": "Server variable, TCP port on which the server will listen for QTV connections.",
       "type": "integer"
     },
     "qtv_streamtimeout": {
+      "group-id": "43",
       "type": ""
     },
     "qwdtools_dir": {
+      "group-id": "7",
       "desc": "Specifies the qwdtools utility placement",
       "type": "string",
       "values": [
@@ -8709,18 +10433,22 @@
       ]
     },
     "r_aliastransadj": {
+      "group-id": "31",
       "desc": "Not much is known about this variable except for that increasing the value will\ncause the player models to be displayed smaller.",
       "type": "float"
     },
     "r_aliastransbase": {
+      "group-id": "31",
       "desc": "Not much is known about this variable except for that increasing the value will\ncause the player models to be displayed smaller.",
       "type": "float"
     },
     "r_ambient": {
+      "group-id": "31",
       "desc": "This variable controls the amount of ambient lighting on the map. When this \nvariable is increased the map will become brighter and all walls and objects \nwill be rendered in a lighter color.\nIt was removed in QWCL and has been re-introduced in this client, however it \ncan only be used when the server is running with cheats enabled (for example \n\"qwsv -cheats\"), because it could be used as a cheat by making it easier to see\nplayers in dark corners when no fullbright skins are used.",
       "type": "float"
     },
     "r_bloom": {
+      "group-id": "8",
       "desc": "Enables lights blooming",
       "remarks": "Lights will have a \\\"diamond\\\" effect near them",
       "type": "boolean",
@@ -8730,18 +10458,22 @@
       ]
     },
     "r_bloom_alpha": {
+      "group-id": "8",
       "desc": "Transparency level of the blooming effect",
       "type": "float"
     },
     "r_bloom_darken": {
+      "group-id": "8",
       "desc": "Level of \\\"darkness\\\" of the blooming effect",
       "type": "integer"
     },
     "r_bloom_diamond_size": {
+      "group-id": "8",
       "desc": "Size of the diamond particle used in the blooming effect",
       "type": "integer"
     },
     "r_bloom_fast_sample": {
+      "group-id": "8",
       "desc": "Faster variant of the blooming effect.",
       "type": "boolean",
       "values": [
@@ -8750,14 +10482,17 @@
       ]
     },
     "r_bloom_intensity": {
+      "group-id": "8",
       "desc": "Intensity of the blooming effect",
       "type": "integer"
     },
     "r_bloom_sample_size": {
+      "group-id": "8",
       "desc": "Size of the particle used in the blooming effect",
       "type": "integer"
     },
     "r_chaticons_alpha": {
+      "group-id": "8",
       "desc": "Opacity of chaticons.",
       "type": "float",
       "values": [
@@ -8765,14 +10500,17 @@
       ]
     },
     "r_clearcolor": {
+      "group-id": "31",
       "desc": "This variable changes the color of the areas outside the map, commonly seen when free floating as a spectator.",
       "type": "float"
     },
     "r_damagestats": {
+      "group-id": "47",
       "desc": "Displays the amount of damage taken recently on the screen above your armour and health.",
       "type": "float"
     },
     "r_drawentities": {
+      "group-id": "8",
       "desc": "This variable can be used to disable that any object entities are drawn. This \ncommand is useful to map authors who wish to take a look at their map without \ndrawing any objects such as lifts, buttons, platforms or items.",
       "type": "boolean",
       "values": [
@@ -8781,6 +10519,7 @@
       ]
     },
     "r_drawflame": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Display no flames." },
@@ -8788,6 +10527,7 @@
       ]
     },
     "r_drawflat": {
+      "group-id": "50",
       "desc": "Disables textures and walls and floors them with a solid color (/r_wallcolor or /r_floorcolor) depending on the angle.",
       "remarks": "Usually used for performance improvements at the expense of eyecandy. See r_wallcolor and r_floorcolor.",
       "type": "enum",
@@ -8799,6 +10539,7 @@
       ]
     },
     "r_draworder": {
+      "group-id": "31",
       "desc": "Allows you to see through object - for development purposes only.",
       "remarks": "Not allowed in multiplayer. See \u0027developer 1\u0027 too.",
       "type": "boolean",
@@ -8808,6 +10549,7 @@
       ]
     },
     "r_drawviewmodel": {
+      "group-id": "54",
       "remarks": "Note: Transparency works in GL only.",
       "type": "float",
       "values": [
@@ -8817,6 +10559,7 @@
       ]
     },
     "r_drawvweps": {
+      "group-id": "8",
       "desc": "Whether to draw vweps (other players\u0027 weapon models).",
       "remarks": "In order for vweps to work, you must have the appropriate models (vwplayer.mdl and w_*.mdl), and the server you\u0027re playing on must have vwep support enabled.",
       "type": "boolean",
@@ -8826,6 +10569,7 @@
       ]
     },
     "r_dspeeds": {
+      "group-id": "31",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not display renderer speed statistics." },
@@ -8833,6 +10577,7 @@
       ]
     },
     "r_dynamic": {
+      "group-id": "15",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not display dynamic lighting." },
@@ -8840,11 +10585,13 @@
       ]
     },
     "r_enemyskincolor": {
+      "group-id": "44",
       "desc": "Allows you to set color for enemies you see in RGB format",
       "remarks": "See r_skincolormode for more info",
       "type": "string"
     },
     "r_explosionLight": {
+      "group-id": "8",
       "type": "float",
       "values": [
         { "name": "0", "description": "No explosion light." },
@@ -8853,6 +10600,7 @@
       ]
     },
     "r_explosionLightColor": {
+      "group-id": "8",
       "desc": "Determines the color of the explosion light.",
       "type": "enum",
       "values": [
@@ -8868,15 +10616,18 @@
       ]
     },
     "r_explosionType": {
+      "group-id": "8",
       "desc": "0 = Fire + sparks\n1 = Fire only\n2 = Teleport\n3 = Blood\n4 = Big blood\n5 = Double gunshot\n6 = Blob effect\n7 = Big explosion\n8 = Fuel Rod Gun Explosion\n9 = Sparks",
       "type": "float"
     },
     "r_farclip": {
+      "group-id": "35",
       "desc": "Can be used to overcome vision being limited to 4096 units in GL clients (good for xpress2 etc).",
       "remarks": "See also: r_nearclip",
       "type": "float"
     },
     "r_fastsky": {
+      "group-id": "51",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable fastsky." },
@@ -8884,6 +10635,7 @@
       ]
     },
     "r_fastturb": {
+      "group-id": "51",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "All turbulences will be displayed normally." },
@@ -8891,6 +10643,7 @@
       ]
     },
     "r_flagColor": {
+      "group-id": "8",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Normal" },
@@ -8902,10 +10655,12 @@
       ]
     },
     "r_floorcolor": {
+      "group-id": "50",
       "desc": "Changes color of floors and ceilings when r_drawflat is set to 1.\nEnter RGB value here, e.g. r_floorcolor \"128 128 128\" goes for gray floor.",
       "type": "string"
     },
     "r_fullbright": {
+      "group-id": "15",
       "desc": "This variable toggles the use of lights at full brightness on the map. This allows map authors to remove all of the lighting effects from the map, effectively removing all shadows.",
       "remarks": "This variable can only be used when the server is running with cheats enabled (for \nexample \"mvdsv -cheats\" or sv_cheats 1), because it could be used as a cheat by making it easier\nto see players in shadows.",
       "type": "boolean",
@@ -8915,6 +10670,7 @@
       ]
     },
     "r_fullbrightSkins": {
+      "group-id": "44",
       "desc": "Determines the fullbright percentage of skins. Fullbright skins can always be used during demo playback. \nThe f_skins response will indicate the brightness level being used as a percentage.",
       "type": "float",
       "values": [
@@ -8924,14 +10680,17 @@
       ]
     },
     "r_glstats": {
+      "group-id": "40",
       "desc": "When enabled, it creates a window in the top right of the screen showing the number of particles and etc. in use.",
       "type": "float"
     },
     "r_graphheight": {
+      "group-id": "31",
       "desc": "This variable used to set the number of lines displayed in the \"r_timegraph\" command.",
       "type": "float"
     },
     "r_grenadeTrail": {
+      "group-id": "8",
       "desc": "Customizable grenade trails.\n",
       "remarks": "trails 8-13 are gl only.",
       "type": "enum",
@@ -8953,13 +10712,16 @@
       ]
     },
     "r_instagibTrail": {
+      "group-id": "8",
       "type": ""
     },
     "r_lavacolor": {
+      "group-id": "51",
       "desc": "Changes colour of lava when r_fastturb set to 1",
       "type": "string"
     },
     "r_lerpframes": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable smoothing." },
@@ -8967,6 +10729,7 @@
       ]
     },
     "r_lerpmuzzlehack": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "No fix for interpolated muzzle flashes." },
@@ -8974,10 +10737,12 @@
       ]
     },
     "r_lgbloodColor": {
+      "group-id": "8",
       "desc": "Determines the color of the blood (for standard particles). The QW-default value is 225.",
       "type": "float"
     },
     "r_lightflicker": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable rocket/explosion/flag/powerup light flickering." },
@@ -8985,6 +10750,7 @@
       ]
     },
     "r_lightmap": {
+      "group-id": "15",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable light sources on the map." },
@@ -8992,6 +10758,7 @@
       ]
     },
     "r_max_size_1": {
+      "group-id": "31",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Off." },
@@ -9000,19 +10767,23 @@
       ]
     },
     "r_maxedges": {
+      "group-id": "31",
       "desc": "This variable sets the maximum number of plane surface edges to be rendered.\nActual default (and minimal) value is 2000.\nOn some new maps you may need to increase this value.\nSee also r_maxsurfs, r_reportedgeout, r_reportsurfout.",
       "type": "float"
     },
     "r_maxsurfs": {
+      "group-id": "31",
       "desc": "This variable sets the maximum number of plane surfaces to be rendered.\nActual default (and minimal) value is 2000.\nOn some new maps you may need to increase this value.\nSee also r_maxedges, r_reportedgeout, r_reportsurfout.",
       "type": "float"
     },
     "r_nearclip": {
+      "group-id": "53",
       "desc": "Distance of clipping nearest objects (v_models).",
       "remarks": "See also: r_farclip",
       "type": "float"
     },
     "r_netgraph": {
+      "group-id": "40",
       "desc": "Setting r_netgraph 1 is a diagnostic tool to help you tweak your rate. If you find that you suffer from short pauses in the game and you see red spikes in your netgraph, you should try setting the rate down a bit.\nThe height of the pink lines towards the bottom is your latency on received packets.\nRed lines are lost packets. (bad)\nYellow lines are from the rate command kicking in, it\u0027s data that wasn\u0027t sent to you because you didn\u0027t have the bandwidth for it. (OK)\nBlue lines are very bad, they invalid delta\u0027s, and are related to the U_REMOVE warnings.",
       "remarks": "If during your play, you frequently see a string of messages with the term \"U_REMOVE\" in them, and your play seems to freeze for serveral seconds, use the console command cl_nodelta 1. This is a slightly less efficient way for QuakeWorld to work, but if your ISP is overloaded or has some configuration problems, it may not pass packets to QuakeWorld properly and cause difficulty.",
       "type": "boolean",
@@ -9022,6 +10793,7 @@
       ]
     },
     "r_netstats": {
+      "group-id": "40",
       "desc": "Shows information about ping, packetloss, average packet size and incoming/outgoing traffic. Equivalent with \u0027net\u0027 HUD element.",
       "type": "boolean",
       "values": [
@@ -9030,6 +10802,7 @@
       ]
     },
     "r_novis": {
+      "group-id": "51",
       "desc": "This variable toggles the use of VIS information from the map data. When this \nvariable is set to \"1\" the game will calculate it\u0027s own VIS information on the \nfly instead of using the information stored in the map data, this will cause \na severe performance penalty in the game. When \"r_novis\" is set to \"1\", the \nvariable \"gl_turbalpha\" has a value lower than \"1\" and the server allows the\nclient to display liquid transparently the player will be able to see through \nliquids. This is a nice effect to see but it is not recommended to keep this \nvariable set to \"1\" because of the huge performance penalty. \nIt is possible to enable transparent liquids and still keep this variable set to\n\"0\" (and thus not experience such a severe performance drop) by using maps that\nare VISed accordingly. You can visit the official Water VIS site at \n\"http://www.sod.net/\" and download the vispatch program along with the patch \ndata files which you would use to update the VIS data for all of your game maps.\nThere are also map packs available that contain VISed versions of the original\nID maps.",
       "type": "boolean",
       "values": [
@@ -9038,6 +10811,7 @@
       ]
     },
     "r_numedges": {
+      "group-id": "31",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not print information about the number of edges." },
@@ -9045,6 +10819,7 @@
       ]
     },
     "r_numsurfs": {
+      "group-id": "31",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not print information about the number of surfaces." },
@@ -9052,6 +10827,7 @@
       ]
     },
     "r_particles_count": {
+      "group-id": "36",
       "desc": "Maximum ammount of particles displayed",
       "remarks": "You can adjust graphics performance with this.",
       "type": "integer",
@@ -9060,6 +10836,7 @@
       ]
     },
     "r_polymodelstats": {
+      "group-id": "31",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not print polygon model statistics." },
@@ -9067,6 +10844,7 @@
       ]
     },
     "r_powerupGlow": {
+      "group-id": "8",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Powerup glow is turned off on all players." },
@@ -9075,9 +10853,11 @@
       ]
     },
     "r_railTrail": {
+      "group-id": "8",
       "type": ""
     },
     "r_reportedgeout": {
+      "group-id": "31",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not report when running out of edges." },
@@ -9085,10 +10865,12 @@
       ]
     },
     "r_reportsurfout": {
+      "group-id": "31",
       "desc": "Toggle the display of how many surfaces where not displayed. This\nshouldn\u0027t happen during normal game play, only when in noclip mode.",
       "type": "float"
     },
     "r_rocketLight": {
+      "group-id": "8",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Turn off dynamic lighting of rockets." },
@@ -9096,6 +10878,7 @@
       ]
     },
     "r_rocketLightColor": {
+      "group-id": "8",
       "desc": "Determines the colour of the rocket light.",
       "type": "enum",
       "values": [
@@ -9110,6 +10893,7 @@
       ]
     },
     "r_rocketTrail": {
+      "group-id": "8",
       "desc": "Customizable rocket trails.\n",
       "remarks": "trails  8 - 13 are GL only",
       "type": "enum",
@@ -9131,6 +10915,7 @@
       ]
     },
     "r_shadows": {
+      "group-id": "15",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not display shadows for entities." },
@@ -9138,6 +10923,7 @@
       ]
     },
     "r_shaftalpha": {
+      "group-id": "8",
       "desc": "Adds transparency to the lightning gun beam (shaft).",
       "remarks": "Disabled in ruleset smackdown",
       "type": "float",
@@ -9146,11 +10932,13 @@
       ]
     },
     "r_shiftbeam": {
+      "group-id": "8",
       "desc": "Shift start of the shaft lights.",
       "remarks": "Doesn\u0027t work with smackdown ruleset. Intended for movies.",
       "type": "float"
     },
     "r_skincolormode": {
+      "group-id": "44",
       "desc": "Toggles different modes of how colors from r_enemyskincolor and r_teamskincolor are applied to players.",
       "type": "enum",
       "values": [
@@ -9163,31 +10951,38 @@
       ]
     },
     "r_skycolor": {
+      "group-id": "51",
       "desc": "Changes colour of sky when r_fastsky set to 1",
       "type": "string"
     },
     "r_skyname": {
+      "group-id": "51",
       "desc": "If you wan\u0027t to use skybox name snow type r_skyname snow, disable skybox with r_skyname \"\"",
       "type": "string"
     },
     "r_slimecolor": {
+      "group-id": "51",
       "desc": "Changes colour of slime when r_fastturb set to 1",
       "type": "string"
     },
     "r_speeds": {
+      "group-id": "40",
       "desc": "Toggles the displaying of drawing time and stats of what is\ncurrently being viewed.\nExample:\n32.7 ms 267/196/ 74 poly   3 surf\n38.6 ms 267/196/ 74 poly  20 surf\n60.4 ms 267/196/ 74 poly  18 surf\n38.2 ms 267/196/ 73 poly  18 surf",
       "type": "float"
     },
     "r_teamskincolor": {
+      "group-id": "44",
       "desc": "Allows you to set color for teammates you see in RGB format",
       "remarks": "See r_skincolormode for more info",
       "type": "string"
     },
     "r_telecolor": {
+      "group-id": "51",
       "desc": "Changes colour of teleport when r_fastturb set to 1",
       "type": "string"
     },
     "r_telesplash": {
+      "group-id": "8",
       "desc": "Toggles teleport splash effect.",
       "type": "boolean",
       "values": [
@@ -9196,6 +10991,7 @@
       ]
     },
     "r_timegraph": {
+      "group-id": "31",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not display the timegraph." },
@@ -9203,6 +10999,7 @@
       ]
     },
     "r_tracker_align_right": {
+      "group-id": "40",
       "desc": "Controls the alignment of the extra frag messages window.",
       "type": "boolean",
       "values": [
@@ -9211,27 +11008,35 @@
       ]
     },
     "r_tracker_color_bad": {
+      "group-id": "40",
       "type": ""
     },
     "r_tracker_color_fragonme": {
+      "group-id": "40",
       "type": ""
     },
     "r_tracker_color_good": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_myfrag": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_suicide": {
+      "group-id": "40",
       "type": ""
     },
     "r_tracker_color_tkbad": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_tkgood": {
+      "group-id": "40",
       "type": ""
     },
     "r_tracker_flags": {
+      "group-id": "40",
       "desc": "Everytime you take, capture or drop a flag, the number of times is displayed on the screen.",
       "remarks": "See r_tracker_*, cl_parseFrags and cl_loadFragFiles variables description for further info.",
       "type": "boolean",
@@ -9241,6 +11046,7 @@
       ]
     },
     "r_tracker_frags": {
+      "group-id": "40",
       "desc": "Controls which frag messages will be shown in extra window, beside the standard onscreen chat (notify area).",
       "remarks": "Values 1 and 2 requires cl_loadfragfiles and cl_parsefrags to be set to 1.",
       "type": "enum",
@@ -9251,6 +11057,7 @@
       ]
     },
     "r_tracker_frame_color": {
+      "group-id": "40",
       "desc": "Controls the opacity and color of the background of the extra frag messages window.",
       "remarks": "See other r_tracker_* variables description for further info.",
       "type": "string",
@@ -9259,51 +11066,65 @@
       ]
     },
     "r_tracker_images_scale": {
+      "group-id": "40",
       "type": ""
     },
     "r_tracker_inconsole": {
+      "group-id": "40",
       "type": ""
     },
     "r_tracker_messages": {
+      "group-id": "40",
       "desc": "Maximum number of custom frag messages to be displayed in extra frag messages window.",
       "remarks": "See other r_tracker_*, cl_parseFrags and cl_loadFragFiles variables description for further info.",
       "type": "integer"
     },
     "r_tracker_name_remove_prefixes": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_name_width": {
+      "group-id": "40",
       "type": ""
     },
     "r_tracker_own_frag_prefix": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_positive_enemy_suicide": {
+      "group-id": "40",
       "desc": "If enabled frag tracker draws enemy suicides using color value of r_tracker_color_good variable.",
       "type": "integer"
     },
     "r_tracker_scale": {
+      "group-id": "40",
       "desc": "Allows you to change the font size in the extra frag messages.",
       "remarks": "See other r_tracker_* variables.",
       "type": "float"
     },
     "r_tracker_streaks": {
+      "group-id": "40",
       "desc": "Everytime a player makes a set number of consecutive kills, it will display a message showing they are on a streak, when the player is killed, it will display the name of the person who ended that streak.",
       "type": "float"
     },
     "r_tracker_string_died": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_string_enemy": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_string_suicides": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_string_teammate": {
+      "group-id": "40",
       "type": "string"
     },
     "r_tracker_time": {
+      "group-id": "40",
       "desc": "Number of seconds the tracker information is drawn on the screen.",
       "remarks": "See other \u0027r_tracker_*\u0027 variables too.",
       "type": "float",
@@ -9312,6 +11133,7 @@
       ]
     },
     "r_tracker_x": {
+      "group-id": "40",
       "desc": "Adjusts the position of extra frag messages window.",
       "remarks": "See other r_tracker_* variables description for more info.",
       "type": "integer",
@@ -9320,6 +11142,7 @@
       ]
     },
     "r_tracker_y": {
+      "group-id": "40",
       "desc": "Adjusts the position of extra frag messages window.",
       "remarks": "See other r_tracker_* variables description for more info.",
       "type": "integer",
@@ -9328,6 +11151,7 @@
       ]
     },
     "r_turbwarp": {
+      "group-id": "31",
       "remarks": "SW only!\nThis variable has the same effect as r_waterwarp in other quake clients. ",
       "type": "boolean",
       "values": [
@@ -9336,6 +11160,7 @@
       ]
     },
     "r_viewmodellastfired": {
+      "group-id": "54",
       "desc": "Display last fired weapon instead of currently held one on MVD / QTV playback.",
       "type": "boolean",
       "values": [
@@ -9344,6 +11169,7 @@
       ]
     },
     "r_viewmodeloffset": {
+      "group-id": "54",
       "desc": "Moves the gun model to the right (positive value) or to the left (negative value). Good for people who like to see right/left-handed looking weapons.",
       "remarks": "You can also change Y and Z coordinates, just provide parameters in \"X Y Z\" format.\nSee also r_shiftbeam variable.",
       "type": "string",
@@ -9352,10 +11178,12 @@
       ]
     },
     "r_viewmodelSize": {
+      "group-id": "54",
       "desc": "This allows you to change the size of the viewmodel (the model of your active \nweapon displayed on the center of your screen) a little, useful if you prefer\nto use \"r_drawviewmodel 1\" and higher fov values (for demos for example).\nFor \"fov 110\" you could try \"r_viewmodelSize 0.8\" or 0.85 for example.",
       "type": "float"
     },
     "r_viewpreselgun": {
+      "group-id": "54",
       "desc": "Will show a gun that was picked as the best by weapon pre-selection.",
       "remarks": "See cl_weaponpreselect and cl_weaponhide.",
       "type": "boolean",
@@ -9365,14 +11193,17 @@
       ]
     },
     "r_wallcolor": {
+      "group-id": "50",
       "desc": "Changes color of walls when r_drawflat is set to 1.\nEnter RGB value here, e.g. r_wallcolor \"128 128 128\" goes for gray walls.",
       "type": "string"
     },
     "r_watercolor": {
+      "group-id": "51",
       "desc": "Changes color of water when r_fastturb set to 1",
       "type": "string"
     },
     "r_zgraph": {
+      "group-id": "31",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not display the z-graph." },
@@ -9380,44 +11211,54 @@
       ]
     },
     "railcolor": {
+      "group-id": "37",
       "desc": "Player\u0027s rail color",
       "remarks": "Possible values are: 1 - 7",
       "type": "enum"
     },
     "rate": {
+      "group-id": "37",
       "desc": "Sets the maximum amount of bytes per second that the server should send to the client.",
       "type": "float"
     },
     "rcon_address": {
+      "group-id": "2",
       "desc": "Address of the server to query with remote console commands",
       "type": "string"
     },
     "rcon_password": {
+      "group-id": "2",
       "desc": "Password used for remote console communication",
       "type": "string"
     },
     "re_trigger_match_0": {
+      "group-id": "22",
       "desc": "Whole matched pattern of the regular expression match.",
       "type": "string"
     },
     "re_trigger_match_1": {
+      "group-id": "22",
       "desc": "First matched subpattern of the regexp match.",
       "type": "string"
     },
     "ruleset": {
+      "group-id": "37",
       "desc": "Enforces a set of restrictions on the client features",
       "remarks": "Most commonly used is \\\"smackdown\\\"",
       "type": "string"
     },
     "s_alsa_device": {
+      "group-id": "26",
       "desc": "Sets which device ALSA will be trying to open (when s_driver is set to alsa). Default is: \"default\", if that fails it will try \"hw\" and if that fails too, \"plug:hw\" will be tried.",
       "type": "string"
     },
     "s_alsa_latency": {
+      "group-id": "26",
       "desc": "Specifies latency for ALSA. If you got distortion in sound, upper the value a bit. If you experience delays, try lowering this value.",
       "type": "float"
     },
     "s_alsa_noworkaround": {
+      "group-id": "26",
       "desc": "If you are having problems with ALSA you can try to set this var to 1 before you try legacy drivers.",
       "remarks": "Linux/FreeBSD only.",
       "type": "enum",
@@ -9427,14 +11268,17 @@
       ]
     },
     "s_ambientfade": {
+      "group-id": "45",
       "desc": "How fast the volume of ambient sounds changes as you move around the map.",
       "type": "float"
     },
     "s_ambientlevel": {
+      "group-id": "45",
       "desc": "Volume level of ambient sounds (produced by liquid and sky brushes).",
       "type": "float"
     },
     "s_bits": {
+      "group-id": "26",
       "desc": "This defines how many sampling bits should be used, when using 16 bits the interpolation quality will be better.",
       "remarks": "Linux only.\nUse s_restart after you change it.",
       "type": "enum",
@@ -9444,10 +11288,12 @@
       ]
     },
     "s_chat_custom": {
+      "group-id": "3",
       "desc": "Controls usage of s_mm*, s_chat_*, s_otherchat_* and s_spec_* variables. ",
       "type": "enum"
     },
     "s_device": {
+      "group-id": "26",
       "desc": "Allows you to choose from multiple sound devices.\n",
       "remarks": "Linux only.\nUse snd_restart after you change it.\n\nFor OSS you should use \"/dev/dsp\", \"/dev/dsp0\", \"/dev/dsp1\", etc\nFor ALSA use \"default\", \"dmix\", etc",
       "type": "string",
@@ -9456,6 +11302,7 @@
       ]
     },
     "s_driver": {
+      "group-id": "26",
       "desc": "Specifices which sounddriver to use: ALSA/OSS or experimental Pulseaudio.\n",
       "type": "enum",
       "values": [
@@ -9465,6 +11312,7 @@
       ]
     },
     "s_khz": {
+      "group-id": "45",
       "desc": "The client includes \"sound interpolation\" which allows it to play sounds at higher frequencies, than the default 11025 Hz with perfect quality. In addition to \"s_khz\" also \"s_bits\" (linux only) will have an influence on interpolation quality. This variable allows you to choose the frequency you want to interpolate the sounds to. You will quickly discover, that the shaft sound is different at increased sampling rate. That\u0027s because shaft sounds were recorded at 22050 kHz, so probably that\u0027s how they should sound from the beginning. If you don\u0027t like it, you can always convert them to 11025.",
       "remarks": "Also you can change it \u0027on fly\u0027 - just do snd_restart after you change s_khz",
       "type": "integer",
@@ -9476,12 +11324,15 @@
       ]
     },
     "s_linearresample": {
+      "group-id": "45",
       "type": ""
     },
     "s_linearresample_stream": {
+      "group-id": "45",
       "type": ""
     },
     "s_loadas8bit": {
+      "group-id": "45",
       "remarks": "This will give a little performance boost when playing the game at the cost of \nquality for the sound samples.)",
       "type": "boolean",
       "values": [
@@ -9490,26 +11341,32 @@
       ]
     },
     "s_mixahead": {
+      "group-id": "45",
       "desc": "Only affects OSS and legacy ALSA:\n\nThis variable defines the delay time for sounds. How low you can set your sound\nmixahead depends on your FPS, when you set it too low, your sound will start \ncrackling. Generally, with 72 FPS you should be able to use a delay of 0.06 seconds.",
       "type": "float"
     },
     "s_mm1_file": {
+      "group-id": "45",
       "desc": "You can specify notification sound for messagemode1 (/messagemode or /say foo) messages.",
       "type": "string"
     },
     "s_mm1_volume": {
+      "group-id": "45",
       "desc": "You can specify volume of notification sound for messagemode1 (/messagemode or /say foo) messages.",
       "type": "float"
     },
     "s_mm2_file": {
+      "group-id": "45",
       "desc": "You can specify notification sound for messagemode2 (/messagemode2 or /say_team foo) messages.",
       "type": "string"
     },
     "s_mm2_volume": {
+      "group-id": "45",
       "desc": "You can specify volume of notification sound for messagemode2 (/messagemode2 or /say_team foo) messages.",
       "type": "float"
     },
     "s_noalsa": {
+      "group-id": "26",
       "desc": "Determinates sound output for linux clients: ALSA (0=default) or OSS.",
       "remarks": "If you dont know what is ALSA and OSS - leave it at default value.",
       "type": "enum",
@@ -9519,6 +11376,7 @@
       ]
     },
     "s_noextraupdate": {
+      "group-id": "45",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Makes Quake update its sound buffers more often to avoid choppy sound when your fps is really low (20 or worse)" },
@@ -9526,6 +11384,7 @@
       ]
     },
     "s_nosound": {
+      "group-id": "45",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Enable the playback of sounds." },
@@ -9533,18 +11392,22 @@
       ]
     },
     "s_oss_device": {
+      "group-id": "26",
       "desc": "Specifies which device OSS will try to open. Default is \"/dev/dsp\"",
       "type": "string"
     },
     "s_otherchat_file": {
+      "group-id": "45",
       "desc": "You can specify notification sound for other messages (than messagemode, messagemode2 and from spectators).",
       "type": "string"
     },
     "s_otherchat_volume": {
+      "group-id": "45",
       "desc": "You can specify volume of notification sound for other messages (than messagemode, messagemode2 and from spectators).",
       "type": "float"
     },
     "s_precache": {
+      "group-id": "45",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable automatic sound caching." },
@@ -9552,15 +11415,18 @@
       ]
     },
     "s_pulseaudio_latency": {
+      "group-id": "26",
       "desc": "Specifies latency for Pulseaudio. If you got distortion in sound, upper the value a bit. If you experience delays, try lowering this value.",
       "type": "float"
     },
     "s_raw_volume": {
+      "group-id": "45",
       "desc": "Controls volume of voice (voip) playback.",
       "remarks": "See cl_voip_play.",
       "type": "float"
     },
     "s_show": {
+      "group-id": "45",
       "desc": "Toggles displaying how many and/or which sound files are currently being played.",
       "type": "enum",
       "values": [
@@ -9570,14 +11436,17 @@
       ]
     },
     "s_spec_file": {
+      "group-id": "45",
       "desc": "You can specify notification sound for spectator messages.",
       "type": "string"
     },
     "s_spec_volume": {
+      "group-id": "45",
       "desc": "You can specify volume of notification sound for spectator messages.",
       "type": "float"
     },
     "s_stereo": {
+      "group-id": "26",
       "desc": "Use stereo or mono sound",
       "remarks": "Linux only.\nUse s_restart after you change it.",
       "type": "boolean",
@@ -9587,6 +11456,7 @@
       ]
     },
     "s_swapstereo": {
+      "group-id": "45",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Off" },
@@ -9594,6 +11464,7 @@
       ]
     },
     "s_uselegacydrivers": {
+      "group-id": "26",
       "desc": "If you are having problems with the new ALSA/OSS drivers you can enable this to be able to use legacy sound drivers, as in the ones used before v2.1.",
       "remarks": "Linux/FreeBSD only.",
       "type": "enum",
@@ -9603,6 +11474,7 @@
       ]
     },
     "samelevel": {
+      "group-id": "43",
       "desc": "When enabled, the same level will be played once the match is over",
       "type": "boolean",
       "values": [
@@ -9611,6 +11483,7 @@
       ]
     },
     "sb_autohide": {
+      "group-id": "42",
       "desc": "This toggles in which cases the server browser should automatically hide itself \nwhen connecting to a server.",
       "type": "enum",
       "values": [
@@ -9620,6 +11493,7 @@
       ]
     },
     "sb_autoupdate": {
+      "group-id": "42",
       "desc": "Enabled auto-updates (pings \u0026 refreshes status) servers from actually marked server sources in Server Browser.",
       "remarks": "Usefull with sb_starttab 1 and \u0027+cfg_load myconfig +menu_slist\u0027 in command-line.",
       "type": "boolean",
@@ -9629,6 +11503,7 @@
       ]
     },
     "sb_findroutes": {
+      "group-id": "42",
       "desc": "Enables automatic lookup of lowest ping path via proxies for connection to each server in the server browser.",
       "remarks": "Use with connectbr command.",
       "type": "boolean",
@@ -9638,6 +11513,7 @@
       ]
     },
     "sb_hidedead": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should hide dead servers.",
       "type": "boolean",
       "values": [
@@ -9646,6 +11522,7 @@
       ]
     },
     "sb_hideempty": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should hide empty servers.",
       "type": "boolean",
       "values": [
@@ -9654,6 +11531,7 @@
       ]
     },
     "sb_hidefull": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should hide full servers.",
       "type": "boolean",
       "values": [
@@ -9662,6 +11540,7 @@
       ]
     },
     "sb_hidehighping": {
+      "group-id": "42",
       "desc": "Remove servers with high ping from the server list and also exclude them from querying servers for details.",
       "type": "boolean",
       "values": [
@@ -9670,6 +11549,7 @@
       ]
     },
     "sb_hidenotempty": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should hide empty servers.",
       "type": "boolean",
       "values": [
@@ -9678,21 +11558,26 @@
       ]
     },
     "sb_ignore_proxy": {
+      "group-id": "42",
       "type": "string"
     },
     "sb_inforetries": {
+      "group-id": "42",
       "desc": "This determines how often ezQuake should try to retrieve information from a server \nuntil it is considered to be not responding.",
       "type": "float"
     },
     "sb_infospersec": {
+      "group-id": "42",
       "desc": "This determines how many serverinfos per second ezQuake should retrieve when \nscanning servers. When setting this value too high you will flood your line,\ncausing you to not receive information from servers or lagging your connect\nto the server you are currently connected to.",
       "type": "float"
     },
     "sb_infotimeout": {
+      "group-id": "42",
       "desc": "This determines how long ezQuake will wait for a reply when trying to retrieve\ninformation from a server until the attempt times out.",
       "type": "float"
     },
     "sb_listcache": {
+      "group-id": "42",
       "desc": "Cache the list of alive servers and load it on next startup of the client.",
       "type": "boolean",
       "values": [
@@ -9701,10 +11586,12 @@
       ]
     },
     "sb_liveupdate": {
+      "group-id": "42",
       "desc": "This will determine how often ezQuake should refresh the serverinfo window, the\nspecified value sets the delay in seconds. Setting it to \"0\" will disable\nautomatic refreshing.",
       "type": "float"
     },
     "sb_mastercache": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should cache the results of queries to master server \n(in directory qw/sb/cache). If you restart ezQuake and don\u0027t update sources or if \na master server is down, ezQuake will use the cache.",
       "type": "boolean",
       "values": [
@@ -9713,14 +11600,17 @@
       ]
     },
     "sb_masterretries": {
+      "group-id": "42",
       "desc": "This determines how often ezQuake should try to retrieve information from a master \nserver until it is considered to be not responding.",
       "type": "float"
     },
     "sb_mastertimeout": {
+      "group-id": "42",
       "desc": "This determines how long ezQuake will wait for a reply when trying to retrieve\ninformation from a master server until the attempt times out.",
       "type": "float"
     },
     "sb_nosockraw": {
+      "group-id": "42",
       "desc": "Disable ICMP pinging in server browser and use UDP QW Ping packet to query servers for their ping (multithreaded).",
       "type": "boolean",
       "values": [
@@ -9729,31 +11619,39 @@
       ]
     },
     "sb_pinglimit": {
+      "group-id": "42",
       "desc": "Limit ping for servers to be visible when sb_hidehighping is enabled.",
       "type": "integer"
     },
     "sb_pings": {
+      "group-id": "42",
       "desc": "This determines how many pings ezQuake will send to a server when trying to\ndetermine your ping to it. A higher value will cause scanning servers to take\nlonger, but the result may be more exact. A lower value obviously makes scanning\nfaster, but pings may be inaccurate.",
       "type": "float"
     },
     "sb_pingspersec": {
+      "group-id": "42",
       "desc": "This determines how many pings per second ezQuake should sent out when scanning\nservers. If you set this value too high the result will be that the pings will \nnot be accurate because you overloaded your line. If you set it too low scanning \nservers will take very long especially when you have a large server list.",
       "type": "float"
     },
     "sb_pingtimeout": {
+      "group-id": "42",
       "desc": "This determines how long ezQuake will wait for a reply when trying to ping a \nserver until the attempt times out.",
       "type": "float"
     },
     "sb_proxinfopersec": {
+      "group-id": "42",
       "type": ""
     },
     "sb_proxretries": {
+      "group-id": "42",
       "type": ""
     },
     "sb_proxtimeout": {
+      "group-id": "42",
       "type": ""
     },
     "sb_showaddress": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should display the server IP column in the server\nlist.",
       "type": "boolean",
       "values": [
@@ -9762,6 +11660,7 @@
       ]
     },
     "sb_showcounters": {
+      "group-id": "31",
       "desc": "This toggles whether ezQuake should display the number of servers or players in\nthe status line.",
       "type": "boolean",
       "values": [
@@ -9770,6 +11669,7 @@
       ]
     },
     "sb_showfraglimit": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should display the fraglimit column in the server\nlist.",
       "type": "boolean",
       "values": [
@@ -9778,6 +11678,7 @@
       ]
     },
     "sb_showgamedir": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should display the gamedir column in the server list,\nfor example to see which mod is being played.",
       "type": "boolean",
       "values": [
@@ -9786,6 +11687,7 @@
       ]
     },
     "sb_showmap": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should display the map column in the server list.",
       "type": "boolean",
       "values": [
@@ -9794,6 +11696,7 @@
       ]
     },
     "sb_showping": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should display the ping column in the server list.",
       "type": "boolean",
       "values": [
@@ -9802,6 +11705,7 @@
       ]
     },
     "sb_showplayers": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should display the players column in the server list\nthat shows how many players are on the server as well as how many players are \nallowed.",
       "type": "boolean",
       "values": [
@@ -9810,10 +11714,12 @@
       ]
     },
     "sb_showproxies": {
+      "group-id": "42",
       "desc": "Toggle display of proxy servers (QWFwd and Qizmo) in the Server Browser.",
       "type": "enum"
     },
     "sb_showtimelimit": {
+      "group-id": "42",
       "desc": "This toggles whether ezQuake should display the timelimit column in the server \nlist.",
       "type": "boolean",
       "values": [
@@ -9822,14 +11728,17 @@
       ]
     },
     "sb_sortplayers": {
+      "group-id": "42",
       "desc": "This determines sort order in the players list. This uses the numbers from the\ndescription of the columns. Check \"Columns available in servers/players list\"\nabove for an explanation of each number. A \"-\" in front of the value reverses \nthe sort order for that value from ascending to descending.\naddress (ip:port).",
       "type": "float"
     },
     "sb_sortservers": {
+      "group-id": "42",
       "desc": "This determines sort order in the servers list. This uses the numbers from the\ndescription of the columns. Check \"Columns available in servers/players list\" \nabove for an explanation of each number. A \"-\" in front of the value reverses \nthe sort order for that value from ascending to descending.\nserver address (ip:port).",
       "type": "float"
     },
     "sb_sortsources": {
+      "group-id": "42",
       "desc": "Ordering instructions for server browser sources list are stored in this variable. You can order source server in Server browser by pressing Ctrl+1, Ctrl+2 and Ctrl+3. Sequence of your desired combination will be stored in this variable, newest keys first.",
       "type": "string",
       "values": [
@@ -9837,10 +11746,12 @@
       ]
     },
     "sb_sourcevalidity": {
+      "group-id": "42",
       "desc": "This sets the time of master servers validity in minutes. Master servers that\nwere updated within the specified time will not be refreshed when updating \nsources with [SPACE].",
       "type": "float"
     },
     "sb_status": {
+      "group-id": "42",
       "desc": "This toggles whether the server status should be displayed in the two bottom \nlines of the server browser.",
       "type": "boolean",
       "values": [
@@ -9849,6 +11760,7 @@
       ]
     },
     "scr_allowsnap": {
+      "group-id": "41",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable" },
@@ -9856,6 +11768,7 @@
       ]
     },
     "scr_autoid": {
+      "group-id": "40",
       "remarks": "Only works when spectating. You can remove the drawing of the playername by using scr_autoid_drawname 0.",
       "type": "enum",
       "values": [
@@ -9868,9 +11781,11 @@
       ]
     },
     "scr_autoid_barlength": {
+      "group-id": "40",
       "type": ""
     },
     "scr_autoid_drawname": {
+      "group-id": "31",
       "desc": "Controls if the player name should be drawn when using scr_autoid \u003e0.",
       "type": "boolean",
       "values": [
@@ -9879,18 +11794,23 @@
       ]
     },
     "scr_autoid_namelength": {
+      "group-id": "40",
       "type": ""
     },
     "scr_autoid_scale": {
+      "group-id": "40",
       "type": ""
     },
     "scr_autoid_weaponicon": {
+      "group-id": "40",
       "type": ""
     },
     "scr_autoid_weapons": {
+      "group-id": "40",
       "type": ""
     },
     "scr_centerMenu": {
+      "group-id": "17",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Off." },
@@ -9898,6 +11818,7 @@
       ]
     },
     "scr_centerSbar": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Off." },
@@ -9905,6 +11826,7 @@
       ]
     },
     "scr_centershift": {
+      "group-id": "40",
       "desc": "Shifts all centerprints. If you are playing in 1280x1024 and want to watch some demo recorded in 320x200 with +wp_stats (ktpro) or sbar_on (teamfortress) you can shift that text down.",
       "type": "integer",
       "values": [
@@ -9912,6 +11834,7 @@
       ]
     },
     "scr_centertime": {
+      "group-id": "40",
       "desc": "This variable sets the amount of time in seconds that centerprinted messages \nstay on the screen.",
       "type": "enum",
       "values": [
@@ -9921,6 +11844,7 @@
       ]
     },
     "scr_coloredfrags": {
+      "group-id": "40",
       "desc": "Frag messages will be colored according to your teamcolor/enemycolor settings.",
       "remarks": "Needs scr_coloredText 1, cl_parsefrags 1, cl_loadfragfiles 1.",
       "type": "boolean",
@@ -9930,6 +11854,7 @@
       ]
     },
     "scr_coloredText": {
+      "group-id": "40",
       "desc": "Allows colored text in scoreboard, console and notify area.\nscr_coloredText",
       "remarks": "See Colored text manual page for more details.",
       "type": "enum",
@@ -9940,6 +11865,7 @@
       ]
     },
     "scr_compactHud": {
+      "group-id": "47",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Compact huds off." },
@@ -9950,6 +11876,7 @@
       ]
     },
     "scr_compactHudAlign": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "determine ammo amounts are aligned to the left." },
@@ -9957,6 +11884,7 @@
       ]
     },
     "scr_conalpha": {
+      "group-id": "5",
       "type": "float",
       "values": [
         { "name": "0", "description": "Transparent." },
@@ -9964,6 +11892,7 @@
       ]
     },
     "scr_conback": {
+      "group-id": "5",
       "desc": "Allows display of map preview as a console background",
       "type": "enum",
       "values": [
@@ -9973,11 +11902,13 @@
       ]
     },
     "scr_conpicture": {
+      "group-id": "5",
       "desc": "Console background image filename.",
       "remarks": "Put console images into id1/gfx or qw/gfx or ezquake/gfx",
       "type": "string"
     },
     "scr_consize": {
+      "group-id": "5",
       "type": "float",
       "values": [
         { "name": "0", "description": "Minimal console height." },
@@ -9985,30 +11916,37 @@
       ]
     },
     "scr_conspeed": {
+      "group-id": "5",
       "desc": "This variable controls the speed at which the console screen scrolls up and down.",
       "type": "float"
     },
     "scr_cursor_alpha": {
+      "group-id": "17",
       "desc": "Level of transparency of the cursor used in menus and HUD editor.",
       "type": "float"
     },
     "scr_cursor_iconoffset_x": {
+      "group-id": "17",
       "desc": "Offset of the cursor image used in menus and HUD editor.",
       "type": "integer"
     },
     "scr_cursor_iconoffset_y": {
+      "group-id": "17",
       "desc": "Offset of the cursor image used in menus and HUD editor.",
       "type": "integer"
     },
     "scr_cursor_scale": {
+      "group-id": "17",
       "desc": "Size of the cursor image used in menus and HUD editor.",
       "type": "float"
     },
     "scr_cursor_sensitivity": {
+      "group-id": "17",
       "desc": "Mouse sensitivity for the cursor used in menus and HUD editor.",
       "type": "float"
     },
     "scr_drawHFrags": {
+      "group-id": "47",
       "desc": "Displays horizontal bar with frag stats (4 cells) in the old hud.",
       "remarks": "Required settings for this to work: scr_newhud 0 or 2, viewsize below 110, cl_sbar 1 or cl_sbar 0 but vid_conwidth below 512; if you migrated from FuhQuake and can\u0027t get this to work, check these settings, the feature should work the same as in FuhQuake",
       "type": "enum",
@@ -10019,6 +11957,7 @@
       ]
     },
     "scr_drawVFrags": {
+      "group-id": "47",
       "desc": "Shows vertical row with frag stats on the right side of the old hud. When teamplay mode is on, will display also frags per team.",
       "remarks": "Note: vid_conwidth must be at least 512, scr_centerSbar must be disabled; works only in deathmatch, not in cooperative",
       "type": "enum",
@@ -10029,6 +11968,7 @@
       ]
     },
     "scr_menualpha": {
+      "group-id": "40",
       "type": "float",
       "values": [
         { "name": "0", "description": "Transparent mainmenu." },
@@ -10036,6 +11976,7 @@
       ]
     },
     "scr_menudrawhud": {
+      "group-id": "40",
       "desc": "Draw HUD elements/crosshair/etc in background of main menu. Useful when HUD distracting you in server browser.",
       "type": "boolean",
       "values": [
@@ -10044,6 +11985,7 @@
       ]
     },
     "scr_newhud": {
+      "group-id": "47",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Old standard status bar" },
@@ -10052,6 +11994,7 @@
       ]
     },
     "scr_newhud_clear": {
+      "group-id": "47",
       "desc": "Force full screen refresh on low viewsize values to prevent uncleared HUD elements background.",
       "type": "boolean",
       "values": [
@@ -10060,13 +12003,16 @@
       ]
     },
     "scr_notifyalways": {
+      "group-id": "40",
       "type": ""
     },
     "scr_printspeed": {
+      "group-id": "5",
       "desc": "This variable controls how fast the text is displayed at the end of the single \nplayer episodes.",
       "type": "float"
     },
     "scr_qtvbuffer": {
+      "group-id": "40",
       "desc": "Enables display of the QTV buffer status",
       "remarks": "Makes it able to check how much of the stream is buffered on the client side",
       "type": "boolean",
@@ -10076,14 +12022,17 @@
       ]
     },
     "scr_qtvbuffer_x": {
+      "group-id": "40",
       "desc": "Horizontal position of the qtvbuffer counter",
       "type": "integer"
     },
     "scr_qtvbuffer_y": {
+      "group-id": "40",
       "desc": "Vertical position of the qtvbuffer counter",
       "type": "integer"
     },
     "scr_sbar_drawammo": {
+      "group-id": "47",
       "desc": "Turns drawing amount of ammo on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10093,6 +12042,7 @@
       ]
     },
     "scr_sbar_drawammocounts": {
+      "group-id": "47",
       "desc": "Turns drawing amounts of ammo on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10102,6 +12052,7 @@
       ]
     },
     "scr_sbar_drawammoicon": {
+      "group-id": "47",
       "desc": "Turns drawing of ammo icon on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10111,6 +12062,7 @@
       ]
     },
     "scr_sbar_drawarmor": {
+      "group-id": "47",
       "desc": "Turns drawing of armor count on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10120,6 +12072,7 @@
       ]
     },
     "scr_sbar_drawarmoricon": {
+      "group-id": "47",
       "desc": "Turns drawing of armor icon on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10129,6 +12082,7 @@
       ]
     },
     "scr_sbar_drawfaceicon": {
+      "group-id": "47",
       "desc": "Turns drawing of face icon on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10138,6 +12092,7 @@
       ]
     },
     "scr_sbar_drawguns": {
+      "group-id": "47",
       "desc": "Turns drawing of available guns on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10147,6 +12102,7 @@
       ]
     },
     "scr_sbar_drawhealth": {
+      "group-id": "47",
       "desc": "Turns drawing of health amount on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10156,6 +12112,7 @@
       ]
     },
     "scr_sbar_drawitems": {
+      "group-id": "47",
       "desc": "Turns drawing of items (powerups and keys) in status bar on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10165,6 +12122,7 @@
       ]
     },
     "scr_sbar_drawsigils": {
+      "group-id": "47",
       "desc": "Turns drawing of sigils on/off.",
       "remarks": "This variable applies for old HUD \u003c= \u0027scr_newhud 0\u0027.",
       "type": "boolean",
@@ -10174,6 +12132,7 @@
       ]
     },
     "scr_scaleMenu": {
+      "group-id": "17",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable scaling." },
@@ -10181,12 +12140,15 @@
       ]
     },
     "scr_scoreboard_afk": {
+      "group-id": "47",
       "type": ""
     },
     "scr_scoreboard_afk_style": {
+      "group-id": "47",
       "type": ""
     },
     "scr_scoreboard_borderless": {
+      "group-id": "47",
       "desc": "Controls scoreboard border behavior",
       "type": "boolean",
       "values": [
@@ -10195,6 +12157,7 @@
       ]
     },
     "scr_scoreboard_centered": {
+      "group-id": "47",
       "desc": "Controls X-position of scoreboard",
       "type": "boolean",
       "values": [
@@ -10203,10 +12166,12 @@
       ]
     },
     "scr_scoreboard_death_color": {
+      "group-id": "47",
       "desc": "Changes the color of the \"dths\" (deaths) column in your scoreboard when \u003e0. Uses RGB values.",
       "type": "string"
     },
     "scr_scoreboard_drawfps": {
+      "group-id": "40",
       "desc": "Substitutes the \"time\" column with a \"FPS\" in scores showing how much FPS each player has.",
       "type": "boolean",
       "values": [
@@ -10215,6 +12180,7 @@
       ]
     },
     "scr_scoreboard_drawtitle": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable scoreboard title." },
@@ -10222,6 +12188,7 @@
       ]
     },
     "scr_scoreboard_fadescreen": {
+      "group-id": "47",
       "desc": "shadowing level, when scoreboard is displayed.",
       "type": "float",
       "values": [
@@ -10229,14 +12196,17 @@
       ]
     },
     "scr_scoreboard_fillalpha": {
+      "group-id": "47",
       "desc": "Change scoreboard fillalpha.",
       "type": "float"
     },
     "scr_scoreboard_fillcolored": {
+      "group-id": "47",
       "desc": "Modify scoreboard fillcolour.",
       "type": "float"
     },
     "scr_scoreboard_forcecolors": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "When you overwrite team/enemy color it will use only those colors for skins" },
@@ -10244,10 +12214,12 @@
       ]
     },
     "scr_scoreboard_kill_color": {
+      "group-id": "47",
       "desc": "Changes the color of the \"kills\" column in your scoreboard when \u003e0. Uses RGB values.",
       "type": "string"
     },
     "scr_scoreboard_posx": {
+      "group-id": "47",
       "desc": "Controls the X-offset of the scoreboard.",
       "type": "integer",
       "values": [
@@ -10255,6 +12227,7 @@
       ]
     },
     "scr_scoreboard_posy": {
+      "group-id": "47",
       "desc": "Controls the Y-offset of the scoreboard.",
       "type": "integer",
       "values": [
@@ -10262,6 +12235,7 @@
       ]
     },
     "scr_scoreboard_showfrags": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable frags on the scoreboard." },
@@ -10269,10 +12243,12 @@
       ]
     },
     "scr_scoreboard_spectator_name": {
+      "group-id": "47",
       "desc": "This variable will change what spectators are called in the scoreboard. When teamplay is not on, this variable is cut to 4 characters. \u0026cRGB values are not accepted.",
       "type": "string"
     },
     "scr_scoreboard_teamsort": {
+      "group-id": "47",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Frag sort." },
@@ -10280,10 +12256,12 @@
       ]
     },
     "scr_scoreboard_tk_color": {
+      "group-id": "47",
       "desc": "Changes the color of the \"tks\" column in your scoreboard when \u003e0. Uses RGB values.",
       "type": "string"
     },
     "scr_showcrosshair": {
+      "group-id": "40",
       "desc": "Allows you to force the display of the crosshair when in menus or in scoreboard",
       "type": "boolean",
       "values": [
@@ -10292,29 +12270,37 @@
       ]
     },
     "scr_shownick_frame_color": {
+      "group-id": "40",
       "type": "string"
     },
     "scr_shownick_name_width": {
+      "group-id": "40",
       "type": ""
     },
     "scr_shownick_order": {
+      "group-id": "40",
       "type": "string"
     },
     "scr_shownick_scale": {
+      "group-id": "40",
       "type": ""
     },
     "scr_shownick_time": {
+      "group-id": "40",
       "type": "float"
     },
     "scr_shownick_x": {
+      "group-id": "40",
       "desc": "Horizontal position of the shownick label",
       "type": "integer"
     },
     "scr_shownick_y": {
+      "group-id": "40",
       "desc": "Vertical position of the shownick label",
       "type": "integer"
     },
     "scr_spectatorMessage": {
+      "group-id": "40",
       "desc": "Switch on/off the text at the bottom of the screen when spectating in free mode: \"SPECTATOR MODE | PRESS [ATTACK] for AutoCamera\"",
       "type": "boolean",
       "values": [
@@ -10323,6 +12309,7 @@
       ]
     },
     "scr_teaminfo": {
+      "group-id": "40",
       "desc": "Displays team info when you are spectating or watching mvd demo.",
       "remarks": "see scr_teaminfo_* for other options.",
       "type": "boolean",
@@ -10332,6 +12319,7 @@
       ]
     },
     "scr_teaminfo_align_right": {
+      "group-id": "40",
       "desc": "Aligns scr_teaminfo left or right",
       "type": "boolean",
       "values": [
@@ -10340,6 +12328,7 @@
       ]
     },
     "scr_teaminfo_armor_style": {
+      "group-id": "40",
       "desc": "Changes %a to different styles.",
       "type": "enum",
       "values": [
@@ -10350,6 +12339,7 @@
       ]
     },
     "scr_teaminfo_frame_color": {
+      "group-id": "40",
       "desc": "Changes the color and transparency of scr_teaminfo\u0027s frame.",
       "type": "string",
       "values": [
@@ -10357,6 +12347,7 @@
       ]
     },
     "scr_teaminfo_loc_width": {
+      "group-id": "40",
       "desc": "Sets the width for %l",
       "type": "integer",
       "values": [
@@ -10364,6 +12355,7 @@
       ]
     },
     "scr_teaminfo_low_health": {
+      "group-id": "40",
       "desc": "Sets a minimum health value to display red. E.g. if scr_teaminfo_low_health is 20, and a teammate has 20 health or less, then their health will be displayed red.",
       "type": "float",
       "values": [
@@ -10371,6 +12363,7 @@
       ]
     },
     "scr_teaminfo_name_width": {
+      "group-id": "40",
       "desc": "Sets name width in scr_teaminfo",
       "type": "integer",
       "values": [
@@ -10378,6 +12371,7 @@
       ]
     },
     "scr_teaminfo_order": {
+      "group-id": "40",
       "desc": "Changes the order of displayed items in scr_teaminfo",
       "remarks": "default: \"%p%n [%l] %h/%a %w\"",
       "type": "string",
@@ -10386,9 +12380,11 @@
       ]
     },
     "scr_teaminfo_powerup_style": {
+      "group-id": "40",
       "type": ""
     },
     "scr_teaminfo_scale": {
+      "group-id": "40",
       "desc": "Scales scr_teaminfo.",
       "type": "float",
       "values": [
@@ -10396,6 +12392,7 @@
       ]
     },
     "scr_teaminfo_show_enemies": {
+      "group-id": "40",
       "desc": "Will show enemy players in the teaminfo table.",
       "remarks": "Works only for MVD playback (servers do not send info about enemies to you anyway).",
       "type": "boolean",
@@ -10405,6 +12402,7 @@
       ]
     },
     "scr_teaminfo_show_self": {
+      "group-id": "40",
       "desc": "Will show row with the status of the current player in the teaminfo table.",
       "type": "enum",
       "values": [
@@ -10414,6 +12412,7 @@
       ]
     },
     "scr_teaminfo_weapon_style": {
+      "group-id": "40",
       "desc": "Changes %w to different styles.",
       "type": "boolean",
       "values": [
@@ -10422,6 +12421,7 @@
       ]
     },
     "scr_teaminfo_x": {
+      "group-id": "40",
       "desc": "Moves scr_teaminfo in the x-direction",
       "type": "integer",
       "values": [
@@ -10429,6 +12429,7 @@
       ]
     },
     "scr_teaminfo_y": {
+      "group-id": "40",
       "desc": "Moves scr_teaminfo in the y-direction",
       "type": "integer",
       "values": [
@@ -10436,6 +12437,7 @@
       ]
     },
     "scr_tracking": {
+      "group-id": "40",
       "desc": "Changes the format of descriptive text displayed when you are tracking someone as spectator or watching a demo where you can see player\u0027s team and name.",
       "remarks": "This variable affects scr_newhud 0. To change same text in new HUD (scr_newhud 1) use /tracking format (hud_tracking_format) settings.",
       "type": "string",
@@ -10444,6 +12446,7 @@
       ]
     },
     "scr_weaponstats": {
+      "group-id": "40",
       "desc": "Displays weapons stats on server that support it",
       "type": "boolean",
       "values": [
@@ -10452,31 +12455,39 @@
       ]
     },
     "scr_weaponstats_align_right": {
+      "group-id": "40",
       "type": ""
     },
     "scr_weaponstats_frame_color": {
+      "group-id": "40",
       "type": "string"
     },
     "scr_weaponstats_order": {
+      "group-id": "40",
       "desc": "Accept next tokens %1 %2 %3 ... %8 which expands in to weapons accuracy, %1 - axe, %2 - sg ... %8 - lg.\n\nBut, for axe accuracy is useless, so better use direct hits instead, for that you must use it like #1.\n\nUnrecognized tokens printed as-is, so for axe order will looks like \"axe: #1\" - that means print string \"axe: \" and axe hits.\n\nAlso variable supports ezquake color sequences.",
       "type": "string"
     },
     "scr_weaponstats_scale": {
+      "group-id": "40",
       "type": ""
     },
     "scr_weaponstats_x": {
+      "group-id": "40",
       "desc": "Horizontal placement of the weapon stats table",
       "type": "integer"
     },
     "scr_weaponstats_y": {
+      "group-id": "40",
       "desc": "Vertical placement of the weapon stats table",
       "type": "integer"
     },
     "sensitivity": {
+      "group-id": "10",
       "desc": "This variable sets the sensitivity of the mouse, it is one of the most important \nvariables in the whole game.",
       "type": "float"
     },
     "show_fps": {
+      "group-id": "40",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disables the display of the frames-per-second value." },
@@ -10484,14 +12495,17 @@
       ]
     },
     "show_fps_x": {
+      "group-id": "40",
       "desc": "Determine where the show_fps is positioned on your screen on the X co-ordinate.",
       "type": "float"
     },
     "show_fps_y": {
+      "group-id": "40",
       "desc": "Determine where the show_fps is positioned on your screen on the Y co-ordinate.",
       "type": "float"
     },
     "show_speed": {
+      "group-id": "40",
       "desc": "Displays a speed counter in the top right corner in the client\u0027s units (Horizontal velocity). (320 - Normal walking speed, 440 - Accel jump, 450 - Bunnyhopping)",
       "type": "enum",
       "values": [
@@ -10501,14 +12515,17 @@
       ]
     },
     "show_speed_x": {
+      "group-id": "40",
       "desc": "Determine where the show_speed is positioned on your screen on the X co-ordinate.",
       "type": "float"
     },
     "show_speed_y": {
+      "group-id": "40",
       "desc": "Determine where the show_speed is positioned on your screen on the Y co-ordinate.",
       "type": "float"
     },
     "show_velocity_3d": {
+      "group-id": "40",
       "desc": "Shows your velocity as 3d vector and its projections (*GL ONLY*).\n",
       "remarks": "See also show_velocity_3d_offset_forward, show_velocity_3d_offset_down.",
       "type": "enum",
@@ -10519,12 +12536,15 @@
       ]
     },
     "show_velocity_3d_offset_down": {
+      "group-id": "40",
       "type": ""
     },
     "show_velocity_3d_offset_forward": {
+      "group-id": "40",
       "type": "float"
     },
     "showdrop": {
+      "group-id": "40",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable text dump printing dropped packets" },
@@ -10532,6 +12552,7 @@
       ]
     },
     "showpackets": {
+      "group-id": "40",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Do not display information about all network packets." },
@@ -10539,6 +12560,7 @@
       ]
     },
     "showpause": {
+      "group-id": "40",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Never display the pause icon." },
@@ -10546,6 +12568,7 @@
       ]
     },
     "showram": {
+      "group-id": "40",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Never display the ram icon" },
@@ -10553,6 +12576,7 @@
       ]
     },
     "showturtle": {
+      "group-id": "40",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Never display the turtle icon." },
@@ -10560,6 +12584,7 @@
       ]
     },
     "skill": {
+      "group-id": "43",
       "type": "enum",
       "values": [
         { "name": "0", "description": "easy level for singleplaying." },
@@ -10569,22 +12594,27 @@
       ]
     },
     "skin": {
+      "group-id": "37",
       "desc": "Sets the skin name for the player.",
       "type": "string"
     },
     "skin_browser_democolor": {
+      "group-id": "25",
       "desc": "Color of the demo entries in the skin browser",
       "type": "string"
     },
     "skin_browser_dircolor": {
+      "group-id": "25",
       "desc": "Color of the dir entries in the skin browser",
       "type": "string"
     },
     "skin_browser_interline": {
+      "group-id": "25",
       "desc": "Size of the space between entries in the skin browser",
       "type": "integer"
     },
     "skin_browser_scrollnames": {
+      "group-id": "25",
       "desc": "Toggle scrolling of the filenames in the skin browser",
       "type": "boolean",
       "values": [
@@ -10593,10 +12623,12 @@
       ]
     },
     "skin_browser_selectedcolor": {
+      "group-id": "25",
       "desc": "Color of the selected entries in the skin browser",
       "type": "string"
     },
     "skin_browser_showdate": {
+      "group-id": "25",
       "desc": "Toggle the date column in the skin browser",
       "type": "boolean",
       "values": [
@@ -10605,6 +12637,7 @@
       ]
     },
     "skin_browser_showsize": {
+      "group-id": "25",
       "desc": "Toggle the file size column in the skin browser",
       "type": "boolean",
       "values": [
@@ -10613,6 +12646,7 @@
       ]
     },
     "skin_browser_showstatus": {
+      "group-id": "25",
       "desc": "Toggle the display of the status bar in the skin browser",
       "type": "boolean",
       "values": [
@@ -10621,6 +12655,7 @@
       ]
     },
     "skin_browser_showtime": {
+      "group-id": "25",
       "desc": "Toggle the time column in the skin browser",
       "type": "boolean",
       "values": [
@@ -10629,10 +12664,12 @@
       ]
     },
     "skin_browser_sortmode": {
+      "group-id": "25",
       "desc": "Sorting mode in the skin browser. Each number represents one column. Their order represents the priority of the sorting.",
       "type": "string"
     },
     "skin_browser_stripnames": {
+      "group-id": "25",
       "desc": "Toggle stripping of the filenames in the skin browser",
       "type": "boolean",
       "values": [
@@ -10641,10 +12678,12 @@
       ]
     },
     "skin_browser_zipcolor": {
+      "group-id": "25",
       "desc": "Color of the zip entries in the skin browser",
       "type": "string"
     },
     "spectator": {
+      "group-id": "37",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Join to server as player." },
@@ -10652,10 +12691,12 @@
       ]
     },
     "spectator_password": {
+      "group-id": "43",
       "desc": "A password spectators must use to connect to local server",
       "type": "string"
     },
     "sshot_autoname": {
+      "group-id": "41",
       "desc": "Add the map name as screenshot filename prefix.",
       "type": "boolean",
       "values": [
@@ -10664,35 +12705,44 @@
       ]
     },
     "sshot_dir": {
+      "group-id": "41",
       "desc": "Change the screenshot directory.",
       "type": "string"
     },
     "sshot_format": {
+      "group-id": "41",
       "desc": "tga = Tga screenshots (gl only)\npng = Png screenshots\njpg = Jpg screenshots (gl only)\npcx = Pcx screenshots (software only)",
       "type": "string"
     },
     "sv_accelerate": {
+      "group-id": "43",
       "desc": "Sets the acceleration value for the player.",
       "type": "float"
     },
     "sv_admininfo": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_aim": {
+      "group-id": "43",
       "desc": "Sets the value for auto-aiming leniency.",
       "type": "float"
     },
     "sv_airaccelerate": {
+      "group-id": "43",
       "desc": "Sets how quickly the player accelerates in air.",
       "type": "float"
     },
     "sv_allowlastscores": {
+      "group-id": "43",
       "type": ""
     },
     "sv_bigcoords": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_cheats": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable cheats." },
@@ -10700,78 +12750,102 @@
       ]
     },
     "sv_cpserver": {
+      "group-id": "43",
       "type": ""
     },
     "sv_crypt_rcon": {
+      "group-id": "43",
       "type": ""
     },
     "sv_cullentities": {
+      "group-id": "43",
       "type": ""
     },
     "sv_default_name": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_demoClearOld": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demoDir": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_demoExtraNames": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demofps": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demoIdlefps": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demoMaxDirSize": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demoMaxSize": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demonovis": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demopings": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demoPrefix": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_demoRegexp": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_demoSuffix": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_demotxt": {
+      "group-id": "43",
       "type": ""
     },
     "sv_demoUseCache": {
+      "group-id": "43",
       "type": ""
     },
     "sv_downloadchunksperframe": {
+      "group-id": "43",
       "desc": "Limits the speed of the chunked downloads",
       "remarks": "Server-side. Clients can set high amount of chunks per frame allowed and make your data eat connection traffic rapidly. Use this variable to prevent this.",
       "type": ""
     },
     "sv_enable_cmd_minping": {
+      "group-id": "43",
       "type": ""
     },
     "sv_enableprofile": {
+      "group-id": "43",
       "type": ""
     },
     "sv_fastconnect": {
+      "group-id": "43",
       "desc": "actually no help.",
       "type": "float"
     },
     "sv_forcenick": {
+      "group-id": "43",
       "type": ""
     },
     "sv_forcenqprogs": {
+      "group-id": "43",
       "desc": "Force loading of NetQuake progs - if progs.dat (typically from Quake 1 sigle player / mods) is present in the gamedir, it will be preferred over qwprogs.dat and spprogs.dat (QW game mods).",
       "type": "boolean",
       "values": [
@@ -10780,23 +12854,29 @@
       ]
     },
     "sv_forcespec_onfull": {
+      "group-id": "43",
       "type": ""
     },
     "sv_friction": {
+      "group-id": "43",
       "desc": "Sets the friction value for the player.",
       "type": "float"
     },
     "sv_getrealip": {
+      "group-id": "43",
       "type": ""
     },
     "sv_gravity": {
+      "group-id": "43",
       "desc": "Sets the global value for the amount of gravity.",
       "type": "float"
     },
     "sv_hashpasswords": {
+      "group-id": "43",
       "type": ""
     },
     "sv_highchars": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -10804,18 +12884,23 @@
       ]
     },
     "sv_kicktop": {
+      "group-id": "43",
       "type": ""
     },
     "sv_kickuserinfospamcount": {
+      "group-id": "43",
       "type": ""
     },
     "sv_kickuserinfospamtime": {
+      "group-id": "43",
       "type": ""
     },
     "sv_ktpro_mode": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_loadentfiles": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable." },
@@ -10823,12 +12908,15 @@
       ]
     },
     "sv_logdir": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_login": {
+      "group-id": "43",
       "type": ""
     },
     "sv_mapcheck": {
+      "group-id": "43",
       "remarks": "Note: A player who has edited his map files to cheat by removing textures \nfrom walls will not be able to join the server and play.",
       "type": "boolean",
       "values": [
@@ -10837,12 +12925,15 @@
       ]
     },
     "sv_maxdownloadrate": {
+      "group-id": "43",
       "type": ""
     },
     "sv_maxlogsize": {
+      "group-id": "43",
       "type": ""
     },
     "sv_maxpitch": {
+      "group-id": "43",
       "desc": "server-side variable for setting maximum of view angles",
       "remarks": "EZQuake and ZQuake (may be some other) clients understand this physics change, old clients will be clamped at [-70~80] (quakeworld default) view angles.",
       "type": "integer",
@@ -10851,28 +12942,35 @@
       ]
     },
     "sv_maxrate": {
+      "group-id": "43",
       "desc": "Maximum rate for clients.",
       "type": "float"
     },
     "sv_maxspeed": {
+      "group-id": "43",
       "desc": "Sets the maximum speed a player can move.",
       "type": "float"
     },
     "sv_maxtic": {
+      "group-id": "43",
       "desc": "The maximum amount of time in seconds before a client a receives an update \nfrom the server.",
       "type": "float"
     },
     "sv_maxuploadsize": {
+      "group-id": "43",
       "type": ""
     },
     "sv_maxvelocity": {
+      "group-id": "43",
       "desc": "Sets the maximum velocity an object can travel.",
       "type": "float"
     },
     "sv_minping": {
+      "group-id": "43",
       "type": ""
     },
     "sv_minpitch": {
+      "group-id": "43",
       "desc": "server-side variable for setting minimum of view angles",
       "remarks": "EZQuake and ZQuake (may be some other) clients understand this physics change, old clients will be clamped at [-70~80] (quakeworld default) view angles.",
       "type": "integer",
@@ -10881,13 +12979,16 @@
       ]
     },
     "sv_mintic": {
+      "group-id": "43",
       "desc": "The minimum amount of time the server will wait before sending packets to \na client.",
       "type": "float"
     },
     "sv_mod_msg_file": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_nailhack": {
+      "group-id": "43",
       "remarks": "smoother and point in the right direction.",
       "type": "boolean",
       "values": [
@@ -10896,12 +12997,15 @@
       ]
     },
     "sv_onDemoRemove": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_onRecordFinish": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_paused": {
+      "group-id": "43",
       "desc": "read-only variable that gives you current pause state (condition).",
       "type": "enum",
       "values": [
@@ -10912,6 +13016,7 @@
       ]
     },
     "sv_phs": {
+      "group-id": "43",
       "remarks": "of the map.",
       "type": "boolean",
       "values": [
@@ -10920,33 +13025,43 @@
       ]
     },
     "sv_progsname": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_progtype": {
+      "group-id": "43",
       "type": ""
     },
     "sv_qwfwd_port": {
+      "group-id": "43",
       "type": ""
     },
     "sv_rconlim": {
+      "group-id": "43",
       "type": ""
     },
     "sv_reconnectlimit": {
+      "group-id": "43",
       "type": ""
     },
     "sv_registrationinfo": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_sayteam_to_spec": {
+      "group-id": "43",
       "type": ""
     },
     "sv_serverip": {
+      "group-id": "43",
       "type": "string"
     },
     "sv_specprint": {
+      "group-id": "43",
       "type": ""
     },
     "sv_spectalk": {
+      "group-id": "43",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Players can\u0027t hear spectators." },
@@ -10954,49 +13069,62 @@
       ]
     },
     "sv_spectatormaxspeed": {
+      "group-id": "43",
       "desc": "Sets the maximum speed a spectator can move.",
       "type": "float"
     },
     "sv_speedcheck": {
+      "group-id": "43",
       "type": ""
     },
     "sv_stopspeed": {
+      "group-id": "43",
       "desc": "Sets the value that determines how fast the player should come to a complete stop.",
       "type": "float"
     },
     "sv_timeout": {
+      "group-id": "43",
       "desc": "Sets the amount of time in seconds before a client is considered disconnected \nif the server does not receive a packet.",
       "type": "float"
     },
     "sv_timestamplen": {
+      "group-id": "43",
       "type": ""
     },
     "sv_unfake": {
+      "group-id": "43",
       "type": ""
     },
     "sv_use_dns": {
+      "group-id": "43",
       "type": ""
     },
     "sv_use_internal_cmd_dl": {
+      "group-id": "43",
       "type": ""
     },
     "sv_wateraccelerate": {
+      "group-id": "43",
       "desc": "Sets the water acceleration value.",
       "type": "float"
     },
     "sv_waterfriction": {
+      "group-id": "43",
       "desc": "Sets the water friction value.",
       "type": "float"
     },
     "sw_contrast": {
+      "group-id": "30",
       "desc": "Change contrast.",
       "type": "float"
     },
     "sw_gamma": {
+      "group-id": "30",
       "desc": "Change gamma.",
       "type": "float"
     },
     "sys_disable_alt_enter": {
+      "group-id": "48",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "alt-enter will toggle full-screen mode" },
@@ -11004,6 +13132,7 @@
       ]
     },
     "sys_disableWinKeys": {
+      "group-id": "48",
       "remarks": "Note: Windows keys are now bindable (LWINKEY, RWINKEY, WINKEY, POPUPMENU). Obviously only useful on NT/2K/XP with sys_disableWinKeys 1 (and possibely useful in Linux too!).",
       "type": "boolean",
       "values": [
@@ -11012,6 +13141,7 @@
       ]
     },
     "sys_highpriority": {
+      "group-id": "48",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Sets process to normal priority." },
@@ -11020,6 +13150,7 @@
       ]
     },
     "sys_inactivesleep": {
+      "group-id": "48",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Prevent freeing of CPU when the client is minimized or not in focus." },
@@ -11027,6 +13158,7 @@
       ]
     },
     "sys_inactivesound": {
+      "group-id": "48",
       "desc": "Enables sounds when the application is not focused",
       "type": "boolean",
       "values": [
@@ -11035,12 +13167,15 @@
       ]
     },
     "sys_restart_on_error": {
+      "group-id": "23",
       "type": "boolean"
     },
     "sys_select_timeout": {
+      "group-id": "23",
       "type": ""
     },
     "sys_yieldcpu": {
+      "group-id": "48",
       "desc": "Controls CPU sharing when client is waiting to draw a frame. When disabled, client will run a loop, actively waiting for the time to draw a new frame. When enabled, client will call system sleep function during the waiting, which will cause the thread to be deactivated for a while - leading to significantly lower CPU usage in most cases.",
       "type": "boolean",
       "values": [
@@ -11049,14 +13184,17 @@
       ]
     },
     "team": {
+      "group-id": "37",
       "desc": "Set the team name.",
       "type": "string"
     },
     "teambothskin": {
+      "group-id": "44",
       "desc": "Overrides the team quad pent skin so you can define the skin which applies to team quads pents.",
       "type": "string"
     },
     "teambottomcolor": {
+      "group-id": "44",
       "desc": "Determines the color of the pants of the teammates you see. Overrides player\u0027s skin settings.",
       "remarks": "To be able to use RGB 24bit colors, look for r_teamskincolor variable.",
       "type": "integer",
@@ -11065,6 +13203,7 @@
       ]
     },
     "teamforceskins": {
+      "group-id": "44",
       "desc": "Allows you to set different skin for every team player even if they all have same skin names set or use names of skins that you do not have in your Quake dir",
       "remarks": "Read \"Player skins\" manual page for more info on skin rules.",
       "type": "enum",
@@ -11076,6 +13215,7 @@
       ]
     },
     "teamlock": {
+      "group-id": "44",
       "desc": "Observing feature. Do not toggle enemy recognition when you switch players. One team will always remain marked as enemy even if you spec their players.",
       "type": "string",
       "values": [
@@ -11083,23 +13223,28 @@
       ]
     },
     "teampentskin": {
+      "group-id": "44",
       "desc": "Overrides the team pent skin so you can define the skin which applies to team pents.",
       "type": "string"
     },
     "teamplay": {
+      "group-id": "43",
       "desc": "Teamplay mode",
       "remarks": "Nowadays only value 2 is used; value 1 prevents you from killing your teammates including yourself",
       "type": "integer"
     },
     "teamquadskin": {
+      "group-id": "44",
       "desc": "Overrides the team quad skin so you can define the skin which applies to team quads.",
       "type": "string"
     },
     "teamskin": {
+      "group-id": "44",
       "desc": "Overrides the team skin so you can define the skin which applies to team mates.",
       "type": "string"
     },
     "teamtopcolor": {
+      "group-id": "44",
       "desc": "Determines the color of the shirt of the teammates you see. Overrides player\u0027s skin settings.",
       "remarks": "To be able to use RGB 24bit colors, look for r_teamskincolor variable.",
       "type": "integer",
@@ -11108,23 +13253,29 @@
       ]
     },
     "telnet_log_level": {
+      "group-id": "43",
       "type": ""
     },
     "telnet_password": {
+      "group-id": "43",
       "type": "string"
     },
     "timelimit": {
+      "group-id": "43",
       "desc": "Number of minutes the match will take",
       "type": "integer"
     },
     "timeout": {
+      "group-id": "43",
       "type": ""
     },
     "topcolor": {
+      "group-id": "37",
       "desc": "Sets the shirt color.",
       "type": "enum"
     },
     "tp_forceTriggers": {
+      "group-id": "49",
       "desc": "Controls whether f_took, f_death etc are forced to execute even if the game isn\u0027t a team game.",
       "type": "boolean",
       "values": [
@@ -11133,6 +13284,7 @@
       ]
     },
     "tp_loadlocs": {
+      "group-id": "49",
       "desc": "Controls whether to load locs for teamplay reporting.\nNote: The locs should be in your \"/id1/locs/\",\n\"/ezquake/locs\" or \"/qw/locs\" folder.",
       "type": "boolean",
       "values": [
@@ -11141,6 +13293,7 @@
       ]
     },
     "tp_msgtriggers": {
+      "group-id": "49",
       "desc": "Switches on/off message triggers",
       "remarks": "For ruleset \u0027Smackdown\u0027 message triggers always are off.",
       "type": "boolean",
@@ -11150,46 +13303,57 @@
       ]
     },
     "tp_name_armor": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_armortype_ga": {
+      "group-id": "13",
       "desc": "Customizes output of %A macro for green armor.",
       "type": "string"
     },
     "tp_name_armortype_ra": {
+      "group-id": "13",
       "desc": "Customizes output of %A macro for red armor.",
       "type": "string"
     },
     "tp_name_armortype_ya": {
+      "group-id": "13",
       "desc": "Customizes output of %A macro for yellow armor.",
       "type": "string"
     },
     "tp_name_at": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_axe": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_backpack": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_cells": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_disp": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_enemy": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_eyes": {
+      "group-id": "13",
       "desc": "Sets the name for ring (invisibility) powerup for teamplay messages.",
       "type": "string",
       "values": [
@@ -11197,101 +13361,126 @@
       ]
     },
     "tp_name_filter": {
+      "group-id": "13",
       "type": "string"
     },
     "tp_name_flag": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_ga": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_gl": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_health": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_lg": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_mh": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_nails": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_ng": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_none": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_nothing": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_pent": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_pented": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_quad": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_quaded": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_ra": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_ring": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_rl": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_rlg": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_rockets": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_rune1": {
+      "group-id": "13",
       "desc": "Sets name of the first rune (Resistance Rune) used for teamplay messages.",
       "type": "string"
     },
     "tp_name_rune2": {
+      "group-id": "13",
       "desc": "Sets name of the second rune (Strength Rune) used for teamplay messages.",
       "type": "string"
     },
     "tp_name_rune3": {
+      "group-id": "13",
       "desc": "Sets name of the third rune (Haste Rune) used for teamplay messages.",
       "type": "string"
     },
     "tp_name_rune4": {
+      "group-id": "13",
       "desc": "Sets name of the fourth rune (Regeneration Rune) used for teamplay messages.",
       "type": "string"
     },
     "tp_name_sentry": {
+      "group-id": "13",
       "desc": "Sets the name for sentry tower in teamplay messages.",
       "type": "string",
       "values": [
@@ -11299,107 +13488,133 @@
       ]
     },
     "tp_name_separator": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_sg": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_shells": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_sng": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_someplace": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_ssg": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_status_blue": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_status_green": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_status_red": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_status_white": {
+      "group-id": "13",
       "desc": "Currently unused",
       "remarks": "tp_name_status_ cvars are used by the client when generating teamplay messages",
       "type": "string"
     },
     "tp_name_status_yellow": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_suit": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_teammate": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_weapon": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_name_ya": {
+      "group-id": "13",
       "desc": "Customizes item",
       "type": "string"
     },
     "tp_need_cells": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_ga": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_health": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_nails": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_ra": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_rl": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_rockets": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_shells": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_weapon": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_need_ya": {
+      "group-id": "14",
       "desc": "Customizes the %u macro",
       "type": "float"
     },
     "tp_pointpriorities": {
+      "group-id": "49",
       "desc": "You can choose the way the client decides what object you want to point with $point macro.",
       "remarks": "Priorities of object are given in tp_point command. You have to type all objects manually in tp_point command. Example: tp_point quad ra mh health. In this example, quad has the highest priority and $point will always return quad if quad ra mh are all in your view. Example: tp_point all. You never know what object will be pointed because all objects get the same priority.",
       "type": "boolean",
@@ -11409,10 +13624,12 @@
       ]
     },
     "tp_soundtrigger": {
+      "group-id": "49",
       "desc": "SoundTrigger like proxys.\nA SoundTrigger must be terminated by either a CR, LF or filter. The .wav extension is not required at the end. Trigger is a character before the sound file.\nExample:\nfilter #a\nsay_team I\u0027m at %l ~location.wav\"\nsay_team ~location.wav$\\me: I\u0027m at %l #a\"\nsay_team ~location$\\me: I\u0027m at %l #a\"\nsay_team I\u0027m at %l ~location #a\"",
       "type": "string"
     },
     "tp_triggers": {
+      "group-id": "49",
       "type": "boolean",
       "values": [
         { "name": "false", "description": "Disable tp triggers." },
@@ -11420,10 +13637,12 @@
       ]
     },
     "tp_weapon_order": {
+      "group-id": "49",
       "desc": "This allows you to define the order from best to worst weapon. The default value\nis \"78564321\", which means that the Rocket Launcher is the best weapon (impulse 7)\nthen Lightning Gun (impulse 8), Super Nailgun (impulse 5), Grenade Launcher\n(impulse 6), Nailgun (impulse 4), Super Shotgun (impulse 3), Shotgun (impulse 2),\nAxe (impulse 1).",
       "type": "string"
     },
     "userdir": {
+      "group-id": "33",
       "desc": "userdir [dir [type]]\nAddition of the given directory to the list searched files",
       "type": "enum",
       "values": [
@@ -11436,14 +13655,17 @@
       ]
     },
     "v_centermove": {
+      "group-id": "53",
       "desc": "This variable sets the distance that the player must move before the screen \nautomatically centers itself when \"lookspring\" is set to \"1\". This variable is \nonly useful to people who only play with the keyboard, have \"lookspring\" set to\n\"1\" and do not have \"+klook\" or \"+mlook\" enabled at that time. When the player \nmoves the distance specified in this variable the screen will pop back to the \ncenter position.",
       "type": "float"
     },
     "v_centerspeed": {
+      "group-id": "53",
       "desc": "This variable sets how quickly your view returns to the center after looking up\nor down and moving after that and \"lookspring\" is set to \"1\". This variable is \nonly useful to people who only play with the keyboard, have \"lookspring\" set to\n\"1\" and do not have \"+klook\" or \"+mlook\" enabled at that time. When the player \nmoves the distance specified in this variable the screen will pop back to the \ncenter position.",
       "type": "float"
     },
     "v_contentblend": {
+      "group-id": "39",
       "desc": "Turning this variable on will temporarily change the hue of your screen when inside liquid (water/slime/lava) (requires gl_polyblend 1)",
       "type": "float",
       "values": [
@@ -11452,10 +13674,12 @@
       ]
     },
     "v_damagecshift": {
+      "group-id": "39",
       "desc": "This variable (0..1) will temporarily add a red hue to your screen when you\u0027ve taken damage. Needs gl_polyblend 1.",
       "type": "float"
     },
     "v_dlightcshift": {
+      "group-id": "39",
       "desc": "Turning this variable on will blend light when you\u0027re inside a light bubble. Also need to set gl_flashblend 1",
       "type": "boolean",
       "values": [
@@ -11464,10 +13688,12 @@
       ]
     },
     "v_gunkick": {
+      "group-id": "53",
       "desc": "Kickback effect when the weapon is fired.",
       "type": "float"
     },
     "v_idlescale": {
+      "group-id": "53",
       "desc": "This variable controls the amount that the screen should sway automatically.\nWhen this variable is set to a value above \"0\" the screen will start swaying in \nall directions, similar as if the player was drunk of had a concussion. If you \nwant to have some real fun, set this variable to a value of \"100\" and run around \nsome maps. The larger the value for this variable the more the screen will sway \nfrom side to side.",
       "type": "integer",
       "values": [
@@ -11475,67 +13701,83 @@
       ]
     },
     "v_ipitch_cycle": {
+      "group-id": "53",
       "desc": "This variable controls the speed at which the screen should sway up and down\nwhen \"v_idlescale\" is set to a value above \"0\".",
       "type": "float"
     },
     "v_ipitch_level": {
+      "group-id": "53",
       "desc": "This variable controls the distance that the screen should sway up and down when \"v_idlescale\" is set to a value above \"0\".",
       "type": "float"
     },
     "v_iroll_cycle": {
+      "group-id": "53",
       "desc": "This variable controls the speed at which the screen should roll clockwise and \ncounter clockwise when \"v_idlescale\" is set to a value above \"0\".",
       "type": "float"
     },
     "v_iroll_level": {
+      "group-id": "53",
       "desc": "This variable controls the distance the screen should roll clockwise and counter\nclockwise when \"v_idlescale\" is set to a value above \"0\".",
       "type": "float"
     },
     "v_iyaw_cycle": {
+      "group-id": "53",
       "desc": "Sets how quickly you look left and right when v_idlescale is active.",
       "type": "float"
     },
     "v_iyaw_level": {
+      "group-id": "53",
       "desc": "Sets how far you look left and right when v_idlescale is active.",
       "type": "float"
     },
     "v_kickpitch": {
+      "group-id": "53",
       "desc": "This variable controls the distance that the screen should move up or down when \nthe player is shot. Most players set this variable to \"0\" in order to remove the \nscreen tilting effect when they are injured by a shot. This allows them to keep \na perfect aim while being fired upon.",
       "remarks": "v_kicktime must be \u003e0 for this to take effect.",
       "type": "float"
     },
     "v_kickroll": {
+      "group-id": "53",
       "desc": "This variable controls the distance that the screen should roll clockwise or \ncounter clockwise when the player is shot. Most players set this variable to \"0\"\nin order to remove the screen tilting effect when they are injured by a shot. \nThis allows them to keep a perfect aim while being fired upon.",
       "remarks": "v_kicktime must be \u003e0 for this to take effect.",
       "type": "float"
     },
     "v_kicktime": {
+      "group-id": "53",
       "desc": "This variable controls the amount of time v_kickpitch and v_kickroll take effect.",
       "type": "float"
     },
     "v_pentcshift": {
+      "group-id": "39",
       "desc": "This variable (0..1) will add a temporary red hue to your screen if you are carry the Pent powerup. Requires gl_polyblend 1",
       "type": "float"
     },
     "v_quadcshift": {
+      "group-id": "39",
       "desc": "This variable (0..1) will add a temporary blue hue to your screen if you are carry the Quad powerup. Requires gl_polyblend 1",
       "type": "float"
     },
     "v_ringcshift": {
+      "group-id": "39",
       "desc": "This variable (0..1) will add a temporary yellow hue to your screen if you are carry the Ring powerup. Requires gl_polyblend 1",
       "type": "float"
     },
     "v_suitcshift": {
+      "group-id": "39",
       "desc": "This variable (0..1) will add a temporary green hue to your screen if you are carry the Suit powerup. Requires gl_polyblend 1",
       "type": "float"
     },
     "v_viewheight": {
+      "group-id": "53",
       "desc": "New variable v_viewheight can be used to get the effect of negative/zero values \nof cl_bobcycle etc in qw 2.33 . Negative values of v_viewheight = lower viewheight, \npositive = higher. Can\u0027t go below -7 or above 4 because that\u0027s the range you can get \nwith qw 2.33 by exploiting the bob cycle bug. Using v_viewheight automatically \nturns off weapon model bobbing (cl_bob*).",
       "type": "float"
     },
     "vid_allowExtensions": {
+      "group-id": "31",
       "type": ""
     },
     "vid_borderless": {
+      "group-id": "52",
       "desc": "When in windowed mode, window will not have a border",
       "type": "boolean",
       "values": [
@@ -11544,11 +13786,13 @@
       ]
     },
     "vid_colorbits": {
+      "group-id": "52",
       "desc": "Determines the color mode",
       "remarks": "Highest quality is \\\"24\\\"",
       "type": "integer"
     },
     "vid_conaspect": {
+      "group-id": "52",
       "desc": "Keep the screen proportions to given aspect ratio.",
       "remarks": "Always changes vid_conheight when you change vid_conwidth.",
       "type": "string",
@@ -11557,51 +13801,68 @@
       ]
     },
     "vid_config_x": {
+      "group-id": "52",
       "desc": "This variable sets the width of the vid_mode 2 window, the minimum possible\nvalue is \"640\".",
       "type": "float"
     },
     "vid_config_y": {
+      "group-id": "52",
       "desc": "This variable sets the width of the vid_mode 2 window, the minimum possible\nvalue is \"400\"",
       "type": "float"
     },
     "vid_conheight": {
+      "group-id": "52",
       "desc": "Height of the text layer.",
       "remarks": "Cannot be higher than the height of the current game resolution.",
       "type": "integer"
     },
     "vid_conscale": {
+      "group-id": "52",
+      "desc": "If vid_conwidth \u0026 vid_conheight are set to 0, vid_conheight will be scaled by the value of this variable",
       "type": "float"
     },
     "vid_conwidth": {
+      "group-id": "52",
       "desc": "Height of the text layer",
       "remarks": "Can\\\u0027t be higher than the height of the current game resolution",
       "type": "integer"
     },
     "vid_customheight": {
+      "group-id": "52",
       "desc": "Screen resolution width for custom screen mode",
       "remarks": "vid_mode must be -1",
       "type": "integer"
     },
     "vid_customwidth": {
+      "group-id": "52",
       "desc": "Screen resolution height for custom screen mode",
       "remarks": "vid_mode must be -1",
       "type": "integer"
     },
     "vid_depthbits": {
+      "group-id": "31",
       "type": ""
     },
     "vid_displayfrequency": {
+      "group-id": "52",
       "desc": "Sets horizontal frequency for your monitor (in hertz - Hz).",
       "type": "integer"
     },
     "vid_displaynumber": {
-      "type": ""
+      "group-id": "52",
+      "desc": "Display/screen to use when in fullscreen mode.",
+      "type": "integer",
+      "values": [
+        { "name": "*", "description": "Use vid_displaylist command to enumerate displays." }
+      ]
     },
     "vid_flashonactivity": {
+      "group-id": "52",
       "desc": "When there is activity in the server, ezQuake\u0027s taskbar window will flash. Activity includes chat, high priority messages, disconnection from server.",
       "type": "float"
     },
     "vid_forcerestoregamma": {
+      "group-id": "52",
       "desc": "Force restore gamma after returning to minimized application.",
       "remarks": "Might be usefull if you have ATI card.",
       "type": "boolean",
@@ -11611,6 +13872,7 @@
       ]
     },
     "vid_fullscreen": {
+      "group-id": "52",
       "desc": "Enables fullscreen mode, when disabled, sets windowed mode",
       "type": "boolean",
       "values": [
@@ -11619,13 +13881,18 @@
       ]
     },
     "vid_fullscreen_mode": {
+      "group-id": "52",
       "desc": "This variable sets the full screen video mode that the game will switch to when\nthe \"vid_fullscreen\" command is executed.",
       "type": "float"
     },
     "vid_height": {
-      "type": ""
+      "group-id": "52",
+      "desc": "Determines width of screen resolution when in fullscreen mode",
+      "remarks": "This value is ignored if vid_usedesktopres is set.",
+      "type": "integer"
     },
     "vid_hwgammacontrol": {
+      "group-id": "52",
       "type": "enum",
       "values": [
         { "name": "0", "description": "Disables hardware gamma control." },
@@ -11634,14 +13901,17 @@
       ]
     },
     "vid_mode": {
+      "group-id": "52",
       "desc": "This variables sets the next video mode to be used, any change of this variable\nwill cause the video mode to be changed immediately.",
       "type": "float"
     },
     "vid_nopageflip": {
+      "group-id": "52",
       "desc": "This variable toggles the use of page-flipping during supported video modes. By \ndefault the game will allow for page-flipping for video modes that support this \nfeature. For example if a given VESA mode can support page flipping, then it \ndefaults to page-flipped operation.  A VESA mode can be forced to \nnon-page-flipped operation by setting the \"vid_nopageflip\" variable to \"1\", then\nsetting the mode (note that \"vid_nopageflip\" takes operation on the next, \nnot the current video mode, and note that it then stays in effect permanently, \neven when the client is exited and restarted, unless it is manually set back to \"0\").\nIf there is not enough memory for two pages in a VESA mode, or if the adapter \ndoesn\u0027t support page flipping, then the mode will automatically be \nnon-page-flipped.  \nPage-flipping works by drawing multiple virtual game screens at the same time in \nthe video memory and then switching among them to display the current \ngamescreen. Page-flipped modes thus use less system memory than non-page-flipped \nmodes, but require more video memory. When using page-flipping, visual quality \nmay be higher, but performance of the game can change to better or worse, \ndepending on the graphics adapter and other hardware (see the discussion of the \nPentium Pro below, for a discussion of why page flipping can be faster but is \nsometimes much slower on that processor). However in most cases the performance \n(and thus frame rate) will be increased, but for people with hardware that has \nproblems with page-flipping \"vid_nopageflip 1\" may help.\nThe Pentium Pro is an example for such a hardware: it is an okay client platform (sniff!), \nbut it has one weak spot, it is by default very slow on writes to video memory.  \nThis means that in default hardware configurations, you are usually much better \noff setting \"vid_nopageflip\" to \"1\" if you use VESA modes, so drawing is done to \nsystem memory instead of to video memory. Remember that you must set the mode\nafter setting \"vid_nopageflip\" to \"1\" in order to get \"vid_nopageflip\" to take\neffect. \"vid_nopageflip 1\" can sometimes be faster on a Pentium too, but not by \nnearly as much in general, and it\u0027s often slower.",
       "type": "float"
     },
     "vid_resetonswitch": {
+      "group-id": "52",
       "remarks": "ezQuake and the screen gets garbaged. When enabled, the client will reset your Windows video mode \nevery time you press alt-tab. Note that some NVidia drivers lock up your system completely \nwhen you alt-tab. vid_resetonswitch will not help in this case (try starting ezQuake with -dibonly).",
       "type": "boolean",
       "values": [
@@ -11650,12 +13920,16 @@
       ]
     },
     "vid_showextensions": {
-      "type": ""
+      "group-id": "52",
+      "desc": "If set, GL_EXTENSIONS string will be displayed when printing graphics info.",
+      "type": "boolean"
     },
     "vid_stencilbits": {
+      "group-id": "31",
       "type": ""
     },
     "vid_stretch_by_2": {
+      "group-id": "52",
       "remarks": "half-resolution in each direction and stretched up to the specified size.)",
       "type": "boolean",
       "values": [
@@ -11664,12 +13938,17 @@
       ]
     },
     "vid_usedesktopres": {
-      "type": ""
+      "group-id": "52",
+      "desc": "If set, vid_width/vid_height are ignored, and desktop resolution is used instead.",
+      "type": "boolean"
     },
     "vid_verbose": {
-      "type": ""
+      "group-id": "52",
+      "desc": "If set, display graphics info on every vid_restart",
+      "type": "boolean"
     },
     "vid_vsync": {
+      "group-id": "52",
       "desc": "Syncs your FPS with your monitor\u0027s vertical refresh rate. This will override cl_maxfps.",
       "type": "boolean",
       "values": [
@@ -11678,16 +13957,19 @@
       ]
     },
     "vid_vsync_lag_fix": {
+      "group-id": "52",
       "desc": "Enables experimental fix for a delay vertical synchronization mode",
       "remarks": "When vid_vsync is set to 1, an artificial delay in the input can appear, enabling this should eliminate the delay",
       "type": "boolean"
     },
     "vid_vsync_lag_tweak": {
+      "group-id": "52",
       "desc": "Custom value for experimental vertical synchronization delay reduction.",
       "remarks": "Too low values (0.2 or lower) may significantly decrease FPS and make it not synced with display frequency. Too high values (10 and above) may turn off the effect of video lag fix completely. Use the lowest value that keeps stable FPS for you.",
       "type": "float"
     },
     "vid_wideaspect": {
+      "group-id": "52",
       "desc": "Recalculates screen proportions so that they suit wide-screen displays. If you toggle this variable from 0 to 1, it will recalculate your field of view (fov) and screen proportions (conwidth/conheight ratio) so that the resulting image looks similar on a 16:10 screen as it did on 4:3 screen.",
       "remarks": "The effect of the variable is only changing values of \"fov\" and \"vid_conheight\" variables when you toggle the value of this variable. The algorithm used to get resulting values is described in the QuakeWorld wiki.",
       "type": "boolean",
@@ -11697,47 +13979,71 @@
       ]
     },
     "vid_width": {
-      "type": ""
+      "group-id": "52",
+      "desc": "Determines width of screen resolution when in fullscreen mode",
+      "remarks": "This value is ignored if vid_usedesktopres is set.",
+      "type": "integer"
     },
     "vid_win_borderless": {
-      "type": ""
+      "group-id": "52",
+      "desc": "If set, windowed mode will be in a borderless window (no title)",
+      "type": "boolean"
     },
     "vid_win_displaynumber": {
-      "type": ""
+      "group-id": "52",
+      "desc": "Display/screen to use when in windowed mode.",
+      "type": "integer",
+      "values": [
+        { "name": "*", "description": "Use vid_displaylist command to enumerate displays." }
+      ]
     },
     "vid_win_height": {
-      "type": ""
+      "group-id": "52",
+      "desc": "Height of display when in windowed mode.",
+      "type": "integer"
     },
     "vid_win_save_pos": {
-      "type": ""
+      "group-id": "52",
+      "desc": "If set, window position variables will be set as window moved around screen",
+      "type": "boolean"
     },
     "vid_win_save_size": {
-      "type": ""
+      "group-id": "52",
+      "desc": "If set, window size variables will be set as window resized",
+      "type": "boolean"
     },
     "vid_win_width": {
-      "type": ""
+      "group-id": "52",
+      "desc": "Width of display when in windowed mode.",
+      "type": "integer"
     },
     "vid_window_x": {
+      "group-id": "52",
       "desc": "This variable sets the x-axis location of the top left corner of the game window \non the desktop.",
       "type": "float"
     },
     "vid_window_y": {
+      "group-id": "52",
       "desc": "This variable sets the y-axis location of the top left corner of the game window \non the desktop.",
       "type": "float"
     },
     "vid_windowed_mode": {
+      "group-id": "52",
       "desc": "This variable sets the windowed video mode that the game will switch to when the \n\"vid_windowed\" command is executed.",
       "type": "float"
     },
     "vid_xpos": {
+      "group-id": "52",
       "desc": "Horizontal position of the client window.",
       "type": "integer"
     },
     "vid_ypos": {
+      "group-id": "52",
       "desc": "Vertical position of the client window",
       "type": "integer"
     },
     "viewsize": {
+      "group-id": "53",
       "desc": "This variable determines how large the viewable screen size is.",
       "remarks": "...",
       "type": "integer",
@@ -11749,17 +14055,21 @@
       ]
     },
     "vip_password": {
+      "group-id": "43",
       "type": "string"
     },
     "vip_values": {
+      "group-id": "43",
       "type": "string"
     },
     "volume": {
+      "group-id": "45",
       "desc": "Sets sound volume.",
       "remarks": "Even higher values than 1 are possible, but sound usually gets faithless with them.",
       "type": "float"
     },
     "w_switch": {
+      "group-id": "37",
       "desc": "This variable allows you to define the highest weapon that the client should switch \nto when picking it up. The possible arguments of \"w_switch\" refer to the impulse \nthat is used to switch to a certain weapon:",
       "type": "enum",
       "values": [
@@ -11774,6 +14084,7 @@
       ]
     },
     "watervis": {
+      "group-id": "34",
       "desc": "This server-side cvar is mirrored to serverinfo as a hint to clients on whether the server is using the so-called watervised maps.",
       "remarks": "It\u0027s a bad idea to use watervis 1 if the maps the server is using are not watervised. Liquids will appear \u0027transparent\u0027 but you won\u0027t be able to see any items/players/etc through it.  And it is a bad idea anyway because Quake maps were not designed for transparent water (or other liquids); enabling it changes gameplay, decreases fps and produces more network traffic and puts non-GL players at a disadvantage because the software renderer doesn\u0027t support transparent water (yet).\nNot saved to config with cfg_save command.",
       "type": "boolean",
@@ -11783,6 +14094,7 @@
       ]
     },
     "zombietime": {
+      "group-id": "43",
       "desc": "The number of minutes that the server will keep the character of a player on \nthe map who seems to have disconnected.",
       "type": "integer"
     }


### PR DESCRIPTION
Change groups section to have id & major grouping, for external docs.
Added group-id field to each cvar (taken from dump_defaults comment)
Corrected spelling of that word.