### PR TITLE
.mvd support for OS X

### DIFF
--- a/misc/install/create_osx_bundle.sh
+++ b/misc/install/create_osx_bundle.sh
@@ -55,5 +55,14 @@ chmod u+x $BUNDLE_NAME/Contents/MacOS/ezquake
 /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" $BUNDLE_NAME/Contents/Info.plist
 /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string qw" $BUNDLE_NAME/Contents/Info.plist
 
+# .mvd file type support
+/usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes array" $BUNDLE_NAME/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:0 dict" $BUNDLE_NAME/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:0:CFBundleTypeName string MVD demo" $BUNDLE_NAME/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:0:CFBundleTypeRole string Viewer" $BUNDLE_NAME/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:0:CFBundleTypeIconFile string $ICON_FILE" $BUNDLE_NAME/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:0:CFBundleTypeExtensions array" $BUNDLE_NAME/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:0:CFBundleTypeExtensions:0 string mvd" $BUNDLE_NAME/Contents/Info.plist
+
 sh $(dirname $0)/fixbundle.sh $BUNDLE_NAME $BUNDLE_NAME/Contents/MacOS/$BINARY
 ditto -c -k --keepParent --arch x86_64 $BUNDLE_NAME ezquake.zip

--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -493,6 +493,10 @@ static void HandleEvents()
 		case SDL_MOUSEWHEEL:
 			mouse_wheel_event(&event.wheel);
 			break;
+		case SDL_DROPFILE: /* OS X only */
+			Cbuf_AddText(va("playdemo %s\n", event.drop.file));
+			SDL_free(event.drop.file);
+			break;
 		}   
 	} 
 }


### PR DESCRIPTION
These changes add .mvd file support to OS X. You double click a .mvd file from the finder and the app launches and plays the demo. Or if it is already launched it will play the demo that has been clicked. You can also drag and drop the file onto the app's icon of course.