### PR TITLE
Fixes ezQuake/ezquake-source#172

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -353,6 +353,8 @@ static byte *FS_LoadFile (const char *path, int usehunk, int *file_length)
 	if (!f)
 		return NULL;
 	len = VFS_GETLEN(f);
+	if(len == -1)
+		return NULL;
 	if (file_length)
 		*file_length = len;
 

--- a/fs.c
+++ b/fs.c
@@ -353,8 +353,10 @@ static byte *FS_LoadFile (const char *path, int usehunk, int *file_length)
 	if (!f)
 		return NULL;
 	len = VFS_GETLEN(f);
-	if(len == -1)
+	if(len == -1) {
+		VFS_CLOSE(f);
 		return NULL;
+	}
 	if (file_length)
 		*file_length = len;
 


### PR DESCRIPTION
Fixes issue #172 
When loading the gamedir, at some point it tries to run fopen(...) on a directory. In linux, running fopen(...) on a directory returns a valid file descriptor but with a file length of -1 (this is what causes problems). 

For more info:
http://stackoverflow.com/questions/18192998/plain-c-opening-a-directory-with-fopen