### PR TITLE
Limitation of the cl_rollangle from 0 to 10 for ruleset thunderdome

### DIFF
--- a/cl_screen.c
+++ b/cl_screen.c
@@ -3097,7 +3097,9 @@ static void SCR_DrawElements(void)
 					// QW262
 					SCR_DrawHud ();
 
-					MVD_Screen ();
+					if (cls.mvdplayback) {
+						MVD_Screen();
+					}
 
 					// VULT STATS
 					SCR_DrawAMFstats();

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -3369,10 +3369,11 @@ static char *Sshot_SshotDirectory(void) {
 	return dir;
 }
 
+// defined in cl_view
 #ifdef X11_GAMMA_WORKAROUND
-unsigned short ramps[3][4096];
+extern unsigned short ramps[3][4096];
 #else
-unsigned short  ramps[3][256];
+extern unsigned short  ramps[3][256];
 #endif
 
 //applies hwgamma to RGB data

--- a/cl_tent.c
+++ b/cl_tent.c
@@ -52,6 +52,7 @@ typedef struct explosion_s
 	model_t *model;
 } explosion_t;
 
+temp_entity_list_t temp_entities;
 
 // cl_free_explosions = linear linked list of free explosions
 explosion_t	cl_explosions[MAX_EXPLOSIONS];

