### PR TITLE
GL_RMAIN: Extend custom LG color to all projectiles

### DIFF
--- a/gl_model.c
+++ b/gl_model.c
@@ -2296,6 +2296,10 @@ void Mod_AddModelFlags(model_t *mod)
 		mod->modhint = MOD_GIB;
 	else if (!strncasecmp(mod->name, "progs/v_", 8))
 		mod->modhint = MOD_VMODEL;
+	else if (!strcmp(mod->name, "progs/missile.mdl"))
+		mod->modhint = MOD_ROCKET;
+	else if (!strcmp(mod->name, "progs/grenade.mdl"))
+		mod->modhint = MOD_GRENADE;
 	else
 		mod->modhint = MOD_NORMAL;
 }

--- a/gl_model.h
+++ b/gl_model.h
@@ -349,7 +349,8 @@ typedef enum
 	MOD_SHAMBLER, 
 	MOD_TELEPORTDESTINATION,
 	MOD_GIB,
-	MOD_VMODEL
+	MOD_VMODEL,
+	MOD_ROCKET
 } modhint_t;
 
 #define	EF_ROCKET	1			// leave a trail

--- a/help_variables.json
+++ b/help_variables.json
@@ -2425,6 +2425,54 @@
       "desc": "When a shambler is preparing to throw lightning, or a tesla coil (TF) is charging to fire, a particle effect is generated.",
       "type": "float"
     },
+    "gl_custom_grenade_color": {
+      "group-id": "35",
+      "desc": "Allows color of grenades to be set without requiring a texture change.",
+      "type": "color",
+      "remarks": "Leave blank to disable.  See gl_custom_grenade_fullbright."
+    },
+    "gl_custom_grenade_fullbright": {
+      "group-id": "35",
+      "desc": "Determines if gl_custom_grenade_color refers to a fullbright color or standard.",
+      "type": "boolean",
+      "remarks": "Has no effect if gl_custom_grenade_color is blank."
+    },
+    "gl_custom_lg_color": {
+      "group-id": "35",
+      "desc": "Allows color of lightning shaft to be set without requiring a texture change.",
+      "type": "color",
+      "remarks": "Leave blank to disable.  Has no effect if particle shaft is enabled."
+    },
+    "gl_custom_lg_fullbright": {
+      "group-id": "35",
+      "desc": "Determines if gl_custom_lg_color refers to a fullbright color or standard.",
+      "type": "boolean",
+      "remarks": "Has no effect if gl_custom_lg_color is blank."
+    },
+    "gl_custom_rocket_color": {
+      "group-id": "35",
+      "desc": "Allows color of rockets to be set without requiring a texture change.",
+      "type": "color",
+      "remarks": "Leave blank to disable.  See gl_custom_rocket_fullbright."
+    },
+    "gl_custom_rocket_fullbright": {
+      "group-id": "35",
+      "desc": "Determines if gl_custom_rocket_color refers to a fullbright color or standard.",
+      "type": "boolean",
+      "remarks": "Has no effect if gl_custom_rocket_color is blank."
+    },
+    "gl_custom_spike_color": {
+      "group-id": "35",
+      "desc": "Allows color of spikes/nails to be set without requiring a texture change.",
+      "type": "color",
+      "remarks": "Leave blank to disable.  See gl_custom_spike_fullbright."
+    },
+    "gl_custom_spike_fullbright": {
+      "group-id": "35",
+      "desc": "Determines if gl_custom_spike_color refers to a fullbright color or standard.",
+      "type": "boolean",
+      "remarks": "Has no effect if gl_custom_spike_color is blank."
+    },
     "gl_detail": {
       "group-id": "8",
       "desc": "Turns on/off fine detailed textures.",


### PR DESCRIPTION
gl_custom_X_color is a color cvar that dictates the color of the projectile
  (if specified, alpha is ignored)
gl_custom_X_fullbright is boolean to dictate if the projectile should
  be drawn fullbright, or lit & textured as normal.

Fixes #123.
