### PR TITLE
NEWHUD : skip player inventory items when freefloating

### DIFF
--- a/hud_ammo.c
+++ b/hud_ammo.c
@@ -224,7 +224,9 @@ void SCR_HUD_DrawAmmoCurrent(hud_t *hud)
 		proportional = HUD_FindVar(hud, "proportional");
 		always = HUD_FindVar(hud, "show_always");
 	}
-	SCR_HUD_DrawAmmo(hud, 0, scale->value, style->value, digits->value, align->string, proportional->integer, always->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmo(hud, 0, scale->value, style->value, digits->value, align->string, proportional->integer, always->integer);
+	}
 }
 
 void SCR_HUD_DrawAmmo1(hud_t *hud)
@@ -238,7 +240,9 @@ void SCR_HUD_DrawAmmo1(hud_t *hud)
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawAmmo(hud, 1, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmo(hud, 1, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+	}
 }
 
 void SCR_HUD_DrawAmmo2(hud_t *hud)
@@ -252,7 +256,9 @@ void SCR_HUD_DrawAmmo2(hud_t *hud)
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawAmmo(hud, 2, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmo(hud, 2, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+	}
 }
 
 void SCR_HUD_DrawAmmo3(hud_t *hud)
@@ -266,7 +272,9 @@ void SCR_HUD_DrawAmmo3(hud_t *hud)
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawAmmo(hud, 3, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmo(hud, 3, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+	}
 }
 
 void SCR_HUD_DrawAmmo4(hud_t *hud)
@@ -280,7 +288,9 @@ void SCR_HUD_DrawAmmo4(hud_t *hud)
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawAmmo(hud, 4, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmo(hud, 4, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+	}
 }
 
 // icons - active ammo, armor, face etc..
@@ -293,19 +303,21 @@ void SCR_HUD_DrawAmmoIcon(hud_t *hud, int num, float scale, int style)
 
 	width = height = (style ? 8 : 24) * scale;
 
-	if (!HUD_PrepareDraw(hud, width, height, &x, &y) || num == 0)
-		return;
+	if (cl.spectator == autocam) {
+		if (!HUD_PrepareDraw(hud, width, height, &x, &y) || num == 0)
+			return;
 
-	if (style) {
-		switch (num) {
-			case 1: Draw_SAlt_String(x, y, "s", scale, false); break;
-			case 2: Draw_SAlt_String(x, y, "n", scale, false); break;
-			case 3: Draw_SAlt_String(x, y, "r", scale, false); break;
-			case 4: Draw_SAlt_String(x, y, "c", scale, false); break;
+		if (style) {
+			switch (num) {
+				case 1: Draw_SAlt_String(x, y, "s", scale, false); break;
+				case 2: Draw_SAlt_String(x, y, "n", scale, false); break;
+				case 3: Draw_SAlt_String(x, y, "r", scale, false); break;
+				case 4: Draw_SAlt_String(x, y, "c", scale, false); break;
+			}
 		}
-	}
-	else {
-		Draw_SPic(x, y, sb_ammo[num - 1], scale);
+		else {
+			Draw_SPic(x, y, sb_ammo[num - 1], scale);
+		}
 	}
 }
 
@@ -351,7 +363,9 @@ void SCR_HUD_DrawAmmoIcon1(hud_t *hud)
 		scale = HUD_FindVar(hud, "scale");
 		style = HUD_FindVar(hud, "style");
 	}
-	SCR_HUD_DrawAmmoIcon(hud, 1, scale->value, style->value);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmoIcon(hud, 1, scale->value, style->value);
+	}
 }
 
 void SCR_HUD_DrawAmmoIcon2(hud_t *hud)
@@ -362,7 +376,9 @@ void SCR_HUD_DrawAmmoIcon2(hud_t *hud)
 		scale = HUD_FindVar(hud, "scale");
 		style = HUD_FindVar(hud, "style");
 	}
-	SCR_HUD_DrawAmmoIcon(hud, 2, scale->value, style->value);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmoIcon(hud, 2, scale->value, style->value);
+	}
 }
 
 void SCR_HUD_DrawAmmoIcon3(hud_t *hud)
@@ -373,7 +389,9 @@ void SCR_HUD_DrawAmmoIcon3(hud_t *hud)
 		scale = HUD_FindVar(hud, "scale");
 		style = HUD_FindVar(hud, "style");
 	}
