### PR TITLE
Fix backwards memcpy

### DIFF
--- a/pr_cmds.c
+++ b/pr_cmds.c
@@ -1771,7 +1771,7 @@ static void NQP_Flush (int count)
 // FIXME, we make no distinction reliable or not
 	assert (count <= nqp_buf.cursize);
 	SZ_Write (&sv.reliable_datagram, nqp_buf_data, count);
-	memcpy (nqp_buf_data, nqp_buf_data + count, nqp_buf.cursize - count);
+	memmove (nqp_buf_data, nqp_buf_data + count, nqp_buf.cursize - count);
 	nqp_buf.cursize -= count;
 }
 


### PR DESCRIPTION
In pr_cmds.c line 1774, memcpy aborts on overlapping copies. I changed it to memmove and it no longer SIGABRTs.