### PR TITLE
NET: use our own INVALID_SOCKET #define regardless of what winsock.h …

### DIFF
--- a/net.h
+++ b/net.h
@@ -123,6 +123,12 @@ typedef int socket_t;
 // common definitions.
 //
 
+// winsock2.h defines INVALID_SOCKET as (SOCKET)(~0)
+// SOCKET is 64 bits on x86_64 while int may still be 32 bit wide
+#if defined _WIN32 && defined INVALID_SOCKET
+#undef INVALID_SOCKET
+#endif
+
 #ifndef INVALID_SOCKET
 #define INVALID_SOCKET  -1
 #endif


### PR DESCRIPTION
I think this is new since I start to build 64 MinGW targets. `INVALID_SOCKET` here is 64 bit wide but we assign these to plain integers.

This results in several warnings throughout the code:

```
warning: overflow in implicit constant conversion [-Woverflow]
```

That does make sense as we assign a 64 bit value to a 32 bit wide variable, ultimately truncating half of the info.

It should be just fine though if you go with your regular `-1` instead though.