### PR TITLE
add pthread on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ ifdef CONFIG_WINDOWS
 	localtime_win.o \
 	sys_win.o \
 	winquake.o
-    LIBS_c += -lopengl32 -lws2_32 -lwinmm
+    LIBS_c += -lopengl32 -lws2_32 -lwinmm -lpthread
 else
     OBJS_c += \
     	localtime_posix.o \


### PR DESCRIPTION
fixes missing symbol sched_yield from libjansson

mingw32-libs/lib/libjansson.a(hashtable_seed.o):(.text+0x41): undefined reference to `sched_yield' 