### PR TITLE
common.c: allow multiple GPL map hashes

### DIFF
--- a/common.c
+++ b/common.c
@@ -1611,12 +1611,8 @@ int Com_TranslateMapChecksum (const char *mapname, int checksum)
 //	Com_Printf ("Map checksum (%s): 0x%x\n", mapname, checksum);
 
 	for (p = table; p->mapname; p++)
-		if (!strcmp(p->mapname, mapname)) {
-			if (checksum == p->gpl)
-				return p->original;
-			else
-				return checksum;
-		}
+		if (!strcmp(p->mapname, mapname) && checksum == p->gpl)
+			return p->original;
 
 	return checksum;
 }


### PR DESCRIPTION
This change allows the GPL map hash table to include multiple entries for one map. This way we can support different GPL map versions. (I'm playing around with this currently)

Also currently "end" is being listed twice. I think the second entry is actually ineffective.