### PR TITLE
LEAKS: Fix leaks during console tab completion

### DIFF
--- a/keys.c
+++ b/keys.c
@@ -309,11 +309,14 @@ void PaddedPrint (char *s)
 {
 	extern int con_linewidth;
 	extern char *str_repeat (char *str, int amount);
+	char *pad = NULL;
 	int nextcolx = 0;
 
 	if (con_completion_format.integer)  // plain list
 	{
-		Com_Printf ("%s&c%s%s&r\n", str_repeat(" ",con_completion_padding.integer), con_completion_color_name.string, s);
+		pad = str_repeat(" ", con_completion_padding.integer);
+		Com_Printf ("%s&c%s%s&r\n", pad, con_completion_color_name.string, s);
+		Q_free(pad);
 	}
 	else
 	{
@@ -331,20 +334,36 @@ void PaddedPrint (char *s)
 	}
 }
 
-void PaddedPrintValue (char *s, char *v, char *dv)  // name, value, default value
+void PaddedPrintMarkAndPad (qbool mark)
 {
 	extern char *str_repeat (char *str, int amount);
 
+	char* s;
+	int padding = con_completion_padding.integer;
+
+	if (mark)
+	{
+		Com_Printf ("&c%s*", con_completion_color_changed_mark.string);
+		padding -= 1;
+	}
+
+	s = str_repeat(" ", padding);
+	Com_Printf ("%s", s);
+	Q_free(s);
+}
+
+void PaddedPrintValue (char *s, char *v, char *dv)  // name, value, default value
+{
 	qbool changed = (strcmp(s, dv) != 0) && (strcmp(dv, v) != 0);
 	qbool add_mark = (con_completion_changed_mark.integer > 0) && changed;
 
 	switch (con_completion_format.integer)
 	{
-		case 1:	// current + deafault
+		case 1:	// current + default
 			if (strcmp(s, dv))
 			{
-				Com_Printf ("%s&c%s%s &c%s:&r &c%s\"&c%s%s&c%s\"&r &c%s:&r &c%s\"&c%s%s&c%s\"&r\n",
-					(add_mark) ? va("&c%s*%s", con_completion_color_changed_mark.string, str_repeat(" ",con_completion_padding.integer - 1)) : str_repeat(" ",con_completion_padding.integer),
+				PaddedPrintMarkAndPad (add_mark);
+				Com_Printf ("&c%s%s &c%s:&r &c%s\"&c%s%s&c%s\"&r &c%s:&r &c%s\"&c%s%s&c%s\"&r\n",
 					con_completion_color_name.string, s , con_completion_color_colon.string,
 					con_completion_color_quotes_current.string, con_completion_color_value_current.string, v,
 					con_completion_color_quotes_current.string, con_completion_color_colon.string,
@@ -353,36 +372,37 @@ void PaddedPrintValue (char *s, char *v, char *dv)  // name, value, default valu
 			}
 			else
 			{
-				Com_Printf ("%s&c%s%s &c%s: &c%s\"&c%s%s&c%s\"&r\n",
-					str_repeat(" ",con_completion_padding.integer), con_completion_color_name.string, s , con_completion_color_colon.string,
+				PaddedPrintMarkAndPad (false);
+				Com_Printf ("&c%s%s &c%s: &c%s\"&c%s%s&c%s\"&r\n",
+					con_completion_color_name.string, s , con_completion_color_colon.string,
 					con_completion_color_quotes_current.string, con_completion_color_value_current.string, v,
 					con_completion_color_quotes_current.string);
 			}
 			break;
 
 		case 2:	// current only
-			Com_Printf ("%s&c%s%s &c%s: &c%s\"&c%s%s&c%s\"&r\n",
-				(add_mark) ? va("&c%s*%s", con_completion_color_changed_mark.string, str_repeat(" ",con_completion_padding.integer - 1)) : str_repeat(" ",con_completion_padding.integer),
+			PaddedPrintMarkAndPad (add_mark);
+			Com_Printf ("&c%s%s &c%s: &c%s\"&c%s%s&c%s\"&r\n",
 				con_completion_color_name.string, s , con_completion_color_colon.string,
 				con_completion_color_quotes_current.string, con_completion_color_value_current.string, v,
 				con_completion_color_quotes_current.string);
 			break;
 
 		case 3:	// default only
-			Com_Printf ("%s&c%s%s &c%s:&r &c%s\"&c%s%s&c%s\"&r\n",
-				(add_mark) ? va("&c%s*%s", con_completion_color_changed_mark.string, str_repeat(" ",con_completion_padding.integer - 1)) : str_repeat(" ",con_completion_padding.integer),
+			PaddedPrintMarkAndPad (add_mark);
+			Com_Printf ("&c%s%s &c%s:&r &c%s\"&c%s%s&c%s\"&r\n",
 				con_completion_color_name.string, s, con_completion_color_colon.string,
 				con_completion_color_quotes_default.string, con_completion_color_value_default.string,
 				dv, con_completion_color_quotes_default.string);
 			break;
 
-		case 4:	// current+default if changed
+		case 4:	// current + default if changed
 			if(changed)
 			{
 				if (strcmp(s, dv))
 				{
-					Com_Printf ("%s&c%s%s &c%s:&r &c%s\"&c%s%s&c%s\"&r &c%s:&r &c%s\"&c%s%s&c%s\"&r\n",
-						(add_mark) ? va("&c%s*%s", con_completion_color_changed_mark.string, str_repeat(" ",con_completion_padding.integer - 1)) : str_repeat(" ",con_completion_padding.integer),
+					PaddedPrintMarkAndPad (add_mark);
+					Com_Printf ("&c%s%s &c%s:&r &c%s\"&c%s%s&c%s\"&r &c%s:&r &c%s\"&c%s%s&c%s\"&r\n",
 						con_completion_color_name.string, s , con_completion_color_colon.string,
 						con_completion_color_quotes_current.string, con_completion_color_value_current.string, v,
 						con_completion_color_quotes_current.string, con_completion_color_colon.string,
@@ -391,16 +411,17 @@ void PaddedPrintValue (char *s, char *v, char *dv)  // name, value, default valu
 				}
 				else
 				{
-					Com_Printf ("%s&c%s%s &c%s: &c%s\"&c%s%s&c%s\"&r\n",
-						str_repeat(" ",con_completion_padding.integer), con_completion_color_name.string, s , con_completion_color_colon.string,
+					PaddedPrintMarkAndPad (false);
+					Com_Printf ("&c%s%s &c%s: &c%s\"&c%s%s&c%s\"&r\n",
+						con_completion_color_name.string, s , con_completion_color_colon.string,
 						con_completion_color_quotes_current.string, con_completion_color_value_current.string, v,
 						con_completion_color_quotes_current.string);
 				}
 			}
 			else
 			{
-				Com_Printf ("%s&c%s%s &c%s: &c%s\"&c%s%s&c%s\"&r\n",
-					(add_mark) ? va("&c%s*%s", con_completion_color_changed_mark.string, str_repeat(" ",con_completion_padding.integer - 1)) : str_repeat(" ",con_completion_padding.integer),
+				PaddedPrintMarkAndPad (add_mark);
+				Com_Printf ("&c%s%s &c%s: &c%s\"&c%s%s&c%s\"&r\n",
 					con_completion_color_name.string, s , con_completion_color_colon.string,
 					con_completion_color_quotes_current.string, con_completion_color_value_current.string, v,
 					con_completion_color_quotes_current.string);
@@ -408,8 +429,8 @@ void PaddedPrintValue (char *s, char *v, char *dv)  // name, value, default valu
 			break;
 
 		case 5:	// none
-			Com_Printf ("%s&c%s%s&r\n",
-				(add_mark) ? va("&c%s*%s", con_completion_color_changed_mark.string, str_repeat(" ",con_completion_padding.integer - 1)) : str_repeat(" ",con_completion_padding.integer),
+			PaddedPrintMarkAndPad (add_mark);
+			Com_Printf ("&c%s%s&r\n",
 				con_completion_color_name.string, s);
 			break;
 

--- a/keys.c
+++ b/keys.c
@@ -448,7 +448,7 @@ extern cvar_t *cvar_vars;
 
 void CompleteCommandNew (void)
 {
-	char *cmd, token[MAXCMDLINE], *s;
+	char *cmd, token[MAXCMDLINE], *s, *escaped;
 	wchar temp[MAXCMDLINE];
 	int c, a, v, start, end, i, diff_len, size, my_string_length;
 
@@ -532,7 +532,9 @@ void CompleteCommandNew (void)
 					sorted_cmds[s_count] = s_c;
 
 				qsort(sorted_cmds, s_count, sizeof (cmd_function_t *), Cmd_CommandCompare);
-				snprintf(completebuff, sizeof(completebuff), "^((?i)%s)", escape_regex(s));
+				escaped = escape_regex(s);
+				snprintf(completebuff, sizeof(completebuff), "^((?i)%s)", escaped);
+				Q_free(escaped);
 
 				for (i = 0; i < s_count; i++) {
 					if (Utils_RegExpMatch(completebuff, sorted_cmds[i]->name))
@@ -561,7 +563,9 @@ void CompleteCommandNew (void)
 					sorted_cvars[s_count] = s_v;
 
 				qsort(sorted_cvars, s_count, sizeof (cvar_t *), Cvar_CvarCompare);
-				snprintf(completebuff, sizeof(completebuff), "^((?i)%s)", escape_regex(s));
+				escaped = escape_regex(s);
+				snprintf(completebuff, sizeof(completebuff), "^((?i)%s)", escaped);
+				Q_free(escaped);
 
 				for (i = 0; i < s_count; i++) {
 					if (Utils_RegExpMatch(completebuff, sorted_cvars[i]->name))
@@ -590,7 +594,9 @@ void CompleteCommandNew (void)
 					sorted_aliases[s_count] = s_a;
 
 				qsort(sorted_aliases, s_count, sizeof (cmd_alias_t *), Cmd_AliasCompare);				
-				snprintf(completebuff, sizeof(completebuff), "^((?i)%s)", escape_regex(s));				
+				escaped = escape_regex(s);
+				snprintf(completebuff, sizeof(completebuff), "^((?i)%s)", escaped);				
+				Q_free(escaped);
 
 				for (i = 0; i < s_count; i++) {
 					if (Utils_RegExpMatch(completebuff, sorted_aliases[i]->name))

--- a/utils.c
+++ b/utils.c
@@ -59,7 +59,7 @@ char *str_repeat (char *str, int amount)
         return NULL;
 
     if (amount <= 0)
-        return "";
+        amount = 0;
 
     ret = (char *) Q_calloc(strlen(str) * amount + 1, sizeof(char)); 
 


### PR DESCRIPTION
Numerous leaks when doing tab completion in the console.

Namely every time either escape_regex or str_repeat is called, if they allocated they will leak.

To reproduce:

1. Open console
2. Type "src" <tab>