### PR TITLE
FRAMEBUFFER: Add `vid_framebuffer_smooth 0` for nearest filtering

### DIFF
--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -193,6 +193,7 @@ cvar_t vid_framebuffer_palette     = {"vid_framebuffer_palette",       "0",     
 cvar_t vid_framebuffer_depthformat = {"vid_framebuffer_depthformat",   "0",       CVAR_NO_RESET | CVAR_LATCH };
 cvar_t vid_framebuffer_hdr         = {"vid_framebuffer_hdr",           "0",       CVAR_NO_RESET | CVAR_LATCH };
 cvar_t vid_framebuffer_hdr_tonemap = {"vid_framebuffer_hdr_tonemap",   "0" };
+cvar_t vid_framebuffer_smooth      = {"vid_framebuffer_smooth",        "1",       CVAR_NO_RESET | CVAR_LATCH };
 
 //
 // function declaration
@@ -848,6 +849,7 @@ static void VID_RegisterLatchCvars(void)
 	Cvar_Register(&vid_framebuffer_palette);
 	Cvar_Register(&vid_framebuffer_depthformat);
 	Cvar_Register(&vid_framebuffer_hdr);
+	Cvar_Register(&vid_framebuffer_smooth);
 
 #ifdef X11_GAMMA_WORKAROUND
 	Cvar_Register(&vid_gamma_workaround);


### PR DESCRIPTION
This can be used to obtain a crisper appearance when using an upscaled framebuffer.

See <http://tanalin.com/en/articles/integer-scaling/> for more information.

## Preview

### `vid_framebuffer_smooth 1` (default)

![2020-05-21_14 56 27](https://user-images.githubusercontent.com/180032/82561702-1c357b00-9b74-11ea-8664-7a85045d2c58.png)

### `vid_framebuffer_smooth 0`

![2020-05-21_14 56 49](https://user-images.githubusercontent.com/180032/82561727-23f51f80-9b74-11ea-958e-f9fe44034e6f.png)