### PR TITLE
OSX: Fix SDL_Thread leaks when updating server browser

### DIFF
--- a/sys_posix.c
+++ b/sys_posix.c
@@ -354,7 +354,8 @@ void Sys_MakeCodeWriteable (unsigned long startaddr, unsigned long length) {
 
 int  Sys_CreateThread(DWORD WINAPI (*func)(void *), void *param)
 {
-	SDL_CreateThread((SDL_ThreadFunction)func, NULL, param);
+	SDL_Thread *thread = SDL_CreateThread((SDL_ThreadFunction)func, NULL, param);
+	SDL_DetachThread(thread);
 	return 1;
 }
 


### PR DESCRIPTION
0.8kb leak when updating server browser, and many other "one off"
threads that are created.

Leak: 0x7fc32be28720  size=816  zone: DefaultMallocZone_0x10849e000
	0x0021d000 0x00007000 0x0021d000 0x00007000 	..!..p....!..p..
	0x00000000 0x00000002 0x00000000 0x00000000 	................
	0x00000000 0x00000000 0x00000000 0x00000000 	................
	0x00000000 0x00000000 0x00000000 0x00000000 	................
	0x00000000 0x00000000 0x00000000 0x00000000 	................
	0x00000000 0x00000000 0x00000000 0x00000000 	................
	0x00000000 0x00000000 0x00000000 0x00000000 	................
	0x00000000 0x00000000 0x00000000 0x00000000 	................
	...
	Call stack: [thread 0x700000081000]:
        |  thread_start
        |  _pthread_body
        |  _pthread_body
        |  RunThread
        |  SDL_RunThread
        |  GetServerPingsAndInfosProc EX_browser_net.c:574
        |  PingHosts EX_browser_ping.c:785
        |  Sys_CreateThread sys_posix.c:358
        |  SDL_CreateThread_REAL
        |  malloc
        |  malloc_zone_malloc

The result of SDL_CreateThread was not being used, but needed to
be freed. Documentation says to either call WaitThread (join) to
wait for the thread to complete, or DetachThread (detach) to have
the thread clean itself up when it completes. The intent here
looks to be let the thread clean itself up, so call DetachThread.