### PR TITLE
MACOS: fix function prototype

### DIFF
--- a/sys_osx.m
+++ b/sys_osx.m
@@ -14,7 +14,7 @@
 
 static URL *url = NULL;
 
-void init_url_handler()
+void init_url_handler(void)
 {
 	if (url == NULL)
 	{


### PR DESCRIPTION
For pedantic compilers..

```
sys_osx.m:17:6: error: function declaration isn't a prototype [-Werror=strict-prototypes]
void init_url_handler()
```