### PR TITLE
TEAMINFO : fix right-aligned frags in header from 3.2->3.6

### DIFF
--- a/hud_teaminfo.c
+++ b/hud_teaminfo.c
@@ -192,9 +192,12 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 	k = 0;
 	if (hud_teaminfo_show_enemies->integer) {
 		while (sorted_teams[k].name) {
-			int width = Draw_SString(x, _y, sorted_teams[k].name, hud_teaminfo_scale->value, hud_teaminfo_proportional->integer);
+			// hmx : different name/scores alignment options are possible in the header
+			// in which case, make sure to differentiate name width vs teaminfo width
+			// i.e int name_width = Draw_SString()
+			Draw_SString(x, _y, sorted_teams[k].name, hud_teaminfo_scale->value, hud_teaminfo_proportional->integer);
 			snprintf(tmp, sizeof(tmp), "%s %4i", TP_ParseFunChars("$.", false), sorted_teams[k].frags);
-			Draw_SStringAligned(x, y, tmp, 1.0f, hud_teaminfo_scale->value, hud_teaminfo_proportional->integer, text_align_right, x + width);
+			Draw_SStringAligned(x, _y, tmp, hud_teaminfo_scale->value, 1.0f, hud_teaminfo_proportional->integer, text_align_right, x + width);
 			_y += FONTWIDTH * hud_teaminfo_scale->value;
 			for (j = 0; j < slots_num; j++) {
 				i = slots[j];


### PR DESCRIPTION
Going from 3.1 to 3.2, the hud_teaminfo team header started aligning the ". frags" text to the right of the teaminfo element.
In the merge to 3.6 the result was broken when this was switched to *Draw_SStringAligned* :
* *y* argument broken, not using the incrementing version : headers overlapping on one line,
* scaling and alpha arguments flipped,
* width, referring to width of the hud element in most other uses of *Draw_SStringAligned*, was overloaded by a new definition in the loop, breaking *text_align_right*.