-	SCR_HUD_DrawAmmoIcon(hud, 3, scale->value, style->value);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmoIcon(hud, 3, scale->value, style->value);
+	}
 }
 
 void SCR_HUD_DrawAmmoIcon4(hud_t *hud)
@@ -384,7 +402,9 @@ void SCR_HUD_DrawAmmoIcon4(hud_t *hud)
 		scale = HUD_FindVar(hud, "scale");
 		style = HUD_FindVar(hud, "style");
 	}
-	SCR_HUD_DrawAmmoIcon(hud, 4, scale->value, style->value);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawAmmoIcon(hud, 4, scale->value, style->value);
+	}
 }
 
 void Ammo_HudInit(void)

--- a/hud_armor.c
+++ b/hud_armor.c
@@ -82,8 +82,9 @@ static void SCR_HUD_DrawArmor(hud_t *hud)
 		level = 0;
 		low = true;
 	}
-
-	SCR_HUD_DrawNum(hud, level, low, scale->value, style->value, digits->value, align->string, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawNum(hud, level, low, scale->value, style->value, digits->value, align->string, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawArmorIcon(hud_t *hud)
@@ -108,57 +109,59 @@ static void SCR_HUD_DrawArmorIcon(hud_t *hud)
 
 	height = (style ? 8 : 24) * scale;
 
-	if (style) {
-		int c;
+	if (cl.spectator == autocam) {
+		if (style) {
+			int c;
 
-		if (!HUD_PrepareDraw(hud, FontFixedWidth(1, scale, 0, v_proportional->integer), height, &x, &y)) {
-			return;
-		}
+			if (!HUD_PrepareDraw(hud, FontFixedWidth(1, scale, 0, v_proportional->integer), height, &x, &y)) {
+				return;
+			}
 
-		if (HUD_Stats(STAT_ITEMS) & IT_INVULNERABILITY) {
-			c = '@';
-		}
-		else  if (HUD_Stats(STAT_ITEMS) & IT_ARMOR3) {
-			c = 'r';
-		}
-		else if (HUD_Stats(STAT_ITEMS) & IT_ARMOR2) {
-			c = 'y';
-		}
-		else if (HUD_Stats(STAT_ITEMS) & IT_ARMOR1) {
-			c = 'g';
+			if (HUD_Stats(STAT_ITEMS) & IT_INVULNERABILITY) {
+				c = '@';
+			}
+			else  if (HUD_Stats(STAT_ITEMS) & IT_ARMOR3) {
+				c = 'r';
+			}
+			else if (HUD_Stats(STAT_ITEMS) & IT_ARMOR2) {
+				c = 'y';
+			}
+			else if (HUD_Stats(STAT_ITEMS) & IT_ARMOR1) {
+				c = 'g';
+			}
+			else {
+				return;
+			}
+
+			c += 128;
+
+			Draw_SCharacterP(x, y, c, scale, v_proportional->integer);
 		}
 		else {
-			return;
-		}
+			mpic_t* pic;
 
-		c += 128;
+			if (!HUD_PrepareDraw(hud, 24 * scale, height, &x, &y)) {
+				return;
+			}
 
-		Draw_SCharacterP(x, y, c, scale, v_proportional->integer);
-	}
-	else {
-		mpic_t  *pic;
+			if (HUD_Stats(STAT_ITEMS) & IT_INVULNERABILITY) {
+				pic = draw_disc;
+			}
+			else  if (HUD_Stats(STAT_ITEMS) & IT_ARMOR3) {
+				pic = sb_armor[2];
+			}
+			else if (HUD_Stats(STAT_ITEMS) & IT_ARMOR2) {
+				pic = sb_armor[1];
+			}
+			else if (HUD_Stats(STAT_ITEMS) & IT_ARMOR1) {
+				pic = sb_armor[0];
+			}
+			else {
+				return;
+			}
 
-		if (!HUD_PrepareDraw(hud, 24 * scale, height, &x, &y)) {
-			return;
+			Draw_SPic(x, y, pic, scale);
 		}
-
-		if (HUD_Stats(STAT_ITEMS) & IT_INVULNERABILITY) {
-			pic = draw_disc;
-		}
-		else  if (HUD_Stats(STAT_ITEMS) & IT_ARMOR3) {
-			pic = sb_armor[2];
-		}
-		else if (HUD_Stats(STAT_ITEMS) & IT_ARMOR2) {
-			pic = sb_armor[1];
-		}
-		else if (HUD_Stats(STAT_ITEMS) & IT_ARMOR1) {
-			pic = sb_armor[0];
-		}
-		else {
-			return;
-		}
-
-		Draw_SPic(x, y, pic, scale);
 	}
 }
 
@@ -186,7 +189,7 @@ void SCR_HUD_DrawBarArmor(hud_t *hud)
 		color_unnatural = HUD_FindVar(hud, "color_unnatural");
 	}
 
-	if (HUD_PrepareDraw(hud, width->integer, height->integer, &x, &y)) {
+	if (HUD_PrepareDraw(hud, width->integer, height->integer, &x, &y) && (cl.spectator == autocam)) {
 		if (!width->integer || !height->integer) {
 			return;
 		}

--- a/hud_face.c
+++ b/hud_face.c
@@ -43,6 +43,9 @@ void SCR_HUD_DrawFace(hud_t *hud)
 
 	scale = max(v_scale->value, 0.01);
 
+	if (cl.spectator != autocam)
+		return;
+	
 	if (!HUD_PrepareDraw(hud, 24 * scale, 24 * scale, &x, &y))
 		return;
 

--- a/hud_guns.c
+++ b/hud_guns.c
@@ -188,7 +188,9 @@ static void SCR_HUD_DrawGun2(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawGunByNum(hud, 2, scale->value, style->value, 0, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawGunByNum(hud, 2, scale->value, style->value, 0, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawGun3(hud_t *hud)
@@ -200,7 +202,9 @@ static void SCR_HUD_DrawGun3(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawGunByNum(hud, 3, scale->value, style->value, 0, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawGunByNum(hud, 3, scale->value, style->value, 0, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawGun4(hud_t *hud)
@@ -212,7 +216,9 @@ static void SCR_HUD_DrawGun4(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawGunByNum(hud, 4, scale->value, style->value, 0, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawGunByNum(hud, 4, scale->value, style->value, 0, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawGun5(hud_t *hud)
@@ -224,7 +230,9 @@ static void SCR_HUD_DrawGun5(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawGunByNum(hud, 5, scale->value, style->value, 0, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawGunByNum(hud, 5, scale->value, style->value, 0, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawGun6(hud_t *hud)
@@ -236,7 +244,9 @@ static void SCR_HUD_DrawGun6(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawGunByNum(hud, 6, scale->value, style->value, 0, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawGunByNum(hud, 6, scale->value, style->value, 0, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawGun7(hud_t *hud)
@@ -248,7 +258,9 @@ static void SCR_HUD_DrawGun7(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawGunByNum(hud, 7, scale->value, style->value, 0, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawGunByNum(hud, 7, scale->value, style->value, 0, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawGun8(hud_t *hud)
@@ -261,7 +273,9 @@ static void SCR_HUD_DrawGun8(hud_t *hud)
 		wide = HUD_FindVar(hud, "wide");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawGunByNum(hud, 8, scale->value, style->value, wide->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawGunByNum(hud, 8, scale->value, style->value, wide->value, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawGunCurrent(hud_t *hud)
@@ -298,7 +312,9 @@ static void SCR_HUD_DrawGunCurrent(hud_t *hud)
 		}
 	}
 
-	SCR_HUD_DrawGunByNum(hud, gun, scale->value, style->value, wide->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawGunByNum(hud, gun, scale->value, style->value, wide->value, proportional->integer);
+	}
 }
 
 void Guns_HudInit(void)

--- a/hud_health.c
+++ b/hud_health.c
@@ -55,7 +55,9 @@ static void SCR_HUD_DrawHealth(hud_t *hud)
 	}
 
 	value = HUD_Stats(STAT_HEALTH);
-	SCR_HUD_DrawNum(hud, (value < 0 ? 0 : value), HUD_HealthLow(), scale->value, style->value, digits->value, align->string, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawNum(hud, (value < 0 ? 0 : value), HUD_HealthLow(), scale->value, style->value, digits->value, align->string, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawHealthDamage(hud_t *hud)
@@ -85,7 +87,7 @@ static void SCR_HUD_DrawBarHealth(hud_t *hud)
 		color_unnatural = HUD_FindVar(hud, "color_unnatural");
 	}
 
-	if (HUD_PrepareDraw(hud, width->integer, height->integer, &x, &y)) {
+	if (HUD_PrepareDraw(hud, width->integer, height->integer, &x, &y) && (cl.spectator == autocam)) {
 		if (!width->integer || !height->integer) {
 			return;
 		}

--- a/hud_items.c
+++ b/hud_items.c
@@ -33,7 +33,8 @@ static void SCR_HUD_DrawPowerup(hud_t *hud, int num, float scale, int style, qbo
 
 	scale = max(scale, 0.01);
 
-	switch (style) {
+	if (cl.spectator == autocam) {
+		switch (style) {
 		case 1:     // letter
 			width = FontFixedWidth(1, scale, false, proportional);
 			height = 8 * scale;
@@ -62,6 +63,7 @@ static void SCR_HUD_DrawPowerup(hud_t *hud, int num, float scale, int style, qbo
 				Draw_SPic(x, y, sb_items[num], scale);
 			}
 			break;
+		}
 	}
 }
 
@@ -74,7 +76,9 @@ static void SCR_HUD_DrawKey1(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawPowerup(hud, 0, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawPowerup(hud, 0, scale->value, style->value, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawKey2(hud_t *hud)
@@ -86,7 +90,9 @@ static void SCR_HUD_DrawKey2(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawPowerup(hud, 1, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawPowerup(hud, 1, scale->value, style->value, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawRing(hud_t *hud)
@@ -98,7 +104,9 @@ static void SCR_HUD_DrawRing(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawPowerup(hud, 2, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawPowerup(hud, 2, scale->value, style->value, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawPent(hud_t *hud)
@@ -110,7 +118,9 @@ static void SCR_HUD_DrawPent(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawPowerup(hud, 3, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawPowerup(hud, 3, scale->value, style->value, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawSuit(hud_t *hud)
@@ -122,7 +132,9 @@ static void SCR_HUD_DrawSuit(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawPowerup(hud, 4, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawPowerup(hud, 4, scale->value, style->value, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawQuad(hud_t *hud)
@@ -134,7 +146,9 @@ static void SCR_HUD_DrawQuad(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawPowerup(hud, 5, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawPowerup(hud, 5, scale->value, style->value, proportional->integer);
+	}
 }
 
 // -----------
@@ -146,8 +160,8 @@ static void SCR_HUD_DrawSigil(hud_t *hud, int num, float scale, int style, qbool
 	int     x, y;
 
 	scale = max(scale, 0.01);
-
-	switch (style) {
+	if (cl.spectator == autocam) {
+		switch (style) {
 		case 1:     // sigil number
 			if (!HUD_PrepareDraw(hud, 8 * scale, 8 * scale, &x, &y)) {
 				return;
@@ -164,6 +178,7 @@ static void SCR_HUD_DrawSigil(hud_t *hud, int num, float scale, int style, qbool
 				Draw_SPic(x, y, sb_sigil[num], scale);
 			}
 			break;
+		}
 	}
 }
 
@@ -176,7 +191,9 @@ static void SCR_HUD_DrawSigil1(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawSigil(hud, 0, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawSigil(hud, 0, scale->value, style->value, proportional->integer);
+	}
 }
 
 void SCR_HUD_DrawSigil2(hud_t *hud)
@@ -188,7 +205,9 @@ void SCR_HUD_DrawSigil2(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawSigil(hud, 1, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawSigil(hud, 1, scale->value, style->value, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawSigil3(hud_t *hud)
@@ -200,7 +219,9 @@ static void SCR_HUD_DrawSigil3(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawSigil(hud, 2, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawSigil(hud, 2, scale->value, style->value, proportional->integer);
+	}
 }
 
 static void SCR_HUD_DrawSigil4(hud_t *hud)
@@ -212,7 +233,9 @@ static void SCR_HUD_DrawSigil4(hud_t *hud)
 		style = HUD_FindVar(hud, "style");
 		proportional = HUD_FindVar(hud, "proportional");
 	}
-	SCR_HUD_DrawSigil(hud, 3, scale->value, style->value, proportional->integer);
+	if (cl.spectator == autocam) {
+		SCR_HUD_DrawSigil(hud, 3, scale->value, style->value, proportional->integer);
+	}
 }
 
 void Items_HudInit(void)


### PR DESCRIPTION
In newhud, going freefloat keeps the last tracked player's inventory on the screen, disconnected from its actual state.
This change makes it behave as per oldhud (and other Quakes etc) where going freefloat does not show the last player's inventory.