### PR TITLE
Fix the Docker image of the nightly build

### DIFF
--- a/misc/docker-nightly-build/Dockerfile
+++ b/misc/docker-nightly-build/Dockerfile
@@ -1,11 +1,10 @@
-FROM base/archlinux
+FROM debian:buster
 
-MAINTAINER Anders Lindmark <anders.lindmark@gmail.com>
+LABEL authors="Anders Lindmark <anders.lindmark@gmail.com>,Andreas Beisler <eb@subdevice.org>"
 
-# Install prerequisites
-RUN pacman-key --init && pacman-key --refresh-keys
-RUN pacman --noconfirm -Syu && pacman-db-upgrade
-RUN pacman --noconfirm -S gcc git make pkg-config p7zip sdl2 libpng jansson libjpeg-turbo mingw-w64-gcc
+RUN apt-get update && \
+    apt-get install -y git build-essential mingw-w64 libsdl2-2.0-0 libsdl2-dev libjansson-dev libexpat1-dev libcurl4-openssl-dev libpng-dev libjpeg-dev libspeex-dev libspeexdsp-dev p7zip-full && \
+    apt-get clean
 
 # Add buildscript
 ADD mk_nightly.sh /

--- a/misc/docker-nightly-build/README.md
+++ b/misc/docker-nightly-build/README.md
@@ -7,7 +7,7 @@ First, you need to create the docker image. You can do this by running
 docker build -t localghost/ezquake_nightly .
 ```
 or using the [`build_image.sh`](build_image.sh)-script.
-This will create a docker image based on Arch Linux that contains the libraries and tools required to compile linux and windows versions of ezQuake.
+This will create a docker image based on Debian Buster that contains the libraries and tools required to compile linux and windows versions of ezQuake.
 
 Now that we have the image ready we can use it to start containers to build ezQuake.
 
@@ -53,4 +53,4 @@ docker run \
 
 This can be done using the [`linux.sh`](linux.sh)-script. *FORCEBUILD* works here too and you need to set *OUTPUTDIR* and *SOURCEDIR* as well.
 
-Please note that the build environment this uses is *Arch Linux*, if you are compiling on another distribution of linux for use on that distribution you are probably better off installing the dependencies yourself and compiling ezQuake without using this method.
+Please note that the build environment this uses is *Debian Buster*, if you are compiling on another distribution of linux for use on that distribution you are probably better off installing the dependencies yourself and compiling ezQuake without using this method.

--- a/misc/docker-nightly-build/forcebuild.sh
+++ b/misc/docker-nightly-build/forcebuild.sh
@@ -1,4 +1,4 @@
-docker run \
+docker run --rm \
 	-v $SOURCEDIR:/source \
 	-v $OUTPUTDIR:/nightly \
 	-e "FORCEBUILD=TRUE" \

--- a/misc/docker-nightly-build/linux.sh
+++ b/misc/docker-nightly-build/linux.sh
@@ -1,4 +1,4 @@
-docker run \
+docker run --rm \
 	-v $SOURCEDIR:/source \
 	-v $OUTPUTDIR:/nightly \
 	-e "TARGET_PLATFORM=LINUX" \

--- a/misc/docker-nightly-build/mk_nightly.sh
+++ b/misc/docker-nightly-build/mk_nightly.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -d /source/ezquake-source ]; then
 	# We need to initialize the build environment

--- a/misc/docker-nightly-build/nightly.sh
+++ b/misc/docker-nightly-build/nightly.sh
@@ -1,4 +1,4 @@
-docker run \
+docker run --rm \
 	-v $SOURCEDIR:/source \
 	-v $OUTPUTDIR:/nightly \
 	localghost/ezquake_nightly


### PR DESCRIPTION
The Arch Linux repository on Docker Hub has moved, but the Dockerfile didn't build anymore with any of the new tags. Since I'm not familiar with Arch Linux, I switched the build environment to Debian Buster and fixed up the Dockerfile and accompanying scripts.