### PR TITLE
fixed gamesummary help text for Ring

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -7718,7 +7718,7 @@
         },
         {
           "description": "number of rings taken",
-          "name": "r"
+          "name": "e"
         }
       ]
     },


### PR DESCRIPTION
The letter for ring appears to be E (i guess for eyes) and not R (that's already used by red armor)