### PR TITLE
TRAVIS: macOS, remove python3.9 before installing deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libsdl2-2.0-0 libegl1-mesa-dev libgles2-mesa-dev libsdl2-dev libjansson-dev libexpat1-dev libcurl4-openssl-dev libpng-dev libjpeg-dev libspeex-dev libspeexdsp-dev libfreetype6-dev libsndfile1-dev; fi
   - if [[ "$EZ_CONFIG_FILE" == ".config_windows" ]]; then sudo apt-get install -y mingw-w64; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink python@3.9; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl2 sdl2_net sdl2_image sdl2_gfx sdl2_mixer jansson speex speexdsp libsndfile; fi
 
 script:


### PR DESCRIPTION
    Installing dependencies will pull in a newer version of python3.9.
    For some reason installing over an existing installation fails
    miserably. Removing it prior seems fine.
