### PR TITLE
Update COMPILING_ON_LINUX.txt

### DIFF
--- a/COMPILING_ON_LINUX.txt
+++ b/COMPILING_ON_LINUX.txt
@@ -1,13 +1,24 @@
-HOW TO BUILD ON XUBUNTU 15.10:
+HOW TO BUILD ON UBUNTU:
 ------------------------------
 
 1) Make sure you have the dependencies installed:
- $ sudo apt-get install git gitk libsdl2-2.0-0 libsdl2-dev libjansson-dev libexpat1-dev libcurl4-openssl-dev libpng12-dev libjpeg-dev libspeex-dev libspeexdsp-dev
 
-2) Run the following (replace 5 with the number of cpu cores you have + 1)
+- For Ubuntu 15.10-16.04:
+ $ sudo apt-get install git build-essential libsdl2-2.0-0 libsdl2-dev libjansson-dev libexpat1-dev libcurl4-openssl-dev libpng12-dev libjpeg-dev libspeex-dev libspeexdsp-dev
+
+- For Ubuntu 16.10+:
+ $ sudo apt install git build-essential libsdl2-2.0-0 libsdl2-dev libjansson-dev libexpat1-dev libcurl4-openssl-dev libpng-dev libjpeg-dev libspeex-dev libspeexdsp-dev
+
+2) Clone the git repository
+ $ git clone https://github.com/ezQuake/ezquake-source.git
+
+3) Switch to ezquake-source path
+ cd ~/ezquake-source/
+
+4) Run the following (replace 5 with the number of cpu cores you have + 1)
  $ make -j5
 
-3) Copy the built binary to your quake folder, on 64bit linux
+5) Copy the built binary to your quake folder, on 64bit linux
    the binary will be called:
    
    ezquake-linux-x86_64


### PR DESCRIPTION
- Removed 'gitk' from dependicies, it is not required for cloning or building
- Added dependecies for Ubuntu 16.10+ (libpng12-dev was replaced by libpng-dev)
- Added some more steps