### PR TITLE
ALL: fix checks for if-a-string-is-set

### DIFF
--- a/cl_cmd.c
+++ b/cl_cmd.c
@@ -851,7 +851,7 @@ void CL_Serverinfo_f (void)
 	}
 	#endif // CLIENTONLY
 
-	if (cls.state >= ca_onserver && cl.serverinfo)
+	if (cls.state >= ca_onserver && cl.serverinfo[0])
 		Info_Print (cl.serverinfo);
 	else		
 		Com_Printf ("Can't \"%s\", not connected\n", Cmd_Argv(0));

--- a/gl_rsurf.c
+++ b/gl_rsurf.c
@@ -664,7 +664,7 @@ void R_DrawWaterSurfaces (void) {
 		EmitWaterPolys (s);
 
 		//Tei "eshaders". 
-		if (s &&s->texinfo && s->texinfo->texture && s->texinfo->texture->name )
+		if (s &&s->texinfo && s->texinfo->texture && s->texinfo->texture->name[0] )
 		{
 
 			switch(s->texinfo->texture->name[1])

--- a/sv_login.c
+++ b/sv_login.c
@@ -647,7 +647,7 @@ void SV_ParseLogin(client_t *cl)
 		MSG_WriteString (&cl->netchan.message, va("Welcome %s\n", log1));
 
 		//VVD: forcenick ->
-		if ((int)sv_forcenick.value && cl->login)
+		if ((int)sv_forcenick.value && cl->login[0])
 		{
 			Info_Set (&cl->_userinfo_ctx_, "name", cl->login);
 			strlcpy (cl->name, cl->login, CLIENT_NAME_LEN);

--- a/sv_user.c
+++ b/sv_user.c
@@ -2215,7 +2215,7 @@ static void Cmd_SetInfo_f (void)
 		}
 		//<-
 		//VVD: forcenick ->
-		if ((int)sv_forcenick.value && (int)sv_login.value && sv_client->login)
+		if ((int)sv_forcenick.value && (int)sv_login.value && sv_client->login[0])
 		{
 			SV_ClientPrintf(sv_client, PRINT_CHAT,
 			                "You can't change your name while logged in on this server.\n");

--- a/teamplay.c
+++ b/teamplay.c
@@ -2382,7 +2382,7 @@ int TP_PlayersNumber(int userid, const char* team)
 
 	for (i = 0; i < MAX_CLIENTS; i++) {
 		cp = &cl.players[i];
-		if (!cp->name || !cp->name[0] || cp->spectator) continue;
+		if (!cp->name[0] || cp->spectator) continue;
 		if (pt)
 			t2 = !strcmp(cp->team, pt);	// is the current one our teammate?
 		else


### PR DESCRIPTION
It may have been that these were pointers before - but now are character arrays. So better check if the first character is set instead of checking whether the memory address of the character arrays is non-NULL.