--- a/cl_view.c
+++ b/cl_view.c
@@ -105,7 +105,7 @@ float V_CalcRoll (vec3_t angles, vec3_t velocity) {
 	sign = side < 0 ? -1 : 1;
 	side = fabs(side);
 
-	side = (side < cl_rollspeed.value) ? side * cl_rollangle.value / cl_rollspeed.value : cl_rollangle.value;
+	side = (side < cl_rollspeed.value) ? side * Ruleset_RollAngle() / cl_rollspeed.value : Ruleset_RollAngle();
 
 	if (side > 45)
 		side = 45;
@@ -773,7 +773,7 @@ void V_CalcViewRoll (void) {
 	float side, adjspeed;
 
 	side = V_CalcRoll (cl.simangles, cl.simvel);
-	adjspeed = cl_rollalpha.value * bound (2, fabs(cl_rollangle.value), 45);
+	adjspeed = cl_rollalpha.value * bound (2, Ruleset_RollAngle(), 45);
 	if (side > cl.rollangle) {
 		cl.rollangle += cls.frametime * adjspeed;
 		if (cl.rollangle > side)

--- a/cmd.c
+++ b/cmd.c
@@ -760,6 +760,10 @@ void Cmd_Alias_f (void)
 		Com_Printf ("Alias name is too long\n");
 		return;
 	}
+	else if (s[0] == '\0') {
+		Com_Printf("Alias name must be specified\n");
+		return;
+	}
 
 	key = Com_HashKey(s) % ALIAS_HASHPOOL_SIZE;
 

--- a/common_draw.h
+++ b/common_draw.h
@@ -92,7 +92,7 @@ void HUD_AfterDraw(void);
 
 qbool Draw_BigFontAvailable(void);
 
-int *gameclockoffset;  // hud_gameclock time offset in seconds
+extern int *gameclockoffset;  // hud_gameclock time offset in seconds
 
 void SCR_DrawWadString(int x, int y, float scale, const char *t);
 void SCR_HUD_DrawBar(int direction, int value, float max_value, byte *color, int x, int y, int width, int height);

--- a/cvar.c
+++ b/cvar.c
@@ -306,6 +306,10 @@ void Cvar_Register (cvar_t *var)
 	int key;
 	cvar_t *old = Cvar_Find (var->name);
 
+	// All variables must be named :)
+	if (var->name[0] == '\0')
+		return;
+
 #ifdef SERVERONLY
 	char* value;
 

--- a/gl_local.h
+++ b/gl_local.h
@@ -285,7 +285,7 @@ void GL_MakeAliasModelDisplayLists (model_t *m, aliashdr_t *hdr);
 
 // gl_rsurf.c
 
-#define	MAX_LIGHTMAPS		192
+#define	MAX_LIGHTMAPS		1024
 
 void EmitDetailPolys (void);
 void R_DrawBrushModel (entity_t *e);

--- a/host.c
+++ b/host.c
@@ -303,8 +303,8 @@ void SYSINFO_Init(void)
 {
 	char cpu_model[256];
 
-	int mib[2], val;
-	unsigned long val_ul;
+	int mib[2];
+	unsigned long long val;
 	size_t len;
 	unsigned long long old_tsc, tsc_freq;
 	struct timeval tp, old_tp;
@@ -320,9 +320,9 @@ void SYSINFO_Init(void)
 // VVD: We can use HW_REALMEM (hw.realmem) for RELENG_5/6/7 for getting exact result,
 // but RELENG_4 have only HW_PHYSMEM (hw.physmem).
 	len = sizeof(val);
-	sysctl(mib, sizeof(mib) / sizeof(mib[0]), &val_ul, &len, NULL, 0);
+	sysctl(mib, sizeof(mib) / sizeof(mib[0]), &val, &len, NULL, 0);
 
-	SYSINFO_memory = val_ul;
+	SYSINFO_memory = val;
 
 	mib[0] = CTL_HW;
 	mib[1] = HW_MODEL;
@@ -351,7 +351,7 @@ void SYSINFO_Init(void)
 		SYSINFO_3D_description = Q_strdup(gl_renderer);
 	}
 
-	snprintf(f_system_string, sizeof(f_system_string), "%dMB", (int)(SYSINFO_memory / 1024. / 1024. + .5));
+	snprintf(f_system_string, sizeof(f_system_string), "%lluMB", (int)(SYSINFO_memory / 1024LLU / 1024LLU));
 
 	if (SYSINFO_processor_description) {
 		strlcat(f_system_string, ", ", sizeof(f_system_string));

--- a/hud_common.c
+++ b/hud_common.c
@@ -56,6 +56,9 @@ hud_t *hud_netgraph = NULL;
 // Items to be filtered out
 static int itemsclock_filter = 0;
 
+// ugh
+int* gameclockoffset;  // hud_gameclock time offset in seconds
+
 // ----------------
 // HUD planning
 //

--- a/keys.c
+++ b/keys.c
@@ -295,7 +295,7 @@ qbool CheckForCommand (void)
 		;
 	*s = 0;
 
-	return (Cvar_Find(command) || Cmd_FindCommand(command) || Cmd_FindAlias(command) || Cmd_IsLegacyCommand(command));
+	return command[0] && (Cvar_Find(command) || Cmd_FindCommand(command) || Cmd_FindAlias(command) || Cmd_IsLegacyCommand(command));
 }
 
 //===================================================================

--- a/menu_options.c
+++ b/menu_options.c
@@ -902,7 +902,7 @@ setting settfps_arr[] = {
 	ADDSET_NUMBER	("View Size (fov)", scr_fov, 40, 140, 2),
 	ADDSET_NUMBER	("Screen Size", scr_viewsize, 30, 120, 5),
 	ADDSET_ADVANCED_SECTION(),
-	ADDSET_NUMBER	("Rollangle", cl_rollangle, 0, 30, 2),
+	ADDSET_NUMBER	("Rollangle", cl_rollangle, 0, 10, 1),
 	ADDSET_NUMBER	("Rollspeed", cl_rollspeed, 0, 30, 2),
 	ADDSET_BOOL		("Gun Kick", v_gunkick),
 	ADDSET_NUMBER	("Kick Pitch", v_kickpitch, 0, 10, 0.5),

--- a/mvd_utils.c
+++ b/mvd_utils.c
@@ -1005,7 +1005,6 @@ char *MVD_BestAmmo (int i) {
 void MVD_Info (void){
 	char str[1024];
 	char mvd_info_final_string[1024], mvd_info_powerups[20], mvd_info_header_string[1024];
-	char *mapname;
 	int x,y,z,i;
 
 
@@ -1017,7 +1016,7 @@ void MVD_Info (void){
 	z=1;
 
 	if (loc_loaded == 0){
-		mapname = TP_MapName();
+		char* mapname = TP_MapName();
 		TP_LoadLocFile (mapname, true);
 		loc_loaded = 1;
 	}
@@ -2238,8 +2237,8 @@ void MVD_Utils_Init (void) {
 }
 
 void MVD_Screen (void){
-	MVD_Info ();
-	MVD_Status ();
+	MVD_Info();
+	MVD_Status();
 }
 
 void MVD_FlushUserCommands (void)

--- a/protocol.h
+++ b/protocol.h
@@ -465,5 +465,5 @@ typedef struct temp_entity_list_s
 	int				count;
 } temp_entity_list_t;
 
-temp_entity_list_t	temp_entities;
+extern temp_entity_list_t temp_entities;
 

--- a/rulesets.c
+++ b/rulesets.c
@@ -81,7 +81,7 @@ qbool RuleSets_DisallowModelOutline(struct model_s *mod)
 		case MOD_THUNDERBOLT:
 			return true;
 		default:
-			return rulesetDef.ruleset == rs_qcon || rulesetDef.ruleset == rs_smackdown || rulesetDef.ruleset == rs_thunderdome;
+			return rulesetDef.ruleset == rs_qcon || rulesetDef.ruleset == rs_smackdown;
 	}
 }
 

--- a/rulesets.c
+++ b/rulesets.c
@@ -33,6 +33,7 @@ static rulesetDef_t rulesetDef = {
 	72.0,
 	false,
 	false,
+	false,
 	false
 };
 
@@ -223,6 +224,7 @@ static void Rulesets_Smackdown(qbool enable)
 		rulesetDef.restrictPacket = true; // packet command could have been exploited for external timers
 		rulesetDef.restrictParticles = true;
 		rulesetDef.ruleset = rs_smackdown;
+		rulesetDef.restrictRollAngle = true;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
 			Cvar_SetFlags(disabled_cvars[i].var, Cvar_GetFlags(disabled_cvars[i].var) & ~CVAR_ROM);
@@ -235,6 +237,7 @@ static void Rulesets_Smackdown(qbool enable)
 		rulesetDef.restrictPacket = false;
 		rulesetDef.restrictParticles = false;
 		rulesetDef.ruleset = rs_default;
+		rulesetDef.restrictRollAngle = false;
 	}
 }
 
@@ -274,6 +277,7 @@ static void Rulesets_Qcon(qbool enable)
 		rulesetDef.restrictParticles = true;
 		rulesetDef.restrictSound = true;
 		rulesetDef.ruleset = rs_qcon;
+		rulesetDef.restrictRollAngle = true;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
 			Cvar_SetFlags(disabled_cvars[i].var, Cvar_GetFlags(disabled_cvars[i].var) & ~CVAR_ROM);
@@ -287,6 +291,7 @@ static void Rulesets_Qcon(qbool enable)
 		rulesetDef.restrictParticles = false;
 		rulesetDef.restrictSound = false;
 		rulesetDef.ruleset = rs_default;
+		rulesetDef.restrictRollAngle = false;
 	}
 }
 static void Rulesets_Thunderdome(qbool enable)
