### PR TITLE
Fix build on FreeBSD/powerpc64

### DIFF
--- a/host.c
+++ b/host.c
@@ -337,11 +337,19 @@ void SYSINFO_Init(void)
 	SYSINFO_processor_description = cpu_model;
 
 	gettimeofday(&old_tp, NULL);
+#ifdef __powerpc64__
+	__asm__ __volatile__("mfspr %%r3, 268": "=r" (old_tsc));
+#else
 	old_tsc = rdtsc();
+#endif
 	do {
 		gettimeofday(&tp, NULL);
 	} while ((tp.tv_sec - old_tp.tv_sec) * 1000000. + tp.tv_usec - old_tp.tv_usec < 1000000.);
+#ifdef __powerpc64__
+	__asm__ __volatile__("mfspr %%r3, 268": "=r" (tsc_freq));
+#else
 	tsc_freq = rdtsc();
+#endif
 	SYSINFO_MHz = (int)((tsc_freq - old_tsc) /
 						(tp.tv_sec - old_tp.tv_sec + (tp.tv_usec - old_tp.tv_usec) / 1000000.) /
 						1000000. + .5);


### PR DESCRIPTION
rdtsc is available only on Intel architectures. PPC64's equivalent is Time Base Register, which this patch implements.

BTW, support for FreeBSD seems awfully outdated. FreeBSD 4.x has been unsupported for 13 years, so you could use `sysctl hw.clockrate` just fine, but probably only on Intel architectures (it's definitely not supported on powerpc64).