### PR TITLE
MACOS: fix/change/refactor application bundle

### DIFF
--- a/misc/install/create_osx_bundle.sh
+++ b/misc/install/create_osx_bundle.sh
@@ -14,6 +14,7 @@ ARCH=$(uname -m | sed -e s/i.86/i386/ -e s/amd64/x86_64/ -e s/sun4u/sparc64/ -e 
 BUNDLE_NAME=ezQuake.app
 BINARY=ezquake-darwin-${ARCH}
 ICON_FILE=ezquake.icns
+VERSION=$(cat version.h | grep VERSION_NUMBER | cut -d " " -f 3 | sed -e 's/^"//' -e 's/"$//')
 
 if [ -d $BUNDLE_NAME ]; then
 	echo "$BUNDLE_NAME already exists"
@@ -26,30 +27,33 @@ if [ ! -f $BINARY ]; then
 fi
 
 mkdir -p $BUNDLE_NAME/Contents/MacOS
-mkdir -p $BUNDLE_NAME/Contents/Resources/id1
+mkdir -p $BUNDLE_NAME/Contents/Resources
 cp $BINARY $BUNDLE_NAME/Contents/MacOS/.
 cp $(dirname $0)/$ICON_FILE $BUNDLE_NAME/Contents/Resources/.
-touch $BUNDLE_NAME/Contents/Resources/id1/Copy\ your\ pak0.pak\ and\ pak1.pak\ files\ here.txt
 
 echo '#!/bin/sh' > $BUNDLE_NAME/Contents/MacOS/ezquake
 echo '' >> $BUNDLE_NAME/Contents/MacOS/ezquake
-echo 'DIRNAME="$(cd "$(dirname "$0")"; pwd -P)"' >> $BUNDLE_NAME/Contents/MacOS/ezquake
+echo 'DIRNAME="$HOME"/Library/Application\ Support/ezQuake' >> $BUNDLE_NAME/Contents/MacOS/ezquake
 echo '' >> $BUNDLE_NAME/Contents/MacOS/ezquake
-echo 'if [ ! -f "$DIRNAME"/../Resources/id1/pak0.pak ]; then' >> $BUNDLE_NAME/Contents/MacOS/ezquake
-echo '    osascript -e "tell app \"Finder\" to open (\"${DIRNAME%/*}/Resources/id1/\" as POSIX file)"' >> $BUNDLE_NAME/Contents/MacOS/ezquake
+echo 'if [ ! -f "$DIRNAME"/id1/pak0.pak ]; then' >> $BUNDLE_NAME/Contents/MacOS/ezquake
+echo '    mkdir -p "$DIRNAME"/id1' >> $BUNDLE_NAME/Contents/MacOS/ezquake
+echo '    touch "$DIRNAME"/id1/Copy\ your\ pak0.pak\ and\ pak1.pak\ files\ here.txt' >> $BUNDLE_NAME/Contents/MacOS/ezquake
+echo '    osascript -e "tell app \"Finder\" to open (\"${DIRNAME}/id1/\" as POSIX file)"' >> $BUNDLE_NAME/Contents/MacOS/ezquake
 echo '    osascript -e "tell app \"Finder\" to activate"' >> $BUNDLE_NAME/Contents/MacOS/ezquake
 echo '    exit' >> $BUNDLE_NAME/Contents/MacOS/ezquake
 echo 'fi' >> $BUNDLE_NAME/Contents/MacOS/ezquake
 echo '' >> $BUNDLE_NAME/Contents/MacOS/ezquake
-echo "exec \"\$DIRNAME\"/$BINARY -basedir \"\$DIRNAME\"/../Resources" >> $BUNDLE_NAME/Contents/MacOS/ezquake
+echo 'PNAME="$(cd "$(dirname "$0")"; pwd -P)"' >> $BUNDLE_NAME/Contents/MacOS/ezquake
+echo '' >> $BUNDLE_NAME/Contents/MacOS/ezquake
+echo "exec \"\$PNAME\"/$BINARY -basedir \"\$DIRNAME\"" >> $BUNDLE_NAME/Contents/MacOS/ezquake
 
 chmod u+x $BUNDLE_NAME/Contents/MacOS/ezquake
 
 /usr/libexec/PlistBuddy -c "Add :CFBundleName string \"ezQuake\"" $BUNDLE_NAME/Contents/Info.plist > /dev/null
 /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string \"$ICON_FILE\"" $BUNDLE_NAME/Contents/Info.plist
 /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string \"ezquake\"" $BUNDLE_NAME/Contents/Info.plist
-/usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string \"net.sf.ezquake\"" $BUNDLE_NAME/Contents/Info.plist
-/usr/libexec/PlistBuddy -c "Add :CFBundleVersion string \"3.0.0\"" $BUNDLE_NAME/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string \"io.github.ezquake\"" $BUNDLE_NAME/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleVersion string \"$VERSION\"" $BUNDLE_NAME/Contents/Info.plist
 
 # qw:// protocol support
 /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array" $BUNDLE_NAME/Contents/Info.plist
@@ -68,4 +72,4 @@ chmod u+x $BUNDLE_NAME/Contents/MacOS/ezquake
 /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:0:CFBundleTypeExtensions:0 string mvd" $BUNDLE_NAME/Contents/Info.plist
 
 sh $(dirname $0)/fixbundle.sh $BUNDLE_NAME $BUNDLE_NAME/Contents/MacOS/$BINARY
-ditto -c -k --keepParent --arch x86_64 $BUNDLE_NAME ezquake.zip
+ditto -c -k --keepParent --arch x86_64 --arch arm64 $BUNDLE_NAME ezquake.zip

--- a/misc/install/fixbundle.sh
+++ b/misc/install/fixbundle.sh
@@ -54,7 +54,7 @@ if [ ! -d "$FRAMEWORK_DIR" ]; then
 fi
 
 function get_deps {
-	echo $(otool -L "$1" | grep local | awk '{print $1}')
+	echo $(otool -L "$1" | grep 'local\|homebrew' | awk '{print $1}')
 }
 
 # readlink -f


### PR DESCRIPTION
- change bundle identifier to ezquake.github.io (fixes #294)
- add a sensible version string taken from version.h to the bundle
- move the base dir to $HOME/Library/Application Support/ezQuake (data files outside bundle on a per user basis, for convenient update, secure bundle stuff, when downloading?)
- check deps being in 'homebrew' folder, newer versions seem to have changed locations

Note that packaging invalidates signatures of dylibs, so we need to figure out how to re-sign.