### PR TITLE
Remove compiler warnings for endian macro being redefined

### DIFF
--- a/q_shared.h
+++ b/q_shared.h
@@ -148,11 +148,17 @@ float	FloatSwapPDP2Lit (float f);
 
 #include <machine/endian.h>
 #if BYTE_ORDER == BIG_ENDIAN
+#ifndef __BIG_ENDIAN__
 #define __BIG_ENDIAN__
+#endif
 #elif BYTE_ORDER == LITTLE_ENDIAN
+#ifndef __LITTLE_ENDIAN__
 #define __LITTLE_ENDIAN__
+#endif
 #elif BYTE_ORDER == PDP_ENDIAN
+#ifndef __PDP_ENDIAN__
 #define __PDP_ENDIAN__
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
In some cases with FreeBSD and OpenBSD (affects clang, might not affect GCC?), there's a warning whenever ```q_shared.h``` is included that looks like this:
```
In file included from com_msg.c:22:
In file included from ./quakedef.h:45:
In file included from ./common.h:35:
./q_shared.h:153:9: warning: '__LITTLE_ENDIAN__' macro redefined [-Wmacro-redefined]
#define __LITTLE_ENDIAN__
        ^
<built-in>:31:9: note: previous definition is here
#define __LITTLE_ENDIAN__ 1
        ^
1 warning generated.
```
The macro will have been defined prior to its definition in ```q_shared.h``` so I added a check to make sure to only set the macro if it already isn't defined.