@@ -322,6 +327,7 @@ static void Rulesets_Thunderdome(qbool enable)
 		rulesetDef.restrictPacket = true; // packet command could have been exploited for external timers
 		rulesetDef.restrictParticles = false;
 		rulesetDef.ruleset = rs_thunderdome;
+		rulesetDef.restrictRollAngle = true;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
 			Cvar_SetFlags(disabled_cvars[i].var, Cvar_GetFlags(disabled_cvars[i].var) & ~CVAR_ROM);
@@ -334,6 +340,7 @@ static void Rulesets_Thunderdome(qbool enable)
 		rulesetDef.restrictPacket = false;
 		rulesetDef.restrictParticles = false;
 		rulesetDef.ruleset = rs_default;
+		rulesetDef.restrictRollAngle = false;
 	}
 }
 static void Rulesets_MTFL(qbool enable)
@@ -383,6 +390,7 @@ static void Rulesets_MTFL(qbool enable)
 			Cvar_SetFlags(limited_min_cvars[i].var, Cvar_GetFlags(limited_min_cvars[i].var) | CVAR_RULESET_MIN);
 		}
 
+		rulesetDef.restrictRollAngle = false;
 		rulesetDef.ruleset = rs_mtfl;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
@@ -394,6 +402,7 @@ static void Rulesets_MTFL(qbool enable)
 		for (i = 0; i < (sizeof(limited_min_cvars) / sizeof(limited_min_cvars[0])); i++)
 			Cvar_SetFlags(limited_min_cvars[i].var, Cvar_GetFlags(limited_min_cvars[i].var) & ~CVAR_RULESET_MIN);
 
