### PR TITLE
meson: add '-msse2' option when available. apparently we do that for accuracy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,10 @@ c_args = [
 	'-Wno-pointer-to-int-cast',
 ]
 
+if meson.get_compiler('c').has_argument('-msse2')
+	c_args += '-msse2'
+endif
+
 png = dependency('libpng', required : false)
 if png.found()
 	deps += png


### PR DESCRIPTION
Found that in the change-log for 3.1. Better add this to meson too to avoid nasty surprises.