### PR TITLE
MENU : double digit precision for float vars, fbskins/rocketlight adjustable as floats

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -15511,22 +15511,23 @@
     },
     "r_rocketLight": {
       "default": "1",
+      "desc": "Enables rocket lights. Values from 0-1 can be used to scale the light.",
       "group-id": "8",
-      "type": "boolean",
+      "type": "float",
       "values": [
         {
-          "description": "Turn off dynamic lighting of rockets.",
-          "name": "false"
+          "description": "Disable dynamic rocket lights.",
+          "name": "0"
         },
         {
-          "description": "Turn on dynamic lighting of rockets.",
-          "name": "true"
+          "description": "Enable dynamic rocket lights, maximum scale.",
+          "name": "1"
         }
       ]
     },
     "r_rocketLightColor": {
       "default": "0",
-      "desc": "Determines the color of the rocket light.",
+      "desc": "Determines the color of the rocket lights.",
       "group-id": "8",
       "type": "enum",
       "values": [

--- a/menu_options.c
+++ b/menu_options.c
@@ -853,7 +853,7 @@ setting settplayer_arr[] = {
 	ADDSET_COLOR	("Shirt Color", topcolor),
 	ADDSET_COLOR	("Pants Color", bottomcolor),
 	ADDSET_ADVANCED_SECTION(),
-	ADDSET_BOOL		("Fullbright Skins", r_fullbrightSkins),
+	ADDSET_NUMBER	("Fullbright Skins", r_fullbrightSkins, 0, 1, 0.05),
 	ADDSET_ENUM    	("Ruleset", ruleset, ruleset_enum),
 	ADDSET_BASIC_SECTION(),
 	
@@ -957,7 +957,7 @@ setting settfps_arr[] = {
 	ADDSET_BASIC_SECTION(),
 	ADDSET_NAMED	("Rocket Trail", r_rockettrail, rockettrail_enum),
 	ADDSET_ADVANCED_SECTION(),
-	ADDSET_BOOL		("Rocket Light", r_rocketlight),
+	ADDSET_NUMBER	("Rocket Light", r_rocketlight, 0, 1, 0.05),
 	ADDSET_NAMED	("Grenade Trail", r_grenadetrail, grenadetrail_enum),
 	ADDSET_BASIC_SECTION(),
 	ADDSET_NUMBER	("Fakeshaft", cl_fakeshaft, 0, 1, 0.05),

--- a/settings_page.c
+++ b/settings_page.c
@@ -125,6 +125,8 @@ static void Setting_DrawNum(int x, int y, int w, setting* setting, qbool active)
 	x = UI_DrawSlider (x, y, SliderPos(setting->min, setting->max, VARFVAL(setting->cvar)));
 	if (setting->step > 0.99)
 		snprintf(buf, sizeof(buf), "%3d", (int) VARFVAL(setting->cvar));
+	else if (((setting->step)*10) < 1)
+		snprintf(buf, sizeof(buf), "%3.2f", VARFVAL(setting->cvar));
 	else
 		snprintf(buf, sizeof(buf), "%3.1f", VARFVAL(setting->cvar));
 


### PR DESCRIPTION
* A bunch of float menu items seem to have double digit precision, but the sliders only use one digit. This enables finer grained control from there as defined per those settings.
* r_fullbrightskins and r_rocketlight do work as floats, but are not documented as such. This exposes the functionality from the menu (help_variables.json not adjusted to reflect this yet) instead of having them as simply booleans.