### PR TITLE
Fix return value inconsistencies for temp files.

### DIFF
--- a/common.c
+++ b/common.c
@@ -300,6 +300,7 @@ void COM_ForceExtensionEx (char *path, char *extension, size_t path_size)
 
 //
 // Get the path of a temporary directory.
+// Returns length of the path or negative value if error.
 //
 int COM_GetTempDir(char *buf, int bufsize)
 {
@@ -332,6 +333,7 @@ int COM_GetTempDir(char *buf, int bufsize)
 
 //
 // Get a unique temp filename.
+// Returns negative value on failure.
 //
 int COM_GetUniqueTempFilename (char *path, char *filename, int filename_size, qbool verify_exists)
 {
@@ -345,7 +347,7 @@ int COM_GetUniqueTempFilename (char *path, char *filename, int filename_size, qb
 	// (This is done automatically in unix)
 	if (path == NULL)
 	{
-		if (!COM_GetTempDir(real_path, MAX_PATH))
+		if (COM_GetTempDir(real_path, MAX_PATH) < 0)
 		{
 			return -1;
 		}

--- a/fs.c
+++ b/fs.c
@@ -1380,7 +1380,7 @@ int FS_GZipUnpackToTemp (char *source_path,		// The compressed source file.
 {
 	int retval;
 	// Get a unique temp filename.
-	if (!COM_GetUniqueTempFilename (NULL, unpack_path, unpack_path_size, true))
+	if (COM_GetUniqueTempFilename (NULL, unpack_path, unpack_path_size, true) < 0)
 	{
 		return 0;
 	}
@@ -1546,7 +1546,7 @@ int FS_ZlibUnpackToTemp (char *source_path,		// The compressed source file.
 {
 	int retval;
 	// Get a unique temp filename.
-	if (!COM_GetUniqueTempFilename (NULL, unpack_path, unpack_path_size, true))
+	if (COM_GetUniqueTempFilename (NULL, unpack_path, unpack_path_size, true) < 0)
 	{
 		return 0;
 	}
@@ -1602,7 +1602,7 @@ int FS_ZipUnpackOneFileToTemp (unzFile zip_file,
 
 
 	// Get a unique temp filename.
-	if (!COM_GetUniqueTempFilename (NULL, unpack_path, unpack_path_size, true)) {
+	if (COM_GetUniqueTempFilename (NULL, unpack_path, unpack_path_size, true) < 0) {
 		return UNZ_ERRNO;
 	}
 
@@ -1792,7 +1792,7 @@ int FS_ZipUnpackToTemp (unzFile zip_file,
 	int	retval = UNZ_OK;
 
 	// Get a unique temp filename.
-	if (!COM_GetUniqueTempFilename (NULL, unpack_path, unpack_path_size, true))
+	if (COM_GetUniqueTempFilename (NULL, unpack_path, unpack_path_size, true) < 0)
 	{
 		return UNZ_ERRNO;
 	}


### PR DESCRIPTION
The functions "COM_GetUniqueTempFilename" and "COM_GetTempDir" contained
inconsistent handling of return values in some error cases (errors were
being masked).

I noted that error handling strategy varies throughout the code but I opted for zero on failure as that was how the functions were being used.