### PR TITLE
HUD_GROUPS: Fixup hud group code a bit

### DIFF
--- a/common_draw.h
+++ b/common_draw.h
@@ -34,13 +34,15 @@ typedef struct cachepic_s
 typedef struct cachepic_node_s 
 {
 	cachepic_t data;
+	unsigned int refcount;
 	struct cachepic_node_s *next;
 } cachepic_node_t;
 
 #define	CACHED_PICS_HDSIZE		64
 
-mpic_t *CachePic_Find(const char *path);
+mpic_t *CachePic_Find(const char *path, qbool inc_refcount);
 mpic_t* CachePic_Add(const char *path, mpic_t *pic);
+qbool CachePic_Remove(const char *path);
 void CachePics_DeInit(void);
 
 int SCR_GetClockStringWidth(const char *s, qbool big, float scale);

--- a/gl_texture.c
+++ b/gl_texture.c
@@ -600,17 +600,16 @@ int GL_LoadPicTexture (const char *name, mpic_t *pic, byte *data)
 	} 
 	else 
 	{
-		buf = (byte *) Q_calloc (glwidth * glheight, 1);
+		buf = Q_calloc(glwidth * glheight, 1);
 
 		src = data;
 		dest = buf;
-		for (i = 0; i < pic->height; i++) 
-		{
-			memcpy (dest, src, pic->width);
+		for (i = 0; i < pic->height; i++) {
+			memcpy(dest, src, pic->width);
 			src += pic->width;
 			dest += glwidth;
 		}
-		pic->texnum = GL_LoadTexture (fullname, glwidth, glheight, buf, TEX_ALPHA, 1);
+		pic->texnum = GL_LoadTexture(fullname, glwidth, glheight, buf, TEX_ALPHA, 1);
 		pic->sl = 0;
 		pic->sh = (float) pic->width / glwidth;
 		pic->tl = 0;

--- a/host.c
+++ b/host.c
@@ -531,7 +531,6 @@ extern void LoadConfig_f(void);
 
 	Cmd_AddCommand ("sb_sourceunmarkall", SB_SourceUnmarkAll);
 	Cmd_AddCommand ("sb_sourcemark", SB_SourceMark);
-	Browser_Init2();
 }
 
 void Startup_Place(void)
@@ -595,6 +594,7 @@ void Host_Init (int argc, char **argv, int default_memsize)
 	NET_Init ();
 
 	Commands_For_Configs_Init ();
+	Browser_Init2();
 	ConfigManager_Init();
 	ResetBinds();
 

--- a/q_shared.c
+++ b/q_shared.c
@@ -635,9 +635,15 @@ qbool Q_glob_match (const char *pattern, const char *text)
 	return (*text == '\0');
 }
 
+extern void Com_Printf (char *fmt, ...);
 unsigned int Com_HashKey (const char *str) {
 	unsigned int hash = 0;
 	int c;
+
+	if (!str) {
+		Com_Printf("warning: Com_HashKey called with NULL argument\n");
+		return 0;
+	}
 
 	// the (c&~32) makes it case-insensitive
 	// hash function known as sdbm, used in gawk


### PR DESCRIPTION
* Reuse same code for all groups

* Fix the log spamming bug

* Introduce CachePic_Remove and reference counting. Not used atm for the
  hud_group pics because with the current code it's not possible to
  determine which pic to unload. First attempt used the old cvar-value,
  however that turns out to be a bad idea during a vid_restart. Code is
  there and can be used in the future if there's a way to determine
  which picture to unload (or decrease refcount on).

* Change CachePic_Add function to make it responsible for data copying
  instead of letting this be up to the caller. Makes it possible to skip
  adding a picture that's already in there.

* Add a warning message to Com_HashKey function in case it's called with
  NULL argument. Basically a developer helper, could have been an
  assert() but IMO crashing due to this is probably a bad idea.

* Move initialization of server browser to a more logical place

* Some small code style changes