### PR TITLE
Make Meson work under any POSIX+X11 OS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -312,7 +312,7 @@ elif host_machine.system() == 'darwin'
 		'-Wl,-framework,IOKit',
 		'-Wl,-framework,OpenGL',
 	]
-elif host_machine.system() == 'linux'
+else # Otherwise assume a roughly POSIX compliant OS with X11.
 	deps += dependency('gl')
 	deps += dependency('xxf86vm')
 	sources += [


### PR DESCRIPTION
We just assume any OS which is not explicitly checked for is roughly POSIX compliant and has X11.

The alternative would be explicitly listing and checking all supported Unix system.

``` meson
elif ['dragonflybsd', 'freebsd', 'linux', 'netbsd', 'openbsd'].contains(host_machine.system())
```

This could get quite long. For example, despite what the [documentation](http://mesonbuild.com/Reference-manual.html#build_machine-object) says, the value of `host_machine.system()` on FreeBSD is not `bsd`, but `freebsd`.
