### PR TITLE
Add basic howto build Ubuntu 20.04 build in Docker

### DIFF
--- a/COMPILING_ON_LINUX_DOCKER.txt
+++ b/COMPILING_ON_LINUX_DOCKER.txt
@@ -1,0 +1,26 @@
+HOW TO BUILD ON LINUX using Dockerfile:
+---------------------------------------
+
+1) Install Docker or something similar
+2) Create docker image to be able to run compilation tools:
+
+  docker build --no-cache -t ezq:dev-focal -f Dockerfile.focal .
+
+3) Run command to generate a binary for current linux platform:
+
+  docker run -it -v $(pwd):/ezquake-source --user "$(id -u):$(id -g)" ezq:dev-focal make -j$(nproc) clean
+  docker run -it -v $(pwd):/ezquake-source --user "$(id -u):$(id -g)" ezq:dev-focal make -j$(nproc) all
+
+4) As a result you should have a for example: `./ezquake-linux-x86_64` which can be used with ~/nquake
+
+  cp -f ./ezquake-linux-x86_64 ~/nquake/
+  cd ~/nquake/
+  hash -r 
+  ./ezquake-linux-x86_64
+
+
+TODO:
+---------------------------------------
+- multi-arch
+- other distros (centos, debian, older distros)
+- using kaniko https://github.com/GoogleContainerTools/kaniko

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -1,8 +1,9 @@
 FROM ubuntu:20.04 as builder
 
 ENV TZ=ETC/Utc
+# hadolint ignore=DL3008
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     curl \

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -1,0 +1,25 @@
+FROM ubuntu:20.04 as builder
+
+ENV TZ=ETC/Utc
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    libfreetype6-dev \
+    libjansson-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libsdl2-2.0-0 \
+    libsdl2-dev \
+    libsndfile-dev \
+    libspeex-dev \
+    libspeexdsp-dev \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ezquake-source/
+USER 1000


### PR DESCRIPTION
Add basic Dockerfile for Ubuntu Focal
Add basic .txt file how to compile under Linux with Docker.

Signed-off-by: Michał Sochoń <kaszpir@gmail.com>

Partially solves #545 - I was able to compile binary for my platform in about 5 minutes :D