### PR TITLE
BUG-161: Remove temp files after demo playback.

### DIFF
--- a/cl_demo.c
+++ b/cl_demo.c
@@ -3518,6 +3518,7 @@ void CL_Play_f (void)
 	#ifndef WITH_VFS_ARCHIVE_LOADING
 	#ifdef WITH_ZIP
 	char unpacked_path[MAX_OSPATH];
+	qbool extracted_from_archive = false;
 	#endif // WITH_ZIP
 	#endif // WITH_VFS_ARCHIVE_LOADING
 
@@ -3553,6 +3554,7 @@ void CL_Play_f (void)
 	if (CL_GetUnpackedDemoPath (Cmd_Argv(1), unpacked_path, sizeof(unpacked_path)))
 	{
 		real_name = unpacked_path;
+		extracted_from_archive = true;
 	}
 	#endif // WITH_ZIP
 	#endif // WITH_VFS_ARCHIVE_LOADING
@@ -3665,6 +3667,19 @@ void CL_Play_f (void)
 			// Close the file on disk now that we have read the file into memory
 			VFS_CLOSE(playbackfile);
 			playbackfile = mmap_file;
+			#ifdef WITH_ZIP
+			if (extracted_from_archive)
+			{
+				char tmp_dir[MAX_OSPATH];
+				if (COM_StripFilename(name, tmp_dir, sizeof(tmp_dir)))
+				{
+					// Remove the extracted file
+					unlink(name);
+					// Remove the temporary directory as well
+					Sys_rmdir(tmp_dir);
+				}
+			}
+			#endif // WITH_ZIP
 		}
 	}
 

--- a/common.c
+++ b/common.c
@@ -122,6 +122,38 @@ char *COM_SkipPathWritable (char *pathname)
 	return last;
 }
 
+int COM_StripFilename(const char *pathname, char *dir, int dir_size)
+{
+	int i = 0;
+	int index_last_sep = -1;
+
+	// Find the last directory separator.
+	while (pathname[i])
+	{
+#ifdef WIN32
+		if (pathname[i] == '/' || pathname[i] == '\\')
+#else
+		if (pathname[i] == '/')
+#endif
+		{
+			index_last_sep = i;
+		}
+
+		i++;
+	}
+
+	if ((index_last_sep == -1) || (index_last_sep >= dir_size))
+	{
+		// No directory separator found or buffer too small.
+		return 0;
+	}
+
+	strncpy(dir, pathname, index_last_sep);
+	dir[index_last_sep] = '\0';
+
+	return 1;
+}
+
 //
 // Makes a path fit in a specified sized string "c:\quake\bla\bla\bla" => "c:\quake...la\bla"
 //

--- a/common.h
+++ b/common.h
@@ -177,6 +177,8 @@ void COM_Init (void);
 
 const char *COM_SkipPath (const char *pathname);
 char *COM_SkipPathWritable (char *pathname);
+// Strip filename from pathname and store result in path.
+int COM_StripFilename(const char *pathname, char *dir, int dir_size);
 char *COM_FitPath(char *dest, int destination_size, char *src, int size_to_fit);
 char *COM_FileExtension (const char *in);
 void COM_StripExtension (const char *in, char *out, int out_size);

--- a/fs.c
+++ b/fs.c
@@ -1583,13 +1583,6 @@ int FS_ZlibUnpackToTemp (char *source_path,		// The compressed source file.
 
 #define ZIP_WRITEBUFFERSIZE (8192)
 
-/*
-[19:23:40] <@disconnect|bla> Cokeman: how do you delete temporary files on windows? =:-)
-[19:23:51] <@Cokeman> I don't :D
-[19:23:52] Cokeman hides
-[19:23:55] <@disconnect|bla> zomfg :E
-[19:24:04] <@disconnect|bla> OK. Linux have same behavior now.
-*/
 int FS_ZipUnpackOneFileToTemp (unzFile zip_file,
 						  const char *filename_inzip,
 						  qbool case_sensitive,


### PR DESCRIPTION
Remove the temporary demo file, which is created during playback from archive, when the demo has been loaded in memory (see https://github.com/ezQuake/ezquake-source/issues/161).