### PR TITLE
BUILD: remove build dependency on xxd utility

### DIFF
--- a/COMPILING_ON_LINUX.txt
+++ b/COMPILING_ON_LINUX.txt
@@ -10,7 +10,7 @@ HOW TO BUILD ON LINUX:
  $ sudo apt install git build-essential libsdl2-2.0-0 libsdl2-dev libjansson-dev libexpat1-dev libcurl4-openssl-dev libpng-dev libjpeg-dev libspeex-dev libspeexdsp-dev
 
 - For Fedora 25+:
- $ sudo dnf install vim-common pcre-devel mesa-libGL-devel SDL2-devel make gcc jansson-devel expat-devel libcurl-devel libpng-devel libjpeg-turbo-devel speex-devel speexdsp-devel
+ $ sudo dnf install pcre-devel mesa-libGL-devel SDL2-devel make gcc jansson-devel expat-devel libcurl-devel libpng-devel libjpeg-turbo-devel speex-devel speexdsp-devel
 
 2) Clone the git repository
  $ git clone https://github.com/ezQuake/ezquake-source.git

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ STRIP ?= strip
 RM ?= rm -f
 RMDIR ?= rm -rf
 MKDIR ?= mkdir -p
-XXD ?= xxd -i
+JSON2C ?= ./json2c.sh
 
 CFLAGS ?= -O2 -Wall -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-strict-aliasing -Werror=strict-prototypes -Werror=old-style-definition -g -MMD $(INCLUDES)
 RCFLAGS ?=
@@ -421,7 +421,7 @@ strip: $(TARG_c)
 
 $(BUILD_c)/%.o: %.json
 	$(E) [JS] $@
-	$(Q)$(XXD) $< > $(BUILD_c)/$*.c
+	$(Q)$(JSON2C) $< > $(BUILD_c)/$*.c
 	$(Q)$(CC) -c $(CFLAGS) $(CFLAGS_c) -o $@ $(BUILD_c)/$*.c
 
 $(BUILD_c)/%.o: %.c

--- a/json2c.sh
+++ b/json2c.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+case "$#" in
+	1)
+		exec 0< "$1"
+		;;
+	2)
+		exec 0< "$1"
+		exec 1> "$2"
+		;;
+	*)
+		echo "Usage: `basename -- "$0"` INPUT [OUTPUT]" >&2
+		exit 64
+		;;
+esac
+od -t x1 -v | awk -v name="`basename -- "$1"`" '
+	BEGIN {
+		if (name ~ /^[0-9]/) {
+			name = "__" name
+		}
+		gsub(/[^0-9A-Za-z]/, "_", name)
+		printf "unsigned char %s[] = {\n", name
+	}
+	{
+		for (i = 2; i <= NF; i++) {
+			printf "\t0x%s,\n", $i
+			len++
+		}
+	}
+	END {
+		printf "};\nunsigned int %s_len = %u;\n", name, len
+	}
+'

--- a/meson.build
+++ b/meson.build
@@ -273,9 +273,9 @@ sources = [
 	'zone.c',
 ]
 
-xxd = find_program('xxd')
-sed = find_program('sed')
-gen = generator(find_program(meson.source_root() + '/xxd.sh'),
+awk = find_program('awk')
+od = find_program('od')
+gen = generator(find_program(meson.source_root() + '/json2c.sh'),
 	output : '@BASENAME@.c',
 	arguments : ['@INPUT@', '@OUTPUT@']
 )

--- a/xxd.sh
+++ b/xxd.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-xxd -i $1 $2
-sed -i"" -E -e 's/[_]*help/help/g' $2


### PR DESCRIPTION
The xxd utility is included with Vim.  It is used in the build
process to convert JSON files into a representation suitable for
inclusion in a C program.

The same task can be accomplished with just regular POSIX
utilities -- mainly awk and od -- which are already present
on most operating systems.  This avoids having to install an
additional complete editor just for this small task in the build
process.