### PR TITLE
Mainmenu aspect ratio

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -12587,10 +12587,10 @@
     },
     "scr_scaleMenu": {
       "group-id": "17",
-      "type": "boolean",
+      "type": "float",
+      "desc": "Scales the frontend menu.",
       "values": [
-        { "name": "false", "description": "Disable scaling." },
-        { "name": "true", "description": "Scales the frontend menu to match the resolution you are using." }
+        { "name": "0", "description": "Disable scaling." },
       ]
     },
     "scr_scoreboard_afk": {

--- a/menu.c
+++ b/menu.c
@@ -1334,8 +1334,14 @@ void M_Draw (void) {
 	}
 
 	if (scr_scaleMenu.value) {
-		menuwidth = 320;
-		menuheight = min (vid.height, 240);
+		if (vid.aspect > 1.0) {
+			menuheight = bound (240, (int)((vid.height / scr_scaleMenu.value) + 0.5f), 960);
+			menuwidth  = (int) ((menuheight * vid.aspect) + 0.5f);
+		} else {
+			menuwidth  = bound (320, (int)((vid.width / scr_scaleMenu.value) + 0.5f), 960);
+			menuheight = (int) ((menuwidth / vid.aspect) + 0.5f);
+		}
+		
 		glMatrixMode(GL_PROJECTION);
 		glLoadIdentity ();
 		glOrtho  (0, menuwidth, menuheight, 0, -99999, 99999);

--- a/menu.c
+++ b/menu.c
@@ -116,7 +116,7 @@ typedef struct menu_window_s {
 //=============================================================================
 /* Support Routines */
 
-cvar_t     scr_scaleMenu = {"scr_scaleMenu","1"};
+cvar_t     scr_scaleMenu = {"scr_scaleMenu","2"};
 int        menuwidth = 320;
 int        menuheight = 240;
 

--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -1377,6 +1377,8 @@ static void GfxInfo_f(void)
 		Com_Printf_State(PRINT_ALL, "[windowed]\n");
 	}
 
+	Com_Printf_State(PRINT_ALL, "RATIO: %f ", vid.aspect);
+
 	Com_Printf_State(PRINT_ALL, "CONRES: %d x %d\n", r_conwidth.integer, r_conheight.integer );
 
 }
@@ -1540,6 +1542,8 @@ static void VID_UpdateConRes(void)
 		Cvar_SetValue(&r_conwidth, vid.conwidth);
 		Cvar_SetValue(&r_conheight, vid.conheight);
 	}
+
+	vid.aspect = (double) glConfig.vidWidth / (double) glConfig.vidHeight;
 
 	vid.numpages = 2; // ??
 	Draw_AdjustConback();


### PR DESCRIPTION
As I have a 21:9 monitor, the menu is way too stretched.
Before:
![ezquake002](https://user-images.githubusercontent.com/7413949/31409695-10285f5a-ae0d-11e7-9bc3-965746028b79.png)
After:
![ezquake003](https://user-images.githubusercontent.com/7413949/31409712-1a5a8e80-ae0d-11e7-9f51-80c8c488fd76.png)

I also took portrait aspect ratio into consideration, so the menu will still look good if the height is bigger than the width.

I am not sure about vid.aspect, it is defined in vid.h viddef_t. But as far as I can see never actually set.

scr_scaleMenu is now the scale factor of the menu.

