### PR TITLE
LEAK: Fix obvious leak in Util_F_Match

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "hud.h"
 #include "utils.h"
 #include "qtv.h"
+#include "teamplay.h"
 
 
 int TP_CategorizeMessage (const char *s, int *offset);
@@ -824,8 +825,10 @@ qbool Util_F_Match (const char *_msg, char *f_request) {
 	msg = Q_strdup(_msg);
 	flags = TP_CategorizeMessage(msg, &offset);
 
-	if (flags != 1 && flags != 4)
+	if (flags != msgtype_normal && flags != msgtype_spec) {
+		Q_free(msg);
 		return false;
+	}
 
 	for (i = 0, s = msg + offset; i < strlen(s); i++)
 		s[i] = s[i] & ~128;		


### PR DESCRIPTION
Function could bail without releasing the strdup. It should cleanup
like all other bails in this function. This could happen if any
f_check was sent through non-normal / spec messages. For example
qtv or say_team:

    say_team f_modified
      => many leaks

Leak size=80  zone: DefaultMallocZone_0x10a1b1000  length: 40  has-length-byte:  "bogojoker): {&c0ff
	Call stack: [thread 0x7fff7a6a9000]:
        | start
        | main sys_posix.c:340
        | Host_Frame host.c:465
        | CL_Frame cl_main.c:2362
        | CL_ReadPackets cl_main.c:1682
        | CL_ParseServerMessage cl_parse.c:3371
        | CL_ParsePrint cl_parse.c:2769
        | FChecks_CheckRequest fchecks.c:180
        | Util_F_Match utils.c:824
        | Q_strdup q_shared.c:916
        | strdup
        | malloc
        | malloc_zone_malloc