### PR TITLE
MACOS: codesign changes for bundle creation

### DIFF
--- a/misc/install/fixbundle.sh
+++ b/misc/install/fixbundle.sh
@@ -89,7 +89,9 @@ done
 
 function fix_symbols {
 	for DEP in $(get_deps "$1"); do
+		codesign --remove-signature "$1"
 		install_name_tool -change "$DEP" "@executable_path/../Frameworks/$(basename $(realpath $DEP))" "$1"
+		codesign -s - "$1"
 	done
 }
 


### PR DESCRIPTION
ARM builds will require a codesign - period. So we remove the
exisiting signature coming from brew.sh and add some addhoc
signature after install_name_tool is run. It may not pass
Gatekepper, but if one disables Gatekeeper locally you actually
have a chance to correctly run it.

--

With these changes I was actually able to create a M1 bundle that runs.
