### PR TITLE
EX_BROWSER_NET: silence compiler about void* <- int casting

### DIFF
--- a/EX_browser_net.c
+++ b/EX_browser_net.c
@@ -632,7 +632,7 @@ void GetServerPingsAndInfos(int full)
 	ping_phase = 1;
 	ping_pos = 0;
 
-	if (Sys_CreateDetachedThread (GetServerPingsAndInfosProc, (void *) full) < 0) {
+	if (Sys_CreateDetachedThread (GetServerPingsAndInfosProc, (void *)(uintptr_t)full) < 0) {
 		Com_Printf("Failed to create GetServerPingsAndInfosProc thread\n");
 	}
 }


### PR DESCRIPTION
Not sure if all platforms include the `uintptr_t` type currently. Works for me..