+		rulesetDef.restrictRollAngle = false;
 		rulesetDef.ruleset = rs_default;
 	}
 }
@@ -684,4 +693,15 @@ qbool Ruleset_AllowPolygonOffset(entity_t* ent)
 	default:
 		return ent->model && ent->model->isworldmodel;
 	}
+}
+
+float Ruleset_RollAngle(void)
+{
+	extern cvar_t cl_rollangle;
+
+	if (cls.demoplayback || cl.spectator || !rulesetDef.restrictRollAngle) {
+		return fabs(cl_rollangle.value);
+	}
+
+	return bound(0.0f, cl_rollangle.value, 5.0f);
 }

--- a/rulesets.h
+++ b/rulesets.h
@@ -51,6 +51,7 @@ typedef struct rulesetDef_s {
 	qbool restrictPacket;
 	qbool restrictParticles;
 	qbool restrictSound;
+	qbool restrictRollAngle;
 } rulesetDef_t;
 
 void  Rulesets_Init(void);
@@ -78,3 +79,5 @@ void Rulesets_OnChange_allow_scripts (cvar_t *var, char *value, qbool *cancel);
 void Rulesets_OnChange_cl_fakeshaft (cvar_t *var, char *value, qbool *cancel);
 void Rulesets_OnChange_cl_delay_packet(cvar_t *var, char *value, qbool *cancel);
 void Rulesets_OnChange_cl_iDrive(cvar_t *var, char *value, qbool *cancel);
+
+float Ruleset_RollAngle(void);

--- a/snd_mem.c
+++ b/snd_mem.c
@@ -793,6 +793,11 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 		return NULL;
 	}
 
+	if (info.dataofs + info.samples * info.channels > filesize) {
+		Com_Printf("%s is corrupt/truncated, delete and re-download\n", s->name);
+		return NULL;
+	}
+
 	if (info.width == 1)
 		COM_CharBias((signed char*)data + info.dataofs, info.samples * info.channels);
 	else if (info.width == 2)

--- a/version.h
+++ b/version.h
@@ -70,7 +70,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 // Note: for server mods to detect version, change VERSION_NUM below
-#define VERSION_NUMBER "3.2"
+#define VERSION_NUMBER "3.2.1"
 
 int build_number(void);
 void CL_Version_f(void);

--- a/version.h
+++ b/version.h
@@ -70,7 +70,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 // Note: for server mods to detect version, change VERSION_NUM below
-#define VERSION_NUMBER "3.2.2-rc1"
+#define VERSION_NUMBER "3.2.2"
 
 int build_number(void);
 void CL_Version_f(void);

