### PR TITLE
MULTIVIEW: Don't reset variables on initial startup

### DIFF
--- a/cl_main.c
+++ b/cl_main.c
@@ -2669,10 +2669,6 @@ static void CL_Multiview(void)
 {
 	static int playernum = 0;
 
-	extern cvar_t gl_polyblend;
-	extern cvar_t gl_clear;
-	extern cvar_t r_lerpframes;
-
 	if (!cls.mvdplayback)
 	{
 		return;

--- a/client.h
+++ b/client.h
@@ -946,7 +946,6 @@ void CL_CalcPlayerFPS(player_info_t *info, int msec);
 
 extern int		CURRVIEW;					// The current view being drawn in multiview mode.
 extern int		nNumViews;					// The number of views in multiview mode.
-extern qbool	bExitmultiview;				// Used when saving effect values on each frame.
 
 extern qbool	mv_skinsforced;				// When using teamcolor/enemycolor in multiview we can't just assume
 											// that the "teammates" should all be colored in the same color as the


### PR DESCRIPTION
A number of variables need to be set to sensible values during multiview
playback.  If not in multiview, the old values are saved, and then restored
before initiating a new connection.  If the command line caused an
immediate connection, the values would be set to their default values,
ignoring options that the user has set in their config file.