### PR TITLE
Q_SHARED: do not redefine strcasecmp() and strncasecmp()

### DIFF
--- a/q_shared.h
+++ b/q_shared.h
@@ -206,7 +206,7 @@ char *Q_strcpy( char *to, char *from );
 char *Q_strlwr( char *s1 );
 
 // Added by VVD {
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define strcasecmp(s1, s2)	_stricmp  ((s1),   (s2))
 #define strncasecmp(s1, s2, n)	_strnicmp ((s1),   (s2),   (n))
 // vc++ snprintf and vsnprintf are non-standard and not compatible with C99.


### PR DESCRIPTION
I think these things are due to Visual Studio being Visual Studio. When compiling on MinGW these should not be needed. And in fact the compiler spills a lot of warnings:

```
In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/guiddef.h:149:0,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/winnt.h:628,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/minwindef.h:163,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/windef.h:8,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/windows.h:69,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/winsock2.h:23,
                 from ../common.h:32,
                 from ../zone.c:25:
C:/msys64/mingw64/x86_64-w64-mingw32/include/string.h:120:0: note: this is the location of the previous definition
 #define strcasecmp _stricmp
```

So I think we are better of checking for `_MSC_VER` which indicates a Visual Studio target instead of `_WIN32` which can be either a Visual Studio target or a MinGW target.