--- a/version.h
+++ b/version.h
@@ -70,7 +70,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 // Note: for server mods to detect version, change VERSION_NUM below
-#define VERSION_NUMBER "3.2.2"
+#define VERSION_NUMBER "3.2.3"
 
 int build_number(void);
 void CL_Version_f(void);

--- a/version.h
+++ b/version.h
@@ -70,7 +70,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 // Note: for server mods to detect version, change VERSION_NUM below
-#define VERSION_NUMBER "3.2.1"
+#define VERSION_NUMBER "3.2.2-rc1"
 
 int build_number(void);
 void CL_Version_f(void);

--- a/vfs.h
+++ b/vfs.h
@@ -131,7 +131,7 @@ vfsfile_t *FS_OpenTCP(char *name);
 // GZIP (*.gz) Support
 //=====================
 #ifdef WITH_ZLIB
-searchpathfuncs_t gzipfilefuncs;
+extern searchpathfuncs_t gzipfilefuncs;
 #endif // WITH_ZLIB
 
 //=====================

--- a/vx_coronas.c
+++ b/vx_coronas.c
@@ -45,6 +45,7 @@ typedef struct
 #define MAX_CORONAS 300
 
 corona_t	r_corona[MAX_CORONAS];
+int ParticleCount, ParticleCountHigh, CoronaCount, CoronaCountHigh, MotionBlurCount, MotionBlurCountHigh;
 
 #define CORONA_SCALE 130
 #define CORONA_ALPHA 1

--- a/vx_stuff.c
+++ b/vx_stuff.c
@@ -27,6 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 int GL_LoadTextureImage (char * , char *, int, int, int);
 int coronatexture;
+int	gunflashtexture;
+int	explosionflashtexture1;
+int	explosionflashtexture2;
+int	explosionflashtexture3;
+int	explosionflashtexture4;
+int	explosionflashtexture5;
+int	explosionflashtexture6;
+int	explosionflashtexture7;
 
 extern cvar_t gl_bounceparticles;
 

--- a/vx_stuff.h
+++ b/vx_stuff.h
@@ -49,15 +49,15 @@ void InitCoronas(void);
 void InitVXStuff(void);
 void NewStaticLightCorona (coronatype_t type, vec3_t origin, entity_t *serialhint);
 
-int	coronatexture;
-int	gunflashtexture;
-int	explosionflashtexture1;
-int	explosionflashtexture2;
-int	explosionflashtexture3;
-int	explosionflashtexture4;
-int	explosionflashtexture5;
-int	explosionflashtexture6;
-int	explosionflashtexture7;
+extern int coronatexture;
+extern int gunflashtexture;
+extern int explosionflashtexture1;
+extern int explosionflashtexture2;
+extern int explosionflashtexture3;
+extern int explosionflashtexture4;
+extern int explosionflashtexture5;
+extern int explosionflashtexture6;
+extern int explosionflashtexture7;
 
 float CL_TraceLine (vec3_t start, vec3_t end, vec3_t impact, vec3_t normal);
 void WeatherEffect(void);
@@ -126,7 +126,7 @@ extern cvar_t amf_part_trailwidth;
 extern cvar_t amf_part_trailtype;
 
 void SCR_DrawAMFstats(void);
-int ParticleCount, ParticleCountHigh, CoronaCount, CoronaCountHigh, MotionBlurCount, MotionBlurCountHigh;
+extern int ParticleCount, ParticleCountHigh, CoronaCount, CoronaCountHigh, MotionBlurCount, MotionBlurCountHigh;
 void CL_CreateBlurs (vec3_t start, vec3_t end, entity_t *ent);
 void CL_UpdateBlurs (void);
 


### PR DESCRIPTION
I think this limitation must be applied for qcon and smackdown rulesets too.

Please, commit it and create release 3.2.3 before Thunderdome 15 starts at middle of February.

Patch in attach:
[ezquake-source.rollangle.diff.txt](https://github.com/ezQuake/ezquake-source/files/5826507/ezquake-source.rollangle.diff.txt)