### PR TITLE
HELP: third batch of updates

### DIFF
--- a/help_commands.json
+++ b/help_commands.json
@@ -1,6 +1,6 @@
 {
   "+attack": {
-    "description": "When active the player will fire the weapon he is currently holding. This is the primary command used to make the player fire the gun. For as long as the key that is bound to this command is held down and this command is active the player will keep on firing the gun."
+    "description": "When active the player will fire the weapon he is currently holding.\nThis is the primary command used to make the player fire the gun.\nFor as long as the key that is bound to this command is held down and this command is active the player will keep on firing the gun."
   },
   "+attack2": {
     "description": "Secondary attack button."
@@ -18,10 +18,10 @@
     "description": "When active the player will move forward."
   },
   "+jump": {
-    "description": "When active the player will do a single jump. The next jump won't be performed  until \"-jump\" has been issued."
+    "description": "When active the player will do a single jump. The next jump won't be performed until \"-jump\" has been issued."
   },
   "+klook": {
-    "description": "When active, \"+forward\" and \"+back\" become \"+lookup\" and \"+lookdown\"  respectively. This command is useful if the player needs to look at objects  which are above or below him."
+    "description": "When active, \"+forward\" and \"+back\" become \"+lookup\" and \"+lookdown\"  respectively.\nThis command is useful if the player needs to look at objects which are above or below him."
   },
   "+left": {
     "description": "When active the player will turn left."
@@ -33,7 +33,7 @@
     "description": "When active the player will look up."
   },
   "+mlook": {
-    "description": "When active moving the mouse or joystick forwards and backwards performs  \"+lookup\" and \"+lookdown\" respectively. This command is very useful if the  player needs to look at objects which are above or below him. Most players  execute this command and never remove it. This way they can use the keyboard to  move the player forward and back and strafe left and right, while using the  mouse to turn the player left and right and to make him look up and down. In  order to have this command set permanently you will have to create a file called  autoexec.cfg in the qw/ directory and put in the line \"+mlook\" into that file.  By doing this the game will automatically execute the autoexec.cfg file and it  will also active that command.  Almost every player uses this command nowadays, because the combination of using  mouse and keyboard is widely considered the best."
+    "description": "When active moving the mouse or joystick forwards and backwards performs \"+lookup\" and \"+lookdown\" respectively.\nThis command is very useful if the player needs to look at objects which are above or below him.\nMost players execute this command and never remove it. This way they can use the keyboard to move the player forward and back and strafe left and right, while using the mouse to turn the player left and right and to make him look up and down.\nIn order to have this command set permanently you will have to create a file called autoexec.cfg in the qw/ directory and put in the line \"+mlook\" into that file.\nBy doing this the game will automatically execute the autoexec.cfg file and it will also active that command.\nAlmost every player uses this command nowadays, because the combination of using mouse and keyboard is widely considered the best."
   },
   "+movedown": {
     "description": "When active the player will swim down when in the water."
@@ -63,10 +63,10 @@
     "description": "When active the player will run."
   },
   "+strafe": {
-    "description": "When active, \"+left\" and \"+right\" function like \"+moveleft\" and \"+moveright\",  strafing in that direction."
+    "description": "When active, \"+left\" and \"+right\" function like \"+moveleft\" and \"+moveright\", strafing in that direction."
   },
   "+use": {
-    "description": "When used it will activate objects in the game that have been designed to react  at \"+use\""
+    "description": "When used it will activate objects in the game that have been designed to react at \"+use\""
   },
   "+voip": {
     "system-generated": true
@@ -96,7 +96,7 @@
     "description": "When used the player will stop jumping if \"+jump\" is active."
   },
   "-klook": {
-    "description": "When used the forward and back keys will stop making the player look up and  down if \"+klook\" is active."
+    "description": "When used the forward and back keys will stop making the player look up and down if \"+klook\" is active."
   },
   "-left": {
     "description": "When used the player will stop turning left if \"+left\" is active."
@@ -108,7 +108,7 @@
     "description": "When used the player will stop looking up if \"+lookup\" is active."
   },
   "-mlook": {
-    "description": "When used the mouse forward and back movement will stop making the player look  up and down if \"+mlook\" is active."
+    "description": "When used the mouse forward and back movement will stop making the player look up and down if \"+mlook\" is active."
   },
   "-movedown": {
     "description": "When used the player will stop moving down if \"+movedown\" is active."
@@ -138,10 +138,10 @@
     "description": "When used the player will walk."
   },
   "-strafe": {
-    "description": "When used the turn left and turn right keys will once again perform their  original functions."
+    "description": "When used the turn left and turn right keys will once again perform their original functions."
   },
   "-use": {
-    "description": "When used it will stop activating objects in the game that have been designed to  react at \"+use\"."
+    "description": "When used it will stop activating objects in the game that have been designed to react at \"+use\"."
   },
   "-voip": {
     "system-generated": true
@@ -165,8 +165,8 @@
     "system-generated": true
   },
   "addip": {
-    "description": "Add a single IP or a domain of IPs to the IP list of the server. Very useful for  banning people or for specifing which IPs only have access to the server.  Examples:  addip 123.123.123.123  addip 123.123.123",
-    "syntax": "(ip)"
+    "description": "Add a single IP or a domain of IPs to the IP list of the server.\nVery useful for banning people or for specifying which IPs only have access to the server.\n\nExamples:\naddip 123.123.123.123\naddip 123.123.123",
+    "syntax": "<ip>"
   },
   "addloc": {
     "arguments": [
@@ -176,30 +176,31 @@
       }
     ],
     "description": "Adds a new loc with the specified name at current location.",
-    "syntax": "addloc \"locname\""
+    "syntax": "\"locname\""
   },
   "addserver": {
-    "description": "Server Browser: This allows you to add a server to the UNBOUND source. This can be used to quickly bookmark servers."
+    "description": "Server Browser: This allows you to add a server to the UNBOUND source.\nThis can be used to quickly bookmark servers."
   },
   "alias": {
-    "description": "Used to create a reference to a command or list of commands. When used without  parameters, displays all current aliases.  Note: Enclose multiple commands within quotes and seperate each command with a semi-colon."
+    "description": "Used to create a reference to a command or list of commands.\nWhen used without parameters, displays all current aliases.",
+    "remarks": "Enclose multiple commands within quotes and separate each command with a semi-colon."
   },
   "alias_in": {
     "arguments": [
       {
-        "description": "alias to be changed",
+        "description": "Alias to be changed",
         "name": "alias"
       },
       {
-        "description": "variable whose value is inserted into alias",
+        "description": "Variable whose value is inserted into alias",
         "name": "variable"
       },
       {
-        "description": "bitmask, 1 - (0 - insert from left, 1 - from right side) 2 - (check in advance whether a string being inserted already exists in alias)  4 - (print an error message if the inserted string is already present in the alias)  8 - (automatically create an alias if it doesn't exist yet) ",
+        "description": "Bitmask:\n0 - insert from left\n1 - from right side\n2 - check in advance whether a string being inserted already exists in alias\n4 - print an error message if the inserted string is already present in the alias\n8 - automatically create an alias if it doesn't exist yet",
         "name": "options"
       }
     ],
-    "description": "Inserts contents of variable into alias. ",
+    "description": "Inserts contents of variable into alias.",
     "syntax": "<alias> <variable> [<options>]"
   },
   "alias_out": {
@@ -212,7 +213,7 @@
   "aliaslist": {
     "arguments": [
       {
-        "description": "will print only [regexp] matching aliases",
+        "description": "Prints only [regexp] matching aliases",
         "name": "[regexp]"
       }
     ],
@@ -223,13 +224,13 @@
     "system-generated": true
   },
   "allskins": {
-    "description": "Downloads all skins that is currently in use. Useful for refreshing skins without  exiting the level"
+    "description": "Downloads all skins that is currently in use.\nUseful for refreshing skins without exiting the level."
   },
   "authenticate": {
     "system-generated": true
   },
   "autotrack": {
-    "description": "Toggles auto-tracking. Auto-tracking switches views for you when you are a spectator or when you are watching a demo or a broadcasted QTV match. It chooses the best available autotrack - if you are spectator, looks for server-side command autotrack, if you are watching a demo or QTV stream, turns on both demo_autotrack and mvd_autotrack, mvd_autotrack will get turned off as soon as demo_autotrack data are found. As a last resort if all previous autotrack are not available, cl_hightrack will be used."
+    "description": "Toggles auto-tracking.\nAuto-tracking switches views for you when you are a spectator or when you are watching a demo or a broadcasted QTV match.\nIt chooses the best available autotrack - if you are spectator, looks for server-side command autotrack, if you are watching a demo or QTV stream, turns on both demo_autotrack and mvd_autotrack, mvd_autotrack will get turned off as soon as demo_autotrack data are found.\nAs a last resort if all previous autotrack are not available, cl_hightrack will be used."
   },
   "bar_armor": {
     "description": "HUD element that displays a bar representing your amount of armor."
@@ -241,10 +242,10 @@
     "system-generated": true
   },
   "bf": {
-    "description": "This command shows a background screen flash that is the same one that is  produced when the player picked up an item in the game. This command basically  serves no useful function except when people want to use it in scripts to give  the user some visual feedback when an aliases is used for example."
+    "description": "This command shows a background screen flash that is the same one that is produced when the player picked up an item in the game.\nThis command basically serves no useful function except when people want to use it in scripts to give the user some visual feedback when an aliases is used for example."
   },
   "bind": {
-    "description": "This command binds one or several commands to a key. To bind multiple commands  to a key, enclose the commands in double-quotes (\") and separate them with  semicolons (;)."
+    "description": "This command binds one or several commands to a key.\nTo bind multiple commands to a key, enclose the commands in double-quotes (\") and separate them with semicolons (;)."
   },
   "bindlist": {
     "description": "Prints all binds."
@@ -252,11 +253,11 @@
   "calc_fov": {
     "arguments": [
       {
-        "description": "The old wideaspect fov used in v2.x",
+        "description": "The old wide aspect FOV used in v2.x",
         "name": "old_fov"
       }
     ],
-    "description": "Convert (ezq2) wideaspect fov to new fov"
+    "description": "Converts (ezq2) wide aspect FOV to new FOV."
   },
   "calendar": {
     "description": "Same as \"date\" but also shows a small calendar of the month. Nice :)"
@@ -272,46 +273,48 @@
         "name": "yaw"
       }
     ],
-    "description": "Set new angles",
-    "syntax": "cam_angles pitch yaw or cam_angles \"pitch yaw\""
+    "description": "Set new camera angles.",
+    "syntax": "<pitch> <yaw> or cam_angles \"pitch yaw\""
   },
   "cam_pos": {
     "arguments": [
       {
-        "description": "X-coord.",
+        "description": "X coordinate",
         "name": "x"
       },
       {
-        "description": "Y-coord.",
+        "description": "Y coordinate",
         "name": "y"
       },
       {
-        "description": "Z-coord.",
+        "description": "Z coordinate",
         "name": "z"
       }
     ],
-    "description": "Set new position",
-    "syntax": "cam_pos x y z or cam_pos \"x y z"
+    "description": "Set new camera position.",
+    "syntax": "<x> <y> <z> or cam_pos \"x y z"
   },
   "cancel": {
     "system-generated": true
   },
   "cd": {
-    "description": "cd play 5 plays cd track #5  Note: You need -cdaudio to use this command."
+    "description": "cd play 5 plays cd track #5",
+    "remarks": "You need -cdaudio to use this command."
   },
   "centerview": {
     "description": "Centers the player's view ahead after +lookup or +lookdown."
   },
   "cfg_load": {
     "description": "This will do a cfg_reset and then execute filename.cfg (ezquake/configs).",
-    "syntax": "(filename)"
+    "syntax": "<filename>"
   },
   "cfg_reset": {
-    "description": "This command will unbind all keys, delete all aliases, msg_triggers,  reset all plus commands, teamplay settings and reset all variables.  User made variables (created with set/seta) are deleted.  After resetting all the above, it executes default.cfg and then autoexec.cfg."
+    "description": "This command will unbind all keys, delete all aliases, msg_triggers, reset all plus commands, teamplay settings and reset all variables.\nUser made variables (created with set/seta) are deleted.\nAfter resetting all the above, it executes default.cfg and then autoexec.cfg."
   },
   "cfg_save": {
-    "description": "This command will dump all aliases, bindings, plus commands,  msg_triggers, teamplay settings and variables to filename.cfg .  User made variables (created with set/seta) are saved as well.  Note: configs saved with cfg_save are saved in quake/ezquake/configs/*.cfg",
-    "syntax": "(filename)"
+    "description": "This command will dump all aliases, bindings, plus commands, msg_triggers, teamplay settings and variables to filename.cfg .\nUser made variables (created with set/seta) are saved as well.",
+    "remarks":"configs saved with cfg_save are saved in quake/ezquake/configs/*.cfg",
+    "syntax": "<filename>"
   },
   "check_maps": {
     "system-generated": true
@@ -335,7 +338,8 @@
     "description": "This command same as cmdlist, but supports (perl) regexp matching."
   },
   "color": {
-    "description": "This command sets the color for the player's shirt and pants.  Note: If only the shirt color is given, the pant color will match."
+    "description": "This command sets the color for the player's shirt and pants.",
+    "remarks": "If only the shirt color is given, the pant color will match."
   },
   "connect": {
     "arguments": [
@@ -360,21 +364,21 @@
     "system-generated": true
   },
   "cvar_reset": {
-    "description": "This will reset cvar to default.  Example:  cvar_reset topcolor will set topcolor to default.",
+    "description": "Resets the cvar to default.\n\nExample:\ncvar_reset topcolor\n - sets topcolor to default.",
     "syntax": "<cvar>"
   },
   "cvar_reset_re": {
-    "description": "This will reset cvar to default. Example: cvar_reset ^gl_.* - resets all OpenGL settings to default values.",
-    "syntax": "<cvar>"
+    "description": "Resets cvar(s) matching the regex to default.\n\nExample:\ncvar_reset ^gl_.*\n- resets all gl_ settings to default values.",
+    "syntax": "[regex]"
   },
   "cvaredit": {
     "system-generated": true
   },
   "cvarlist": {
-    "description": "Print cvars"
+    "description": "Print cvars."
   },
   "cvarlist_re": {
-    "description": "This command same as cvarlist, but supports (perl) regexp matching. "
+    "description": "This command same as cvarlist, but supports (perl) regexp matching."
   },
   "date": {
     "description": "Shows current time, date, month and year."
@@ -382,30 +386,31 @@
   "demo_capture": {
     "arguments": [
       {
-        "description": "Directive that tells the client to start capturing.",
+        "description": "Tells the client to start capturing.",
         "name": "start"
       },
       {
-        "description": "Number of seconds the capturing should take. Can be float value. Must be positive. Required argument.",
+        "description": "Duration of the capture, in seconds.\nCan be float value. Must be positive. Required argument.",
         "name": "time"
       },
       {
-        "description": "When third argument is present instead of singlescreenshot avifile will be saved. See demo_capture_codec.",
+        "description": "An .avi file is saved instead of screenshots. See demo_capture_codec.",
         "name": "avifile"
       },
       {
-        "description": "You can force the client to stop capturing before the time given by <time> argument passes.",
+        "description": "Stop the capture manually before <time>.\nExample: demo_capture stop",
         "name": "stop"
       }
     ],
-    "description": "Captures series of screenshot or avi file. See below.",
-    "syntax": "<start time [avifile] | stop>"
+    "description": "Captures a series of screenshots or an .avi file.",
+    "syntax": "<start> <time> [avifile] | <stop>"
   },
   "demo_controls": {
     "system-generated": true
   },
   "demo_jump": {
-    "description": "This jumps playback to a point in time you specify.  Examples:  demo_jump 120 will make playback jump to 120 seconds from the start of  the demo.  demo_jump 4:30 will make playback jump to 4 minutes and 30 seconds  from the start of the demo."
+    "description": "Jumps playback to a point in time.\n\nExamples:\ndemo_jump 120\n - Jump playback to 120 seconds from the start of the demo.\ndemo_jump 4:30\n - Jump playback to 4 minutes and 30 seconds from the start of the demo.",
+    "syntax": "[+|-][m:]<s>"
   },
   "demo_jump_mark": {
     "system-generated": true
@@ -421,24 +426,24 @@
     "syntax": "<condition>"
   },
   "demo_playlist_clear": {
-    "description": "clears the demo playlist"
+    "description": "Clears the demo playlist."
   },
   "demo_playlist_next": {
-    "description": "will go to the next demo in the playlist"
+    "description": "Goes to the next demo in the playlist."
   },
   "demo_playlist_prev": {
-    "description": "will go to the previous demo in the playlist"
+    "description": "Goes to the previous demo in the playlist."
   },
   "demo_playlist_stop": {
-    "description": "will stop the demo playlist playback"
+    "description": "Stops the demo playlist playback."
   },
   "demo_setspeed": {
-    "description": "You can vary the speed of demo playback with the 'demo_setspeed' command.  'demo_setspeed x' sets the playback speed to x% of normal speed so that 'demo_setspeed 50'  is half speed and 'demo_setspeed 300' gives you triple speed.",
+    "description": "You can vary the speed of demo playback with the 'demo_setspeed' command.\n'demo_setspeed x' sets the playback speed to x% of normal speed so that 'demo_setspeed 50' is half speed and 'demo_setspeed 300' gives you triple speed.",
     "syntax": "[default: 100]"
   },
   "describe": {
     "description": "Prints manual info about given variable or command into the console.",
-    "syntax": "(variable or command name)"
+    "syntax": "<variable or command name>"
   },
   "dev_cache_print": {
     "system-generated": true
@@ -474,8 +479,9 @@
     "system-generated": true
   },
   "dev_pointfile": {
-    "description": "If qbsp generates a non-zero .pts file a leak exists in the level. This file is created in the maps directory. By using the pointfile command, it will load the .pts file and give a dotted line indicating where the leak(s) are on the level.",
-    "syntax": "(filename)"
+    "description": "The pointfile command will load a .pts file and give a dotted line indicating where the leak(s) are on the level.",
+    "syntax": "<filename>",
+    "remarks":"If a leak exists in the level, qbsp generates a non-zero .pts file in the maps directory."
   },
   "devmap": {
     "description": "Try it in cheats mode, start a map (devmap dm6) and type fly."
@@ -487,18 +493,18 @@
     "description": "This command will disconnect you from the server/demo/proxy you are currently connected to."
   },
   "dns": {
-    "description": "Performs dns lookups and reverse lookups.",
-    "syntax": "(address)"
+    "description": "Performs DNS lookups and reverse lookups.",
+    "syntax": "<address>"
   },
   "download": {
-    "description": "Manually download a quake file from the server.  Example:  download skins/foo.pcx"
+    "description": "Manually download a quake file from the server.\n\nExample:\ndownload skins/foo.pcx"
   },
   "easyrecord": {
-    "description": "This start recording demo and rename it like you have put with match_*  settings."
+    "description": "This start recording demo and rename it like you have put with match_* settings."
   },
   "echo": {
     "description": "This command will print text to your local console.",
-    "syntax": "(text)"
+    "syntax": "<text>"
   },
   "edict": {
     "description": "Reports information on a given edict in the game."
@@ -510,7 +516,8 @@
     "description": "Displays information on all edicts in the game."
   },
   "enemycolor": {
-    "description": "This will overwride enemy color.  Example:  enemycolor 12 13  Note: If only the shirt color is given, the pant color will match."
+    "description": "This will override enemy color.\n\nExample:\nenemycolor 12 13",
+    "remarks": "If only the shirt color is given, the pant color will match."
   },
   "eval": {
     "arguments": [
@@ -519,14 +526,15 @@
         "name": "expression"
       }
     ],
-    "description": "Evaluates given expression and prints the result into the console",
+    "description": "Evaluates given expression and prints the result into the console.",
     "syntax": "<expression>"
   },
   "exec": {
     "description": "Executes a config file from \\qw, \\id1 or \\ezquake."
   },
   "f_modified": {
-    "description": "All the usual dm models, sounds, palettes etc are included in the check.  In teamfortress the teamfortress flag, dispensers and sentry guns are also  checked. There is also an f_modified command which will print your  f_modified response.  Note: You need to install security files."
+    "description": "All the usual dm models, sounds, palettes etc are included in the check.\nIn Team Fortress the TF flag, dispensers and sentry guns are also checked. There is also an f_modified command which will print your f_modified response.",
+    "remarks":"You need to install security files."
   },
   "f_ruleset": {
     "system-generated": true
@@ -535,7 +543,7 @@
     "description": "Prints proxies you are using."
   },
   "filter": {
-    "description": "Message filtering system. Only team messages are filtered.  Use filter with no parameters to list current filters and filter clear to remove all filters.  Example:  filter #a  say_team i can see this message #a.  say_team i can't see this message #d."
+    "description": "Message filtering system. Only team messages are filtered.\nUse filter with no parameters to list current filters and filter clear to remove all filters.\n\nExample:\nfilter #a  say_team i can see this message #a.\nsay_team i can't see this message #d."
   },
   "find": {
     "system-generated": true
@@ -565,10 +573,11 @@
     "system-generated": true
   },
   "flush": {
-    "description": "This command will clear the current game cache. It is usually used by developers  to flush the memory of all game information and objects to test if the mechanism  which handles the loading of the necessary files into memory works properly.  Sometimes the game cache can become filled with unnecessary information and may  need to be flushed manually. This is usually not necessary since the game  automatically flushes all the data between every map."
+    "description": "This command will clear the current game cache.\nIt is usually used by developers to flush the memory of all game information and objects to test if the mechanism which handles the loading of the necessary files into memory works properly.\nSometimes the game cache can become filled with unnecessary information and may need to be flushed manually. This is usually not necessary since the game automatically flushes all the data between every map."
   },
   "fly": {
-    "description": "You can fly around the map with flymode on.  Note: Needs cheat support by server."
+    "description": "You can fly around the map with flymode on.",
+    "remarks": "Needs cheat support by server."
   },
   "fog": {
     "description": "Changes color of fog.",
@@ -581,10 +590,10 @@
     "description": "Loads specified TrueType font for use where _proportional is set."
   },
   "force_centerview": {
-    "description": "This command centers the player's screen. It was created because the original  \"centerview\" command did not work when \"+mlook\" was enabled. This command will  center the screen in any mode no matter commands are active."
+    "description": "This command centers the player's screen.\nIt was created because the original \"centerview\" command did not work when \"+mlook\" was enabled.\nThis command will center the screen in any mode no matter commands are active."
   },
   "fraglogfile": {
-    "description": "Enables logging of kills to a file. Useful for external frag polling programs.  The file name is frag_##.log"
+    "description": "Enables logging of kills to a file.\nUseful for external frag polling programs.\nThe file name is frag_##.log"
   },
   "fs_diff": {
     "system-generated": true
@@ -611,35 +620,40 @@
     "description": "Search the filesystem cache by suffix."
   },
   "fullinfo": {
-    "description": "Used by QuakeSpy and Qlist to set setinfo variables.  Note: Use the setinfo command to see the output.  Example:  fullinfo \"\\quote\\I am the only Lamer!\\\""
+    "description": "Used by QuakeSpy and Qlist to set setinfo variables.\n\nExample:\nfullinfo \"\\quote\\I am the only Lamer!\\\"",
+    "remarks": "Use the setinfo command to see the output."
   },
   "gamedir": {
-    "description": "Specifies the directory where the QWPROGS.DAT file is found and other additional  files such as maps, models, sound, and skins for Quake modifications.  Note: This command can be specified while a game is in progress, after the current  map ends this command will take effect."
+    "description": "Specifies the directory where the QWPROGS.DAT file is found and other additional files such as maps, models, sound, and skins for Quake modifications.",
+    "remarks": "This command can be specified while a game is in progress, after the current map ends this command will take effect."
   },
   "gamma": {
-    "description": "You can edit brightness.  Note: This is shortcut for sw_gamma in vga and gl_gamma in gl."
+    "description": "You can edit brightness.",
+    "remarks": "This is a shortcut for sw_gamma in vga and gl_gamma in gl."
   },
   "give": {
-    "description": "Give user a certain amount of an item.  Items:  1 - Axe  2 - Shotgun  3 - Double-Barrelled Shotgun  4 - Nailgun  5 - Super Nailgun  6 - Grenade Launcher  7 - Rocket Launcher  8 - ThunderBolt  C - Cells  H - Health  N - Nails  R - Rockets  S - Shells  Note: The -cheats parameter must be used to launch the server to use  the give command. Also the key and value *cheats ON will be displayed  in the serverinfo information.  Examples:  give 1234 R 99 will give for user 1234 99 rockets.  give 1234 7 will give for user 1234 rocket launcher."
+    "description": "Give user a certain amount of an item.\nItems:\n1 - Axe\n2 - Shotgun\n3 - Double-Barrelled Shotgun\n4 - Nailgun\n5 - Super Nailgun\n6 - Grenade Launcher\n7 - Rocket Launcher\n8 - ThunderBolt\nC - Cells\nH - Health\nN - Nails\nR - Rockets\nS - Shells\n\nExamples:\ngive 1234 R 99\n - gives 99 rockets to user 1234\ngive 1234 7\n - gives the rocket launcher to user 1234",
+    "remarks": "The -cheats parameter must be used to launch the server to use the give command. Also the key and value *cheats ON will be displayed in the serverinfo information."
   },
   "gl_checkmodels": {
-    "description": "Not well implemented yet. Quickly looks at the pmodel and emodel listed in every player's infokey and reports anything unusual it finds. Basically it saves you having to type \"users. user x\" and then comparing the models for everyone."
+    "description": "Not well implemented yet. Quickly looks at the pmodel and emodel listed in every player's infokey and reports anything unusual it finds.\nBasically it saves you having to type \"users. user x\" and then comparing the models for everyone."
   },
   "gl_inferno": {
-    "description": "Clientside (noone else can see it) hard-striking rocket, serves well for your entertainment."
+    "description": "Clientside (no one else can see it) hard-striking rocket, serves well for your entertainment."
   },
   "gl_setmode": {
-    "description": "Quickly sets many variables to fit pre-defined scheme. Try using \"newtrails\" or \"vultwah\".",
-    "syntax": "(modename)"
+    "description": "Quickly sets many variables to fit pre-defined scheme.\nTry using \"newtrails\" or \"vultwah\".",
+    "syntax": "<modename>"
   },
   "god": {
-    "description": "You are immortal with god mode on.  Note: Needs cheats support by server."
+    "description": "You are immortal with god mode on.",
+    "remarks": "Needs cheats support by server."
   },
   "hash": {
     "system-generated": true
   },
   "heartbeat": {
-    "description": "Forces a heartbeat to be sent to the master server. A heartbeat informs  the master server of the server's IP address thus making sure that  the master server knows that the server is still alive."
+    "description": "Forces a heartbeat to be sent to the master server.\nA heartbeat informs the master server of the server's IP address thus making sure that the master server knows that the server is still alive."
   },
   "help": {
     "description": "Enters manual pages. Use arrows, [Page Down], [Page Up], [Tab] and [Enter] for navigation."
@@ -647,38 +661,38 @@
   "hide": {
     "system-generated": true
   },
-  "hud262_add": {
+  "HUD262_add": {
     "arguments": [
       {
-        "description": "can be cvar or str",
+        "description": "Can be cvar or str",
         "name": "type"
       },
       {
-        "description": "string or cvarname",
+        "description": "String or cvarname",
         "name": "param"
       }
     ],
-    "description": "creates or changes a hud element with hud_name; the following types of hud elements are avaliable:  cvar\ta value of a variable is displayed; in this case param must be a name of this variable.\t str\ta string defined by param is displayed; Cvar and %macros expansion is performed every time element is shown",
+    "description": "Creates or changes a HUD element with hud_name.\nThe following types of HUD elements are available:\ncvar - a value of a variable is displayed; in this case param must be a name of this variable.\nstr - a string defined by param is displayed\nCvar and %macros expansion is performed every time element is shown.",
     "syntax": "<hud_name> <type> <param>"
   },
-  "hud262_alpha": {
+  "HUD262_alpha": {
     "arguments": [
       {
-        "description": "hud element's name",
+        "description": "HUD element's name",
         "name": "name"
       },
       {
-        "description": " from 0 up to 1 (0 - invisible, 1 - opaque",
+        "description": "From 0 up to 1 (0 - invisible, 1 - opaque)",
         "name": "value"
       }
     ],
-    "description": "Sets a transparency for strings-hud element",
+    "description": "Sets a transparency for strings-HUD element.",
     "syntax": "<name> <value>"
   },
-  "hud262_bg": {
+  "HUD262_bg": {
     "arguments": [
       {
-        "description": "Hud element's name",
+        "description": "HUD element's name",
         "name": "hud_name"
       },
       {
@@ -686,121 +700,121 @@
         "name": "bg_color"
       }
     ],
-    "description": "defines a color of the hud element backgdround; 0 - transparent (default).",
+    "description": "Defines a color of the HUD element background.\n0 - transparent (default).",
     "syntax": "<hud_name> <bg_color>"
   },
-  "hud262_blink": {
+  "HUD262_blink": {
     "arguments": [
       {
-        "description": "hud element's name",
+        "description": "HUD element's name",
         "name": "name"
       },
       {
-        "description": "blinking perion in milliseconds",
+        "description": "Blinking period in milliseconds",
         "name": "period"
       },
       {
-        "description": "defines what exactly should blink: 0 - nothing 1 - text only 2 - background only 3 - text and background",
+        "description": "Defines what exactly should blink:\n0 - nothing\n1 - text only\n2 - background only\n3 - text and background",
         "name": "mask"
       }
     ],
-    "description": "Allows to make blinking strings-hud elements.",
+    "description": "Allows to make blinking strings-HUD elements.",
     "syntax": "<name> <period> <mask>"
   },
-  "hud262_bringtofront": {
+  "HUD262_bringtofront": {
     "arguments": [
       {
-        "description": "hud element's name",
+        "description": "HUD element's name",
         "name": "name"
       }
     ],
-    "description": "Transfers all hud elements created after hud_name element (including) to the end of drawing list, that in short means that they will be displayed above all other elements which could be present on that place already.",
+    "description": "Transfers all HUD elements created after hud_name element (including) to the end of drawing list, that in short means that they will be displayed above all other elements which could be present on that place already.",
     "syntax": "<name>"
   },
-  "hud262_disable": {
+  "HUD262_disable": {
     "arguments": [
       {
-        "description": "Hud element's name",
+        "description": "HUD element's name",
         "name": "hud_name"
       }
     ],
-    "description": "prohibits to display one or more hud elements.",
+    "description": "Prohibits to display one or more HUD elements.",
     "syntax": "<hud_name> [hud_name2...]"
   },
-  "hud262_enable": {
+  "HUD262_enable": {
     "arguments": [
       {
-        "description": "Hud element's name",
+        "description": "HUD element's name",
         "name": "hud_name"
       }
     ],
-    "description": "allows to display one or more hud elements.",
+    "description": "Allows to display one or more HUD elements.",
     "syntax": "<hud_name> [hud_name2...]"
   },
-  "hud262_list": {
+  "HUD262_list": {
     "arguments": [
       {
-        "description": "print only [regexp] matching huds",
+        "description": "Print only [regexp] matching HUDs",
         "name": "regexp"
       }
     ],
-    "description": "prints a list of strings-hud elements.",
+    "description": "Prints a list of strings-HUD elements.",
     "syntax": "[regexp]"
   },
-  "hud262_move": {
+  "HUD262_move": {
     "arguments": [
       {
-        "description": "Hud element's name",
+        "description": "HUD element's name",
         "name": "hud_name"
       },
       {
-        "description": "horisontal shift",
+        "description": "Horizontal shift",
         "name": "dx"
       },
       {
-        "description": "vertical shift",
+        "description": "Vertical shift",
         "name": "dy"
       }
     ],
-    "description": "moves a hud element; dx and dy deviations are measured in symbols.",
+    "description": "Moves a HUD element.\ndx and dy deviations are measured in symbols.",
     "syntax": "<hud_name> <dx> <dy>"
   },
-  "hud262_position": {
+  "HUD262_position": {
     "arguments": [
       {
-        "description": "name of your hud element",
+        "description": "Name of your HUD element",
         "name": "hud_name"
       },
       {
-        "description": "Posotion:  1 upper left corner  2 upper rightcorner  3 lower right corner  4 lower left corner  5 upper central position  6 lower central position.",
+        "description": "Position:\n1 - upper left corner\n2 - upper right corner\n3 - lower right corner\n4 - lower left corner\n5 - upper central position\n6 - lower central position",
         "name": "pos"
       },
       {
-        "description": "horisontal offset",
+        "description": "Horizontal offset",
         "name": "x"
       },
       {
-        "description": "vertical offset",
+        "description": "Vertical offset",
         "name": "y"
       }
     ],
-    "description": "indicates position of a hud element on the screen;",
+    "description": "Indicates position of a HUD element on the screen.",
     "syntax": "<hud_name> <pos> <x> <y>"
   },
-  "hud262_remove": {
+  "HUD262_remove": {
     "arguments": [
       {
-        "description": "Hud element's name",
+        "description": "HUD element's name",
         "name": "hud_name"
       }
     ],
-    "description": "kills a hud element.",
+    "description": "Kills a HUD element.",
     "syntax": "<hud_name>"
   },
-  "hud262_width": {
+  "HUD262_width": {
     "arguments": [
       {
-        "description": "Hud element's name",
+        "description": "HUD element's name",
         "name": "hud_name"
       },
       {
@@ -808,7 +822,7 @@
         "name": "width"
       }
     ],
-    "description": "forces a hud element width and cuts undesired space or adds it when needed.",
+    "description": "Forces a HUD element width and cuts undesired space or adds it when needed.",
     "syntax": "<hud_name> <width>"
   },
   "hud_editor": {
@@ -821,14 +835,14 @@
         "name": "filename"
       }
     ],
-    "description": "Saves setup of your HUD (scr_newhud 1) into separate .cfg file.",
+    "description": "Saves setup of your HUD (scr_newHUD 1) into a separate .cfg file.",
     "syntax": "<filename>"
   },
   "hud_fps_min_reset": {
     "system-generated": true
   },
   "hud_recalculate": {
-    "description": "Refresh the positions of your HUD elements"
+    "description": "Refresh the positions of your HUD elements."
   },
   "if": {
     "arguments": [
@@ -837,7 +851,7 @@
         "name": "expr1"
       },
       {
-        "description": "==, =, !=, <>, >, <, >=, <=, isin, !isin. Where 'isin' means \"expr1 is a substring of expr2\" and '!isin' is a negation of this. The others are standard mathematical comparison.",
+        "description": "==, =, !=, <>, >, <, >=, <=, isin, !isin\nWhere 'isin' means \"expr1 is a substring of expr2\" and '!isin' is a negation of this.\nThe others are standard mathematical comparison.",
         "name": "operator"
       },
       {
@@ -857,54 +871,54 @@
     "syntax": "<expr1> <operator> <expr2> <cmd1> [else <cmd1>]"
   },
   "if_exists": {
-    "description": "if an object <name> of a type <type> exists, a command <cmd1> will be issued, or a command <cmd2> if such object could not be found.  The type of the object can be either cvar, alias, trigger or hud.",
+    "description": "If an object <name> of a type <type> exists, a command <cmd1> will be issued, or a command <cmd2> if such object could not be found.\nThe type of the object can be either cvar, alias, trigger or HUD.",
     "syntax": "<type> <name>  <cmd1> [<cmd2>]"
   },
   "ignore": {
-    "description": "You can give ignore either a player's name (name completion is useful for this)  or a userid (ignore <name|userid>). ignore without any command line  parameters displays your ignore list.",
+    "description": "You can give ignore either a player's name (name completion is useful for this) or a user ID (ignore <name|userid>).\nIgnore without any command line parameters displays your ignore list.",
     "syntax": "<name|userid>"
   },
   "ignore_id": {
-    "description": "ignore_id is identical except it only accepts user id's (only useful if there is  a player whose name is the userid of someone you want to ignore).",
-    "syntax": "(userid)"
+    "description": "Identical to ignore, except it only accepts user IDs (only useful if there is a player whose name is the user ID of someone you want to ignore).",
+    "syntax": "<userid>"
   },
   "ignore_team": {
-    "description": "You can ignore teams instead of players.  Example:  ignoreteam nine will ignore whole clan nine."
+    "description": "Ignores a team instead of players.\n\nExample:\nignore_team nine\n - ignores whole clan nine."
   },
   "ignore_voip": {
     "system-generated": true
   },
   "ignorelist": {
-    "description": "Prints ignorelist"
+    "description": "Prints ignore list."
   },
   "impulse": {
-    "description": "This command calls a game function or QuakeC function. Often impulses are used  by the mod by defining aliases for game functions like \"ready\" and \"break\" that  call certain impulses."
+    "description": "This command calls a game function or QuakeC function.\nOften impulses are used by the mod by defining aliases for game functions like \"ready\" and \"break\" that call certain impulses."
   },
   "in_evdevlist": {
-    "description": "print list of evdev devices if you got empty list, probably you dont have access rights to /dev/input/eventX sudo chmod 644 /dev/input/event* should help you"
+    "description": "Prints list of evdev devices.\nIf the list is empty, you probably don't have access rights to /dev/input/eventX\nsudo chmod 644 /dev/input/event* should help you."
   },
   "in_restart": {
     "system-generated": true
   },
   "inc": {
-    "description": "Increments a variable by one or adds to it the optional second argument.  There are no 'add' or 'dec' commands because 'inc' can handle both addition and  subtraction.  Example:  inc sensitivity -2 would subtract 2 from sensitivity."
+    "description": "Increments a variable by one or adds to it the optional second argument.\nThere are no 'add' or 'dec' commands because 'inc' can handle both addition and subtraction.\n\nExample:\ninc sensitivity -2\n - subtracts 2 from sensitivity."
   },
   "itemsclock": {
-    "description": "HUD element displaying items that will spawn soon in the game. Works only in MVD and QuakeTV playback."
+    "description": "HUD element displaying items that will spawn soon in the game. Works only in MVD and QTV playback."
   },
   "join": {
-    "description": "joins a specified server as player. If no address is specified, join will reconnect to the last visited server as a player.  Example:  join 123.124.125.126",
-    "syntax": "(address)"
+    "description": "Joins a specified server as player.\nIf no address is specified, join will reconnect to the last visited server as a player.\n\nExample:\njoin 123.124.125.126",
+    "syntax": "<address>"
   },
   "joyadvancedupdate": {
-    "description": "This command initializes the joystick's advanced features. It is necessary to  issue this command after making any changes to the other joystick commands. This  command will initialize all of the settings."
+    "description": "This command initializes the joystick's advanced features.\nIt is necessary to issue this command after making any changes to the other joystick commands.\nThis command will initialize all of the settings."
   },
   "keycode": {
     "description": "This command enables the setting of a new keymapping.",
-    "syntax": "keycode [ext] <scancode> <key> [<shiftmap>] [<altgrmap>]"
+    "syntax": "[ext] <scancode> <key> [<shiftmap>] [<altgrmap>]"
   },
   "keymap_init": {
-    "description": "This resets the current keymapping and then generates a copy of the internal defaults (US keyboard) to be the new keymappings. This can be used as a base to generate a new keymapping file. It has the same (unchangeable) mapping as the example keymap-file \"default.kmap\""
+    "description": "This resets the current keymapping and then generates a copy of the internal defaults (US keyboard) to be the new keymappings.\nThis can be used as a base to generate a new keymapping file.\nIt has the same (unchangeable) mapping as the example keymap file \"default.kmap\""
   },
   "keymap_list": {
     "description": "This command prints all the current keymappings to the quake console."
@@ -914,18 +928,18 @@
     "syntax": "keymap_load [layoutname] <filename>"
   },
   "keymap_reset": {
-    "description": "This command switches off the current keymappings and sets it back to the internal defaults; it also restores \"keymap_name\" to its default name \"Default\". The defaults are an internally defined (and not changeable) keymapping for US keyboards."
+    "description": "This command switches off the current keymappings and sets it back to the internal defaults; it also restores \"keymap_name\" to its default name \"Default\".\nThe defaults are an internally defined (and not changeable) keymapping for US keyboards."
   },
   "keymap_save": {
-    "description": "With this command the active keymappings will be written to a kmap-file (including a descriptive header which explains the usage).",
+    "description": "With this command the active keymappings will be written to a .kmap file (including a descriptive header which explains the usage).",
     "syntax": "[layoutname] <filename>"
   },
   "keymaplist": {
     "description": "This command prints all the current keymappings to the quake console."
   },
   "kick": {
-    "description": "Removes a user from the server. Use the status command to receive the user's id.  Example:  kick 1234",
-    "syntax": "(userid)"
+    "description": "Removes a user from the server. Use the status command to receive the user's id.\n\nExample:\nkick 1234",
+    "syntax": "<userid>"
   },
   "kill": {
     "description": "Suicide. (-2 frags on ktpro/kteam servers)"
@@ -941,38 +955,39 @@
     "syntax": "[ver]"
   },
   "listip": {
-    "description": "Prints out the current list of IPs on the server list. Not to be confused with  the status command which prints out the list of the IPs of the connected players."
+    "description": "Prints out the current list of IPs on the server list. Not to be confused with the status command which prints out the list of the IPs of the connected players."
   },
   "load": {
     "description": "Load 123 loads saved game 123.",
-    "syntax": "(filename)"
+    "syntax": "<filename>"
   },
   "loadFragfile": {
     "system-generated": true
   },
   "loadcharset": {
-    "description": "You can change your console font from within ezQuake. Put all your charset images in qw/textures/charsets/*.png (and *.tga) and use  /loadcharset XXX to load XXX.png (or tga). \"/loadcharset original\" will restore the 8bit  font in your gfx.wad (this is default). Note that the /loadcharset command is just a 'shortcut'  for the new gl_consolefont variable."
+    "description": "You can change your console font from within ezQuake. Put all your charset images in qw/textures/charsets/*.png (and *.tga) and use /loadcharset XXX to load XXX.png (or tga).\n\"/loadcharset original\" will restore the 8bit font in your gfx.wad (this is default).",
+    "remarks": "This command is just a 'shortcut' for the new gl_consolefont variable."
   },
   "loadfont": {
     "system-generated": true
   },
   "loadfragfile": {
-    "description": "loadfragfile 123 loads fragfile 123",
-    "syntax": "(filename)"
+    "description": "Loads the specified fragfile.",
+    "syntax": "<filename>"
   },
   "loadloc": {
-    "description": "Loads a loc file (must be located in id1/locs, qw/locs, or ezquake/locs.  The \".loc\" extention is optional, for example, \"loadloc dm6\"; if the file name has  no extension, use its explicit name (\"loadloc dm6.\").",
-    "syntax": "(filename)"
+    "description": "Loads a loc file (must be located in id1/locs, qw/locs, or ezquake/locs.\nThe \".loc\" extension is optional, for example, \"loadloc dm6\"; if the file name has no extension, use its explicit name (\"loadloc dm6.\").",
+    "syntax": "<filename>"
   },
   "loadpak": {
     "system-generated": true
   },
   "loadsky": {
-    "description": "Loads your skybox (qw\\env).  Example:  loadsky snow",
-    "syntax": "(filename)"
+    "description": "Loads your skybox (qw\\env).\n\nExample:\nloadsky snow",
+    "syntax": "<filename>"
   },
   "localinfo": {
-    "description": "Shows or sets localinfo variables. Useful for mod programmers who need to allow the admin  to change settings. This is an alternative storage space to the serverinfo space for mod  variables. The variables stored in this space are not broadcast on the network.  This space also has a 32-kilobyte limit which is much greater then the 512-byte limit on  the serverinfo space.  Special Keys: (current map) (next map) - Using this combination will allow the creation  of a custom map cycle without editing code.  Examples:  localinfo dm2 dm4  localinfo dm4 dm6  localinfo dm6 dm2"
+    "description": "Shows or sets localinfo variables. Useful for mod programmers who need to allow the admin to change settings.\nThis is an alternative storage space to the serverinfo space for mod variables. The variables stored in this space are not broadcast on the network.\nThis space also has a 32-kilobyte limit which is much greater then the 512-byte limit on the serverinfo space.\nSpecial Keys: (current map) (next map) - Using this combination will allow the creation of a custom map cycle without editing code.\n\nExamples:\nlocalinfo dm2 dm4\nlocalinfo dm4 dm6\nlocalinfo dm6 dm2"
   },
   "locate": {
     "system-generated": true
@@ -996,8 +1011,8 @@
     "description": "Create a new location in the current spot."
   },
   "log": {
-    "description": "If you type \"log filename\" it will log console to filename.log in your gamedir.  It overwrites logs without asking.",
-    "syntax": "(filename)"
+    "description": "If you type \"log filename\" it will log console to filename.log in your gamedir.\nIt overwrites logs without asking.",
+    "syntax": "<filename>"
   },
   "logerrors": {
     "system-generated": true
@@ -1021,23 +1036,23 @@
     "description": "Prints a list of all available macros."
   },
   "map": {
-    "description": "loads a map and start a game.  Example: map e1m1"
+    "description": "Loads a map and starts a game.\n\nExample:\nmap e1m1"
   },
   "mapgroup": {
-    "description": "mapgroup 2fort5r 2fort5: will make 2fort5r and 2fort5 use the 2fort5r textures, locs and etc... ",
+    "description": "mapgroup 2fort5r 2fort5: will make 2fort5r and 2fort5 use the 2fort5r textures, locs and etc...",
     "syntax": "mapgroup [map1] [map2] ..."
   },
   "master_rcon_password": {
     "system-generated": true
   },
   "match_forcestart": {
-    "description": "Simulates the start of a match (so that auto recording etc is triggered). Useful if you join a  ktpro server after countdown has started, or you are playing a mode that doesn't have a  proper countdown (eg race mode).  Most importantly this is useful for tf servers, since you can use a msg_trigger to execute  match_forcestart on \"MATCH BEGINS NOW\"."
+    "description": "Simulates the start of a match (so that auto recording etc is triggered).\nUseful if you join a ktpro server after countdown has started, or you are playing a mode that doesn't have a proper countdown (eg race mode).\nMost importantly this is useful for TF servers, since you can use a msg_trigger to execute match_forcestart on \"MATCH BEGINS NOW\"."
   },
   "match_format_macrolist": {
     "description": "Prints a list of the macros and their meaning for autorecording and autoscreenshots."
   },
   "match_save": {
-    "description": "If you are using 'match_auto_record 1' then a temp demo will be recorded to  c:\\quake\\ezquake\\temp\\_!_temp_!_.qwd each time a map starts. This temp demo will be overwritten  when the next match starts. If you want to keep the temp demo, use the \"match_save\" command.  This will move the demo to the same folder and filename that easyrecord would have used."
+    "description": "If you are using 'match_auto_record 1' then a temp demo will be recorded to c:\\quake\\ezquake\\temp\\_!_temp_!_.qwd each time a map starts.\nThis temp demo will be overwritten when the next match starts.\nIf you want to keep the temp demo, use the \"match_save\" command. This will move the demo to the same folder and filename that easyrecord would have used."
   },
   "menu_demos": {
     "description": "This command will display the demos menu."
@@ -1052,7 +1067,7 @@
     "description": "This command will display the keys menu."
   },
   "menu_load": {
-    "description": "This command will display the load menu to load singleplaying saves."
+    "description": "This command will display the singleplayer load menu."
   },
   "menu_main": {
     "description": "This command will display the main menu."
@@ -1073,7 +1088,7 @@
     "description": "This command will display the quit menu."
   },
   "menu_save": {
-    "description": "This command will display the save menu to save singleplaying games."
+    "description": "This command will display the singleplayer save menu."
   },
   "menu_setup": {
     "description": "This command will display the setup menu."
@@ -1094,7 +1109,7 @@
     "description": "Prompts for string to broadcast to team members."
   },
   "messagemodeqtvtogame": {
-    "description": "Go into message mode for chatting in the Quake TV chat."
+    "description": "Go into message mode for chatting in the QTV chat."
   },
   "mod": {
     "system-generated": true
@@ -1112,8 +1127,8 @@
     "description": "Fast forward 5seconds."
   },
   "mp3_loadplaylist": {
-    "description": "Loads the playlist filename.m3u  Example:  mp3_loadplaylist top10 will load top10.m3u",
-    "syntax": "(filename)"
+    "description": "Loads the playlist filename.m3u\n\nExample:\nmp3_loadplaylist top10\n - loads top10.m3u.",
+    "syntax": "<filename>"
   },
   "mp3_next": {
     "description": "Next song."
@@ -1125,31 +1140,31 @@
     "description": "Play mp3."
   },
   "mp3_playlist": {
-    "description": "Displays playlist. Currently playign track is highlighted."
+    "description": "Displays playlist. Currently playing track is highlighted."
   },
   "mp3_playtrack": {
-    "description": "Play track number #num from playlist.  Example:  mp3_playtrack 5 will play track 5 from playlist.",
-    "syntax": "(track)"
+    "description": "Play track number #num from playlist.\n\nExample:\nmp3_playtrack 5\n - plays track 5 from playlist.",
+    "syntax": "<track>"
   },
   "mp3_prev": {
     "description": "Previous song."
   },
   "mp3_repeat": {
     "description": "Repeat playlist.",
-    "syntax": "(off/on)"
+    "syntax": "<off|on>"
   },
   "mp3_rewind": {
     "description": "Rewind 5seconds."
   },
   "mp3_shuffle": {
     "description": "Shuffle mp3s.",
-    "syntax": "(off/on)"
+    "syntax": "<off|on>"
   },
   "mp3_songinfo": {
-    "description": "displays song title and other info like time elapsed, total time,  and whether paused, stopped or playing."
+    "description": "Displays song title and other info like time elapsed, total time, and whether paused, stopped or playing."
   },
   "mp3_startwinamp": {
-    "description": "Starts winamp if winamp is not running."
+    "description": "Starts winamp if it is not running."
   },
   "mp3_stop": {
     "description": "Stop mp3."
@@ -1168,11 +1183,12 @@
         "name": "string"
       },
       {
-        "description": "Level of the message. Level 0 is pickup messages, level 1 is death messages, level 2 is critical messages, level 3 is chat messages. Everything else is level 4.",
+        "description": "Level of the message.\n0 - pickup messages\n1 - death messages\n2 - critical messages\n3 - chat messages\nEverything else is level 4.",
         "name": "level"
       }
     ],
-    "description": "Allows you to set rules that will automatically execute actions when a certain message is sent from a server. This is very usefull in Team Fortress, in deathmatch it can be used for example for auto-reporting \"quad in 30\" when you receive \"Quad Damage is wearing out\" message. Note that only some server messages can be triggered. Usually no pickup messages nor your teammates text is triggered.",
+    "description": "Allows you to set rules that will automatically execute actions when a certain message is sent from a server.\nThis is very useful in Team Fortress, in deathmatch it can be used for example for auto-reporting \"quad in 30\" when you receive \"Quad Damage is wearing out\" message.",
+    "remarks": "Only some server messages can be triggered. Usually no pickup messages nor your teammates text is triggered.",
     "syntax": "<alias> <string> [-l] <level>"
   },
   "mute": {
@@ -1182,7 +1198,7 @@
     "system-generated": true
   },
   "mvd_dumpstats": {
-    "description": "Will dump statistics gathered from a MVD demo into a \"stats.xml\" file in the current working directory"
+    "description": "Dumps statistics gathered from a MVD demo into a \"stats.xml\" file in the current working directory."
   },
   "mvd_list_items": {
     "system-generated": true
@@ -1203,14 +1219,15 @@
     "description": "HUD element - icon displayed when network traffic is experiencing problems like lost packets, large delay, etc."
   },
   "noclip": {
-    "description": "You can fly and go thru objects (free mode as spectator)  Note: Needs cheats support by server."
+    "description": "You can fly and go thru objects free mode as spectator",
+    "remarks": "Needs cheats support by server."
   },
   "nslookup": {
     "system-generated": true
   },
   "observe": {
-    "description": "observe connects you to a server as a spectator. If no address is specified, observe will reconnect to the last visited server as a spectator.  Example:  observe 123.124.125.126",
-    "syntax": "(address)"
+    "description": "Connects you to a server as a spectator. If no address is specified, observe will reconnect to the last visited server as a spectator.\n\nExample:\nobserve 123.124.125.126",
+    "syntax": "<address>"
   },
   "observeqtv": {
     "system-generated": true
@@ -1219,8 +1236,8 @@
     "system-generated": true
   },
   "packet": {
-    "description": "Sends a packet with specified contents to the destination.  Example:  packet 123.123.123.123:27500 \"status\"",
-    "syntax": "(address)"
+    "description": "Sends a packet with specified contents to the destination.\n\nExample:\npacket 123.123.123.123:27500 \"status\"",
+    "syntax": "<address>"
   },
   "password": {
     "description": "Set the password to enter a password protected server."
@@ -1229,7 +1246,8 @@
     "description": "Shows what paths ezQuake is using."
   },
   "pause": {
-    "description": "Pauses a game.  Note: Servers must support pausing."
+    "description": "Pauses a game.",
+    "remarks": "Servers must support pausing."
   },
   "penaltylist": {
     "system-generated": true
@@ -1241,16 +1259,16 @@
     "system-generated": true
   },
   "play": {
-    "description": "Plays a sound effect.  Example:  play misc/runekey.wav",
-    "syntax": "(filename)"
+    "description": "Plays a sound effect.\n\nExample:\nplay misc/runekey.wav",
+    "syntax": "<filename>"
   },
   "playdemo": {
-    "description": "Plays a recorded demo. Example: playdemo thresh.qwd",
+    "description": "Plays a recorded demo.\n\nExample:\nplaydemo thresh.qwd",
     "syntax": "<filename>"
   },
   "playvol": {
-    "description": "Plays a sound at a given volume.  Examples:  playvol items/protect.wav .5  playvol items/protect.wav 2",
-    "syntax": "(filename)"
+    "description": "Plays a sound at a given volume.\n\nExamples:\nplayvol items/protect.wav .5\nplayvol items/protect.wav 2",
+    "syntax": "<filename> (volume)"
   },
   "profile": {
     "description": "Reports information about QuakeC stuff."
@@ -1261,11 +1279,11 @@
   "qtv": {
     "arguments": [
       {
-        "description": "IP address of the internet QuakeTV broadcasting some QW action",
+        "description": "IP address of the internet QTV broadcasting some QW action",
         "name": "address"
       }
     ],
-    "description": "Connects you to internet QuakeTV broadcasting some action, using your local proxy. Starts local QuakeTV proxy, tells it what broadcasting proxy it should connect to and by connecting to it you'll see the action broadcasted on the IP you've specified.",
+    "description": "Connects you to internet QTV broadcasting some action, using your local proxy.\nStarts local QTV proxy, tells it what broadcasting proxy it should connect to and by connecting to it you'll see the action broadcasted on the IP you've specified.",
     "syntax": "<address>"
   },
   "qtv_close": {
@@ -1284,7 +1302,7 @@
     "system-generated": true
   },
   "qtv_reconnect": {
-    "description": "Reconnect to last QuakeTV server the client was connected to."
+    "description": "Reconnect to last QTV server the client was connected to."
   },
   "qtv_status": {
     "system-generated": true
@@ -1312,7 +1330,7 @@
     "syntax": "<property> <value>"
   },
   "rcon": {
-    "description": "Issue the set of commands to the server you are currently connected to or  have set in rcon_address. You must know the rcon password for that specific  server."
+    "description": "Issue the set of commands to the server you are currently connected to or have set in rcon_address.\nYou must know the rcon password for that specific server."
   },
   "re_trigger": {
     "arguments": [
@@ -1321,11 +1339,11 @@
         "name": "rt_name"
       },
       {
-        "description": "regexp defines which messages (or whatever) will activate a trigger. The client uses the PCRE library (Perl-compatible regular expression library). You can find information how to write regexps in the PCRE's documentation.",
+        "description": "Regexp defines which messages (or whatever) will activate a trigger.\nThe client uses the PCRE library (Perl-compatible regular expression library).\nYou can find information how to write regexps in the PCRE's documentation.",
         "name": "regexp"
       }
     ],
-    "description": "when used w/o parameter, prints a list of all triggers; when regexp is not defined prints options set for rt_name trigger; otherwise creates or changes rt_name trigger.",
+    "description": "When used w/o parameter, prints a list of all triggers.\nWhen regexp is not defined prints options set for rt_name trigger; otherwise creates or changes rt_name trigger.",
     "syntax": "re_trigger [rt_name [regexp]]"
   },
   "re_trigger_delete": {
@@ -1335,7 +1353,7 @@
         "name": "rt_name"
       }
     ],
-    "description": "deletes the corresponding trigger.",
+    "description": "Deletes the corresponding trigger.",
     "syntax": "re_trigger_delete rt_name"
   },
   "re_trigger_disable": {
@@ -1345,7 +1363,7 @@
         "name": "rt_name"
       }
     ],
-    "description": "disables activation of one or more triggers.",
+    "description": "Disables activation of one or more triggers.",
     "syntax": "re_trigger_disable rt_name1 [rt_name2...]"
   },
   "re_trigger_enable": {
@@ -1355,75 +1373,75 @@
         "name": "rt_name"
       }
     ],
-    "description": "enables activation of one or more triggers.",
+    "description": "Enables activation of one or more triggers.",
     "syntax": "re_trigger_enable rt_name1 [rt_name2...]"
   },
   "re_trigger_match": {
     "arguments": [
       {
-        "description": "Re_trigger name",
+        "description": "re_trigger name",
         "name": "trigger_name"
       },
       {
-        "description": "your string",
+        "description": "Your string",
         "name": "string"
       }
     ],
-    "description": "allows to direct a <string> to a trigger <trigger_name>. If this string match regexp, then a corresponding alias is activated.",
+    "description": "Allows to direct a <string> to a trigger <trigger_name>. If this string match regexp, then a corresponding alias is activated.",
     "syntax": "re_trigger_match <trigger_name> <string>"
   },
   "re_trigger_options": {
     "arguments": [
       {
-        "description": "value represents a bit mask which determines which types of messages can cause activation of a trigger: 1 - pickup messages  2 - death messages  4 - critical messages (most of TeamFortress messages)  8 - chat  16 - centerprint  32 - echo command output  64 - other strings printed in the console The default mask for any trigger equals 31.",
+        "description": "Value represents a bit mask which determines which types of messages can cause activation of a trigger:\n1 - pickup messages\n2 - death messages\n4 - critical messages (most of Team Fortress messages)\n8 - chat\n16 - centerprint\n32 - echo command output\n64 - other strings printed in the console\nThe default mask for any trigger equals 31.",
         "name": "mask"
       },
       {
-        "description": "sets a minimal interval of trigger activation (in seconds). If a second activation happened earlier than the value time - it is ignored. Default is 0.",
+        "description": "Sets a minimal interval of trigger activation (in seconds). If a second activation happened earlier than the value time, it is ignored.\nDefault is 0.",
         "name": "interval"
       },
       {
-        "description": "if activation of this trigger happened, the remaining (in the list of triggers) triggers are not  checked. Triggers are checked in a reversed order of their definition.",
+        "description": "If activation of this trigger happened, the remaining (in the list of triggers) triggers are not checked.\nTriggers are checked in a reversed order of their definition.",
         "name": "final"
       },
       {
-        "description": "activation of such trigger doesn't stop the checking of other triggers (default).",
+        "description": "Activation of such trigger doesn't stop the checking of other triggers (default).",
         "name": "notfinal"
       },
       {
-        "description": "a string which caused activation of a trigger is not printed on the screen.",
+        "description": "A string which caused activation of a trigger is not printed on the screen.",
         "name": "remove"
       },
       {
-        "description": "a string which caused activation of a trigger is printed on the screen (default).",
+        "description": "A string which caused activation of a trigger is printed on the screen (default).",
         "name": "noremove"
       },
       {
-        "description": "a string which caused activation of a trigger is not added to a log-file.",
+        "description": "A string which caused activation of a trigger is not added to a log-file.",
         "name": "log"
       },
       {
-        "description": "a string which caused activation of a trigger is added to a log-file (default).",
+        "description": "A string which caused activation of a trigger is added to a log-file (default).",
         "name": "nolog"
       },
       {
-        "description": "a corresponding alias is not executed upon a trigger activation. There is no need to exec alias if all you need is to use remove option :)",
+        "description": "A corresponding alias is not executed upon a trigger activation.\nThere is no need to exec alias if all you need is to use remove option :)",
         "name": "noaction"
       },
       {
-        "description": "a corresponding alias is executed upon a trigger activation (default).",
+        "description": "A corresponding alias is executed upon a trigger activation (default).",
         "name": "action"
       }
     ],
-    "description": "changes options for a corresponding trigger",
+    "description": "Changes options for a corresponding trigger.",
     "syntax": "re_trigger_options rt_name option_list"
   },
   "reconnect": {
     "description": "Reconnects to the last server/proxy."
   },
   "record": {
-    "description": "Records a demo.  Example:  record test records test.qwd to qw folder",
-    "syntax": "(filename)"
+    "description": "Records a demo.\n\nExample:\nrecord test\n - records test.qwd to qw folder",
+    "syntax": "<filename>"
   },
   "recordqwd": {
     "system-generated": true
@@ -1432,11 +1450,11 @@
     "system-generated": true
   },
   "removeip": {
-    "description": "Removes an IP address from the server IP list.  Examples:  removeip 123.123.123.123  removeip 123.123.123",
-    "syntax": "(ip)"
+    "description": "Removes an IP address from the server IP list.\n\nExamples:\nremoveip 123.123.123.123\nremoveip 123.123.123",
+    "syntax": "<ip>"
   },
   "removeloc": {
-    "description": "Remove the closest location (use teamsay to see which)"
+    "description": "Remove the closest location (use teamsay to see which)."
   },
   "removepak": {
     "system-generated": true
@@ -1451,7 +1469,8 @@
     "system-generated": true
   },
   "rotate": {
-    "description": "rotates the player by x degrees.  Note: Negative values can also be used for the desired angle.  Example: \"rotate 180\" will rotate your pov by 180 degrees."
+    "description": "Rotates the player by x degrees.\n\nExample: \"rotate 180\"\n - rotates your POV by 180 degrees.",
+    "remarks": "Negative values can also be used for the desired angle."
   },
   "s_audiodevicelist": {
     "system-generated": true
@@ -1463,7 +1482,7 @@
     "system-generated": true
   },
   "save": {
-    "description": "To save games in singleplaying.  Example: save 123"
+    "description": "Saves a game in singleplayer.\n\nExample:\nsave 123"
   },
   "saveloc": {
     "arguments": [
@@ -1473,25 +1492,25 @@
       }
     ],
     "description": "Saves the current locs in memory to the specified file.",
-    "syntax": "(filename)"
+    "syntax": "<filename>"
   },
   "say": {
-    "description": "Broadcasts a string to all other players.  Example: say ezQuake rules!"
+    "description": "Broadcasts a string to all other players.\n\nExample:\nsay ezQuake rules!"
   },
   "say_team": {
-    "description": "Broadcasts a string to teammates.  Example: say_team stop boring!"
+    "description": "Broadcasts a string to teammates.\n\nExample:\nsay_team stop boring!"
   },
   "sb_buildpingtree": {
     "system-generated": true
   },
   "sb_pingsdump": {
-    "description": "Dumps a list of pairs (IP address, ping) into the console based on the current content of the Server Browser list"
+    "description": "Dumps a list of pairs (IP address, ping) into the console based on the current content of the Server Browser list."
   },
   "sb_proxygetpings": {
     "system-generated": true
   },
   "sb_refresh": {
-    "description": "Causes Server Browser refresh ping and status info for all servers"
+    "description": "Causes Server Browser refresh ping and status info for all servers."
   },
   "sb_sourceadd": {
     "arguments": [
@@ -1536,11 +1555,11 @@
   "screenshot": {
     "arguments": [
       {
-        "description": "Optional. When used tells the destination filename. If extension is not preset it will be added automatically according to sshot_format setting.",
+        "description": "Optional. When used tells the destination filename.\nIf extension is not preset it will be added automatically according to sshot_format setting.",
         "name": "name"
       }
     ],
-    "description": "Saves a still picture of current screen to your harddrive.",
+    "description": "Saves a still picture of current screen to your hard drive.",
     "syntax": "[name]"
   },
   "script": {
@@ -1570,11 +1589,11 @@
     "syntax": "<varname> <value>"
   },
   "set_alias_str": {
-    "description": "assigns variable a value which contains an indicated alias.",
+    "description": "Assigns variable a value which contains an indicated alias.",
     "syntax": "<cvar> <alias>"
   },
   "set_bind_str": {
-    "description": "assigns variable a value which contains anything bound to an indicated key.",
+    "description": "Assigns variable a value which contains anything bound to an indicated key.",
     "syntax": "<cvar> <key>"
   },
   "set_calc": {
@@ -1584,11 +1603,11 @@
         "name": "cvar"
       },
       {
-        "description": "Possible commands: strlen - gets length of given string, int - converts given float value to integer, substr - return substring of given string, set_substr - replaces given position in string with another string, pos - gets position of substring in given string.",
+        "description": "Possible commands:\nstrlen - gets length of given string\nint - converts given float value to integer\nsubstr - return substring of given string\nset_substr - replaces given position in string with another string\npos - gets position of substring in given string",
         "name": "command"
       },
       {
-        "description": "Arguments of commands: strlen <string>; int <float>; substr <sourcestr> <position> [<length>]; set_substr - <replacestr> <position>; pos <haystack> <needle>;",
+        "description": "Arguments of commands:\nstrlen <string>\nint <float>\nsubstr <sourcestr> <position> [<length>]\nset_substr <replacestr> <position>\npos <haystack> <needle>",
         "name": "cmdargs"
       },
       {
@@ -1611,7 +1630,7 @@
     "system-generated": true
   },
   "set_ex": {
-    "description": "assigns a new value to a variable, expansion of %macros and variables is performed even in case if a parameter is inside the dual quotation marks.",
+    "description": "Assigns a new value to a variable, expansion of %macros and variables is performed even in case if a parameter is inside the dual quotation marks.",
     "syntax": "<cvar> <value>"
   },
   "set_ex2": {
@@ -1621,10 +1640,10 @@
     "system-generated": true
   },
   "setinfo": {
-    "description": "Sets information about your FuhWorld user. Used without a key it will list  all of your current settings. Specifying a non-existent key and a value will  create the new key."
+    "description": "Sets information about your FuhWorld user.\nUsed without a key it will list all of your current settings. Specifying a non-existent key and a value will create the new key."
   },
   "setmaster": {
-    "description": "Lists the server with up to eight masters. When a server is listed with a master,  the master is aware of the server's IP address and port and it is added to the  list of current server connected to a master. A heartbeat is sent to the master  from the server to indicated that the server is still running and alive.  Examples:  setmaster 192.246.40.12:27002  setmaster 192.246.40.12:27002 192.246.40.12:27004"
+    "description": "Lists the server with up to eight masters.\nWhen a server is listed with a master, the master is aware of the server's IP address and port and it is added to the list of current server connected to a master. A heartbeat is sent to the master from the server to indicated that the server is still running and alive.\n\nExamples:\nsetmaster 192.246.40.12:27002\nsetmaster 192.246.40.12:27002 192.246.40.12:27004"
   },
   "show": {
     "system-generated": true
@@ -1639,15 +1658,16 @@
     "description": "Increases the screen size."
   },
   "skins": {
-    "description": "Refreshes skin settings.  Note: If you have set noskins to 0 and do this it will download all skins  that players are using on server."
+    "description": "Refreshes skin settings.",
+    "remarks":"If you have set noskins to 0 and do this it will download all skins that players are using on server."
   },
   "skygroup": {
     "description": "In basics works same as mapgroup.",
     "syntax": "skyboxname map1 [map2] ..."
   },
   "snap": {
-    "description": "Remote screenshot from a player.  Example:  snap 1234 (server request remote screenshot from user 1234)",
-    "syntax": "(userid)"
+    "description": "Remote screenshot from a player.\n\nExample:\nsnap 1234\n - server requests remote screenshot from user 1234",
+    "syntax": "<userid>"
   },
   "snapall": {
     "description": "Remote screenshots from all players."
@@ -1659,7 +1679,8 @@
     "description": "Reports a list of sounds in the cache."
   },
   "spectator_password": {
-    "description": "Sets spectator password to ezQuake local server.  Note: spectator (password) to connect server that got spectator password."
+    "description": "Sets spectator password to ezQuake local server.",
+    "remarks": "Spectators must use \"spectator <password>\" to connect to a server with a spectator password."
   },
   "speed": {
     "description": "Shows your current movement speed."
@@ -1719,7 +1740,8 @@
     "system-generated": true
   },
   "sv_gamedir": {
-    "description": "Displays or determines the value of the serverinfo *gamedir variable.   This is the directory clients will use.  Note: Useful when the physical gamedir directory has a different  name than the widely accepted gamedir directory.  Examples:  gamedir tf2_5; sv_gamedir fortress  gamedir ctf4_2; sv_gamedir ctf  gamedir ktffa;  sv_gamedir qw  // FFA servers should use default *gamedir"
+    "description": "Displays or determines the value of the serverinfo *gamedir variable.\nThis is the directory clients will use.\n\nExamples:\ngamedir tf2_5; sv_gamedir fortress\ngamedir ctf4_2; sv_gamedir ctf\ngamedir ktffa; sv_gamedir qw  // FFA servers should use default *gamedir",
+    "remarks": "Useful when the physical gamedir directory has a different name than the widely accepted gamedir directory."
   },
   "sv_lastscores": {
     "system-generated": true
@@ -1731,15 +1753,15 @@
     "system-generated": true
   },
   "tcl_eval": {
-    "description": "execute <string> as tcl code",
+    "description": "Execute <string> as Tcl code.",
     "syntax": "<string>"
   },
   "tcl_exec": {
-    "description": "execute a config as tcl script",
+    "description": "Execute a config as Tcl script.",
     "syntax": "<filename>"
   },
   "tcl_proc": {
-    "description": "execute a Tcl-procedure <name> with parameters <parameters>. Procedure must be difened before thru tcl_eval or tcl_exec commands.",
+    "description": "Execute a Tcl procedure <name> with parameters <parameters>. Procedure must be defined before thru tcl_eval or tcl_exec commands.",
     "syntax": "<name> [parameters]"
   },
   "tcpconnect": {
@@ -1757,7 +1779,8 @@
     "syntax": "<address>:<port>"
   },
   "teamcolor": {
-    "description": "This will overwride team color.  Example: teamcolor 12 13  Note: If only the shirt color is given, the pant color will match."
+    "description": "This will override team color.\n\nExample:\nteamcolor 12 13",
+    "remarks": "If only the shirt color is given, the pant color will match."
   },
   "teamholdbar": {
     "description": "Displays overall map control per team when watching multiview demo."
@@ -1766,29 +1789,29 @@
     "description": "Displays items possession stats per team when watching multiview demo."
   },
   "tempalias": {
-    "description": "cfg_save won't save tempaliases to your config."
+    "description": "Sets a temporary alias.\nTempaliases will not save to your config."
   },
   "timedemo": {
-    "description": "This command will load and play a demo at full speed. It will then divide the total number of frames in the demo by the total time it took finish, and calculate the average frames-per-second rate. Example: timedemo demoname",
-    "syntax": "(filename)"
+    "description": "This command will load and play a demo at full speed. It will then divide the total number of frames in the demo by the total time it took finish, and calculate the average frames-per-second rate.\n\nExample:\ntimedemo demoname",
+    "syntax": "<filename>"
   },
   "timedemo2": {
     "system-generated": true
   },
   "timerefresh": {
-    "description": "This command will perform a 360 degree turn and calculate the frames-per-second  rate."
+    "description": "This command will perform a 360 degree turn and calculate the frames-per-second rate."
   },
   "toggle": {
-    "description": "You can turn off/on cvars.  Example:  toggle sensitivity turns off sensitivity and toggle sensitivity again turns on."
+    "description": "You can turn off/on cvars.\n\nExample:\ntoggle sensitivity turns off sensitivity and toggle sensitivity again turns on."
   },
   "toggle_re": {
-    "description": "You can turn variable values ON and OFF. Example: toggle ^gl_part.* - turns all particle effects on/off.",
+    "description": "You can turn variable values ON and OFF.\n\nExample:\ntoggle ^gl_part.* - turns all particle effects on/off.",
     "syntax": "[cvar_regexp1] [cvar_regexp2] ... [cvar_regexpN]"
   },
   "toggleconsole": {
     "description": "Brings the console up and down."
   },
-  "togglehud": {
+  "toggleHUD": {
     "system-generated": true
   },
   "togglemenu": {
@@ -1801,16 +1824,16 @@
     "system-generated": true
   },
   "tp_msgcoming": {
-    "description": "Will send a message to your teammates telling them where you are coming from, and what your status is. Doubles as tp_lost when you are dead (because you can't be coming from somewhere if you're dead)."
+    "description": "Will send a message to your teammates telling them where you are coming from, and what your status is.\nDoubles as tp_lost when you are dead (because you can't be coming from somewhere if you're dead)."
   },
   "tp_msgenemypwr": {
-    "description": "This command could be used for all cases involving players with powerup. If you, a teammate, or enemy has powerup, this bind will report it. If eyes is in your point, we assume enemy only because this is tp_ENEMYpwr, otherwise there is no way to tell if a player with ring is enemy or teammate."
+    "description": "This command could be used for all cases involving players with powerup.\nIf you, a teammate, or enemy has powerup, this bind will report it.\nIf eyes is in your point, we assume enemy only because this is tp_ENEMYpwr, otherwise there is no way to tell if a player with ring is enemy or teammate."
   },
   "tp_msggetpent": {
-    "description": "Informs your teammates to get the pent. Will print enemy/team pent if you, teammate, or enemy has pent and they're in your point. Will print nothing if eyes is in point. "
+    "description": "Informs your teammates to get the pent.\nWill print enemy/team pent if you, teammate, or enemy has pent and they're in your point.\nWill print nothing if eyes is in point."
   },
   "tp_msggetquad": {
-    "description": "Informs your teammates to get the quad. Reports team/enemy quad if you, a teammate, or an enemy has quad and they are in your point. Reports nothing if eyes is in your point."
+    "description": "Informs your teammates to get the quad.\nReports team/enemy quad if you, a teammate, or an enemy has quad and they are in your point.\nReports nothing if eyes is in your point."
   },
   "tp_msghelp": {
     "description": "Requests help at a location. Also gives your status."
@@ -1822,16 +1845,17 @@
     "system-generated": true
   },
   "tp_msglost": {
-    "description": "Will send a message to your teammates telling them you died at a location. Also tells them how many enemies are there, and what weapon (if any) you dropped."
+    "description": "Will send a message to your teammates telling them you died at a location.\nAlso tells them how many enemies are there, and what weapon (if any) you dropped."
   },
   "tp_msgneed": {
-    "description": "Equivalent of %u (need macro). Will display what you need (health/armor/ammo)."
+    "description": "Equivalent of %u (need macro).\nWill display what you need (health/armor/ammo)."
   },
   "tp_msgnocancel": {
     "system-generated": true
   },
   "tp_msgpoint": {
-    "description": "Will report to your team item you see in your point at its location. Will report team/enemy powerup if you, a teammte, or an enemy has a powerup and are in your point. Note that tp_pointpriorities is default to 1 and it is strongly suggested to keep this value. You can alter the priorities of this bind by altering tp_point."
+    "description": "Will report to your team item you see in your point at its location.\nWill report team/enemy powerup if you, a teammate, or an enemy has a powerup and are in your point.",
+    "remarks": "Note that tp_pointpriorities defaults to 1 and it is strongly suggested to keep this value. You can alter the priorities of this bind by altering tp_point."
   },
   "tp_msgquaddead": {
     "description": "Reports quad is dead. Will print enemy/team powerup if you, a teammate, or an enemy have quad and are in your point."
@@ -1840,10 +1864,10 @@
     "description": "Requests a teammate to replace you at your location."
   },
   "tp_msgreport": {
-    "description": "Will send a message to your teammates about your current status - health, armor, location, powerups, weapon. Doubles as tp_lost when you are dead."
+    "description": "Will send a message to your teammates about your current status: health, armor, location, powerups, weapon.\nDoubles as tp_lost when you are dead."
   },
   "tp_msgsafe": {
-    "description": "Will send a message to your teammates informing them your current location is safe. Will print nothing if there is enemy in your point. Also reports your status."
+    "description": "Will send a message to your teammates informing them your current location is safe.\nWill print nothing if there is enemy in your point.\nAlso reports your status."
   },
   "tp_msgslipped": {
     "system-generated": true
@@ -1852,10 +1876,10 @@
     "system-generated": true
   },
   "tp_msgtook": {
-    "description": "Informs your team of the last item you took. Saves each item in memory for 15 seconds."
+    "description": "Informs your team of the last item you took.\nSaves each item in memory for 15 seconds."
   },
   "tp_msgtrick": {
-    "description": "Requests a trick at a location. Best for cases like dm2 when you need a teammate to help you get quad from stairs."
+    "description": "Requests a trick at a location.\nBest for cases like dm2 when you need a teammate to help you get quad from stairs."
   },
   "tp_msgutake": {
     "system-generated": true
@@ -1867,21 +1891,21 @@
     "system-generated": true
   },
   "tp_pickup": {
-    "description": "Item can be: quad, pent, ring, suit, ra, ya, ga, mh, health, lg,  rl, gl, sng, ng, ssg, pack, cells, rockets, nails, shells, flag,  armor, weapons, powerups, ammo, all, default, none"
+    "description": "Item can be: quad, pent, ring, suit, ra, ya, ga, mh, health, lg, rl, gl, sng, ng, ssg, pack, cells, rockets, nails, shells, flag, armor, weapons, powerups, ammo, all, default, none"
   },
   "tp_point": {
-    "description": "Specifies which items will be used in point (%x or $point) macro. If you point at an item and such item is not listed here, your message will be tp_name_nothing (default: \"nothing\"). Supported items: powerups, quad, pent, ring, armor, ra, ya, ga,  weapons, lg, rl, gl, sng, ng, ssg,  ammo, cells, rockets, nails, shells,  players, eyes, teammate, enemy,  mh, health, pack, flag, all, default, none, suit  Item names can be customized with tp_name_item",
+    "description": "Specifies which items will be used in point (%x or $point) macro.\nIf you point at an item and such item is not listed here, your message will be tp_name_nothing (default: \"nothing\").\nSupported items: powerups, quad, pent, ring, armor, ra, ya, ga, weapons, lg, rl, gl, sng, ng, ssg, ammo, cells, rockets, nails, shells, players, eyes, teammate, enemy, mh, health, pack, flag, all, default, none, suit\nItem names can be customized with tp_name_item.",
     "syntax": "item1 item2 ... DO NOT USE QUOTES"
   },
   "tp_took": {
-    "description": "Specifies which items will be included in the took (%X or $took) macro. If you took an item and it's not listed in tp_took list, %X and $took macro will display tp_name_nothing (default: \"nothing\"). Supported items: quad, pent, ring, suit, ra, ya, ga, mh, health, lg, rl, gl, sng, ng, ssg, pack, cells, rockets, nails, shells, flag, armor, weapons, powerups, ammo, all, default, none. Item names can be customized with tp_name_item.",
+    "description": "Specifies which items will be included in the took (%X or $took) macro.\nIf you took an item and it's not listed in tp_took list, %X and $took macro will display tp_name_nothing (default: \"nothing\").\nSupported items: quad, pent, ring, suit, ra, ya, ga, mh, health, lg, rl, gl, sng, ng, ssg, pack, cells, rockets, nails, shells, flag, armor, weapons, powerups, ammo, all, default, none\nItem names can be customized with tp_name_item.",
     "syntax": "item1 item2 ... DO NOT USE QUOTES"
   },
   "track": {
     "system-generated": true
   },
   "track-": {
-    "description": "This means when you are spectating or watching an mvd, keys will automatically be assigned  to track certain players (so in a 4v4 8 keys are needed, the first 4 make you track the  4 players in the first team and the last 4 make you track the second team)."
+    "description": "This means when you are spectating or watching an mvd, keys will automatically be assigned to track certain players.\nSo in a 4v4 8 keys are needed, the first 4 make you track the 4 players in the first team and the last 4 make you track the second team."
   },
   "track1": {
     "system-generated": true
@@ -1896,7 +1920,7 @@
     "system-generated": true
   },
   "trackkiller": {
-    "description": "Will switch view to the player who killed the player we are tracking at the moment"
+    "description": "Will switch view to the player who killed the player we are tracking at the moment."
   },
   "trackteam": {
     "arguments": [
@@ -1912,10 +1936,10 @@
     "description": "Performs a check on client settings and displays possible sources of issues."
   },
   "unalias": {
-    "description": "Example:  unalias myreport removes myreport alias."
+    "description": "Example:\nunalias myreport\n - removes myreport alias."
   },
   "unalias_re": {
-    "description": "Deletes given alias(es). Example: unalias ^_zoom. - removes all aliases beginning with '_zoom', e.g. _zoom_in, _zoom_out",
+    "description": "Deletes given alias(es).\n\nExample:\nunalias ^_zoom.\n - removes all aliases beginning with '_zoom', e.g. _zoom_in, _zoom_out",
     "syntax": "<cvar1> [cvar2] ..."
   },
   "unaliasall": {
@@ -1928,36 +1952,36 @@
     "description": "Removes all keyboard bindings."
   },
   "unignore": {
-    "description": "unginore name or userid number to remove ignore.",
-    "syntax": "(name/userid)"
+    "description": "Removes name or user ID number from ignore list.",
+    "syntax": "<name|userid>"
   },
   "unignoreAll": {
-    "description": "Removes all users from the ignore list."
+    "description": "Removes all users from ignore list."
   },
   "unignoreAll_team": {
-    "description": "Removes all ignored teams."
+    "description": "Removes all ignored teams from ignore list."
   },
   "unignore_id": {
-    "description": "unignore usedid removed player from ignore.",
-    "syntax": "(userid)"
+    "description": "Removes userid from ignore list.",
+    "syntax": "<userid>"
   },
   "unignore_team": {
-    "description": "If you have ignored team nine and wan't to remove team nine from ignore so type unignore_team nine  to remove ignore."
+    "description": "Removes team from ignore list."
   },
   "unignore_voip": {
     "system-generated": true
   },
   "unset": {
-    "description": "removes user-created variable ",
+    "description": "Removes user-created variable.",
     "syntax": "<cvar1> [cvar2] ..."
   },
   "unset_re": {
-    "description": "removes user-created variable",
+    "description": "Removes user-created variable.",
     "syntax": "<cvar1|regex1> [cvar2|regex2] ..."
   },
   "user": {
     "description": "This command queries the user for his setinfo information.",
-    "syntax": "(userid)"
+    "syntax": "<userid>"
   },
   "userdir": {
     "arguments": [
@@ -1966,24 +1990,25 @@
         "name": "dir"
       },
       {
-        "description": "Optional number. Default is 0. 0 - <quake_dir>/<gamedir>/<dir>,  1 - <quake_dir>/<dir>/<gamedir>.  2 - <quake_dir>/qw/<dir>/<gamedir>,  3 - <quake_dir>/qw/<dir>,  4 - <quake_dir>/<dir>,  5 - $HOME/qw/<dir>",
+        "description": "Optional number. Default is 0.\n0 - <quake_dir>/<gamedir>/<dir>\n1 - <quake_dir>/<dir>/<gamedir>\n2 - <quake_dir>/qw/<dir>/<gamedir>\n3 - <quake_dir>/qw/<dir>\n4 - <quake_dir>/<dir>\n5 - $HOME/qw/<dir>",
         "name": "type"
       }
     ],
-    "description": "A userdir command can be used for addition of directories to the list searched for files by the client (configs, sounds, models, etc.). Real handy when several players with their own configs files play Quake on a single computer. When issuing this command after reconnection to a server or parameter is not defined, a current userdir is printed in the console.",
+    "description": "A userdir command can be used for addition of directories to the list searched for files by the client (configs, sounds, models, etc.).\nReal handy when several players with their own configs files play Quake on a single computer.\nWhen issuing this command after reconnection to a server or parameter is not defined, a current userdir is printed in the console.",
     "syntax": "[dir [type]]"
   },
   "userinfo": {
     "description": "Prints your user settings."
   },
   "users": {
-    "description": "Reports information on connected players and retrieve user ids."
+    "description": "Reports information on connected players and retrieve user IDs."
   },
   "v_cshift": {
-    "description": "This adjusts all of the colors currently being displayed.  Used when you are underwater, hit, have the Ring of Shadows, or  Quad Damage.  Example: v_cshift 16 32 64  Note: v_cshift (red) (green) (blue) (intensity)"
+    "description": "This adjusts all of the colors currently being displayed.\nUsed when you are underwater, hit, have the Ring of Shadows, or Quad Damage.\n\nExample:\nv_cshift 16 32 64\n",
+    "syntax": "<red> <green> <blue> <intensity>"
   },
   "validate_clients": {
-    "description": "This shows authed ezQuake users, nonauthed and non ezQuake users."
+    "description": "This shows authed ezQuake users, non-authed and non-ezQuake users."
   },
   "version": {
     "description": "Prints client version number and date into the console."
@@ -1995,13 +2020,13 @@
     "description": "This command will force ezQuake to use a certain video mode."
   },
   "vid_fullscreen": {
-    "description": "This command will switch to a fullscreen video mode specified in the  \"vid_fullscreen_mode\" variable."
+    "description": "This command will switch to a fullscreen video mode specified in the \"vid_fullscreen_mode\" variable."
   },
   "vid_gfxinfo": {
-    "description": "This command will print out useful information about your video card, GL version, and refresh rate, video mode (width/height resolution and color depth) to console. Useful to make sure everything is right, and also to screenshot to show other people."
+    "description": "This command will print out useful information about your video card, GL version, and refresh rate, video mode (width/height resolution and color depth) to console.\nUseful to make sure everything is right, and also to screenshot to show other people."
   },
   "vid_minimize": {
-    "description": "This command will minimize the windowed game screen. It was made available  because the game takes control over the mouse when it is moved onto the game  window thus prohibiting the normal minimization of the game window."
+    "description": "This command will minimize the windowed game screen.\nIt was made available because the game takes control over the mouse when it is moved onto the game window thus prohibiting the normal minimization of the game window."
   },
   "vid_modelist": {
     "description": "Prints all supported video modes."
@@ -2010,13 +2035,13 @@
     "description": "Will restart your video renderer. Needed for some changes to take affect."
   },
   "vid_testmode": {
-    "description": "This command will switch to the specified video mode for 5-seconds in order to  test it."
+    "description": "This command will switch to the specified video mode for 5-seconds in order to test it."
   },
   "vid_windowed": {
-    "description": "This command will switch the a windowed video mode specified in the  \"vid_windowed_mode\" variable."
+    "description": "This command will switch the a windowed video mode specified in the \"vid_windowed_mode\" variable."
   },
   "viewalias": {
-    "description": "Example:  viewalias mystatus print mystatus alias."
+    "description": "Example:\nviewalias mystatus\n - prints mystatus alias."
   },
   "vip_addip": {
     "system-generated": true
@@ -2034,7 +2059,7 @@
     "description": "Adds one wait frame."
   },
   "weapon": {
-    "description": "Weapon selection command. Will select the best available weapon according to the sequence you choose.",
+    "description": "Weapon selection command.\nWill select the best available weapon according to the sequence you choose.",
     "syntax": "<w1> [<w2> [...]]"
   },
   "windows": {

--- a/help_variables.json
+++ b/help_variables.json
@@ -327,9 +327,9 @@
       ]
     },
     "allow_download_gfx": {
-      "desc": "Enables downloading files from the server from the gfx directory",
+      "desc": "Enables downloading files from the server from the gfx directory.",
       "group-id": "43",
-      "remarks": "Server-side",
+      "remarks": "Server-side.",
       "type": "boolean",
       "values": [
         {
@@ -374,9 +374,9 @@
     },
     "allow_download_other": {
       "default": "0",
-      "desc": "Enables downloading files from the server which are not in \\\"skins\\\", \\\"progs\\\", \\\"sound\\\", \\\"maps\\\" nor \\\"gfx\\\" directories",
+      "desc": "Enables downloading files from the server which are not in \"skins\", \"progs\", \"sound\", \"maps\" nor \"gfx\" directories.",
       "group-id": "43",
-      "remarks": "Server-side",
+      "remarks": "Server-side.",
       "type": "boolean",
       "values": [
         {
@@ -468,15 +468,15 @@
       "default": "2",
       "desc": "Possibility to prove, that you do NOT use scripts. Of course, values 0 and 1 will block 'rotate' command.",
       "group-id": "9",
-      "remarks": "Your current 'allow_scripts' setting will be reported to 'f_scripts' query and anyone will be able to check it. If anyone said 'f_scripts' since last mapchange, the client will also autoreport any change of allow_scripts. So if you don't use scripts, turn them off to prove you don't use them. And remember - scripts _are allowed_, so don't call ppl who use them 'cheaters'.\n\nThis variable will be set to 0 on startup if a command line switches -norjscripts or -noscripts are used",
+      "remarks": "Your current 'allow_scripts' setting will be reported to 'f_scripts' query and anyone will be able to check it.\nIf anyone said 'f_scripts' since last mapchange, the client will also autoreport any change of allow_scripts. So if you don't use scripts, turn them off to prove you don't use them.\nAnd remember - scripts _are allowed_, so don't call ppl who use them 'cheaters'.\n\nThis variable will be set to 0 on startup if a command line switches -norjscripts or -noscripts are used.",
       "type": "enum",
       "values": [
         {
-          "description": "Same as 1, but also block fast +lookdown/+lookup, so even simple rjump will be impossible. Blocks KTPro /kfjump and /krjump aliases.",
+          "description": "Same as 1, but also block fast +lookdown/+lookup, so even simple rjump will be impossible.\nBlocks KTPro /kfjump and /krjump aliases.",
           "name": "0"
         },
         {
-          "description": "Allow only simple scripts - it will block left/right turning, so fjump (for example) will be impossible, but normal rjump (+lookdown;+attack;+jump) will be possible. Blocks KTPro alias /kfjump too.",
+          "description": "Allow only simple scripts - it will block left/right turning, so fjump (for example) will be impossible, but normal rjump (+lookdown;+attack;+jump) will be possible.\nBlocks KTPro alias /kfjump too.",
           "name": "1"
         },
         {
@@ -492,7 +492,7 @@
     },
     "auth_validate": {
       "group-id": "27",
-      "remarks": "If you have 'auth_warninvalid 1' and someone gives a dirty hash in a version response (because they are using a hacked client that can't work out the right response), the client will print something like \n'Warning Invalid Client: playername (userid)' in your console ('auth_warninvalid 0' is default).",
+      "remarks": "If you have 'auth_warninvalid 1' and someone gives a dirty hash in a version response (because they are using a hacked client that can't work out the right response), the client will print something like\n'Warning Invalid Client: playername (userid)' in your console ('auth_warninvalid 0' is default).",
       "type": "boolean",
       "values": [
         {
@@ -500,7 +500,7 @@
           "name": "false"
         },
         {
-          "description": "which performs the validation (but you need to use 'validate_clients'",
+          "description": "Performs the validation (but you need to use 'validate_clients')",
           "name": "true"
         }
       ]
@@ -526,7 +526,7 @@
     },
     "b_switch": {
       "default": "",
-      "desc": "This variable allows you to define the highest weapon that the client should switch to upon a backpack pickup. The possible arguments of \"b_switch\" refer to the impulse that is used to switch to a certain weapon.  Note that a setting of 1 will effectively disable backpack weapon switching.",
+      "desc": "This variable allows you to define the highest weapon that the client should switch to upon a backpack pickup.\nThe possible arguments of \"b_switch\" refer to the impulse that is used to switch to a certain weapon.\nNote that a setting of 1 will effectively disable backpack weapon switching.",
       "group-id": "37",
       "type": "enum",
       "values": [
@@ -656,19 +656,19 @@
     },
     "cam_dist": {
       "default": "100",
-      "desc": "Distance from player. Use +forward/+back to adjust it smoothly",
+      "desc": "Distance from player. Use +forward/+back to adjust it smoothly.",
       "group-id": "46",
-      "remarks": "For use with cam_thirdperson",
+      "remarks": "For use with cam_thirdperson.",
       "type": "float"
     },
     "cam_lockdir": {
       "default": "0",
-      "desc": "Force camera to locked direction mode",
+      "desc": "Force camera to locked direction mode.",
       "group-id": "46",
       "type": "boolean",
       "values": [
         {
-          "description": "Dont force",
+          "description": "Don't force",
           "name": "false"
         },
         {
@@ -679,13 +679,13 @@
     },
     "cam_lockpos": {
       "default": "0",
-      "desc": "Force camera to locked position mode",
+      "desc": "Force camera to locked position mode.",
       "group-id": "46",
-      "remarks": "EXPEREMENTAL",
+      "remarks": "EXPERIMENTAL.",
       "type": "boolean",
       "values": [
         {
-          "description": "Dont force",
+          "description": "Don't force",
           "name": "false"
         },
         {
@@ -696,9 +696,9 @@
     },
     "cam_thirdperson": {
       "default": "0",
-      "desc": "Enables third person view in demo playback and spectator mode. In track mode, we look at the person being tracked rather than through his eyes. Unlike cl_camera_tpp, you can use the mouse to look around.",
+      "desc": "Enables third person view in demo playback and spectator mode.\nIn track mode, we look at the person being tracked rather than through his eyes.\nUnlike cl_camera_tpp, you can use the mouse to look around.",
       "group-id": "46",
-      "remarks": "in track mode, we look at the person being tracked rather than through his eyes",
+      "remarks": "in track mode, we look at the person being tracked rather than through his eyes.",
       "type": "boolean",
       "values": [
         {
@@ -713,7 +713,7 @@
     },
     "cam_zoomaccel": {
       "default": "2000",
-      "desc": "To control how fast you zoom in onto the target with +forward/+back in cam_thirdperson mode",
+      "desc": "To control how fast you zoom in onto the target with +forward/+back in cam_thirdperson mode.",
       "group-id": "46",
       "type": "float"
     },
@@ -739,22 +739,22 @@
       ]
     },
     "cfg_browser_democolor": {
-      "desc": "Color of the demo entries in the cfg browser",
+      "desc": "Color of the demo entries in the cfg browser.",
       "group-id": "25",
       "type": "string"
     },
     "cfg_browser_dircolor": {
-      "desc": "Color of the dir entries in the cfg browser",
+      "desc": "Color of the dir entries in the cfg browser.",
       "group-id": "25",
       "type": "string"
     },
     "cfg_browser_interline": {
-      "desc": "Size of the space between entries in the cfg browser",
+      "desc": "Size of the space between entries in the cfg browser.",
       "group-id": "25",
       "type": "integer"
     },
     "cfg_browser_scrollnames": {
-      "desc": "Toggle scrolling of the filenames in the cfg browser",
+      "desc": "Toggle scrolling of the filenames in the cfg browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -769,12 +769,12 @@
       ]
     },
     "cfg_browser_selectedcolor": {
-      "desc": "Color of the selected entries in the cfg browser",
+      "desc": "Color of the selected entries in the cfg browser.",
       "group-id": "25",
       "type": "string"
     },
     "cfg_browser_showdate": {
-      "desc": "Toggle the date column in the cfg browser",
+      "desc": "Toggle the date column in the cfg browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -789,7 +789,7 @@
       ]
     },
     "cfg_browser_showsize": {
-      "desc": "Toggle the file size column in the cfg browser",
+      "desc": "Toggle the file size column in the cfg browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -804,7 +804,7 @@
       ]
     },
     "cfg_browser_showstatus": {
-      "desc": "Toggle the display of the status bar in the cfg browser",
+      "desc": "Toggle the display of the status bar in the cfg browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -819,7 +819,7 @@
       ]
     },
     "cfg_browser_showtime": {
-      "desc": "Toggle the time column in the cfg browser",
+      "desc": "Toggle the time column in the cfg browse.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -839,7 +839,7 @@
       "type": "string"
     },
     "cfg_browser_stripnames": {
-      "desc": "Toggle stripping of the filenames in the cfg browser",
+      "desc": "Toggle stripping of the filenames in the cfg browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -854,7 +854,7 @@
       ]
     },
     "cfg_browser_zipcolor": {
-      "desc": "Color of the zip entries in the cfg browser",
+      "desc": "Color of the zip entries in the cfg browser.",
       "group-id": "25",
       "type": "string"
     },
@@ -958,7 +958,7 @@
     },
     "cfg_save_onquit": {
       "default": "0",
-      "desc": "When enabled, your main configuration (config.cfg) will be saved when you exit the application",
+      "desc": "When enabled, your main configuration (config.cfg) will be saved when you exit the application.",
       "group-id": "4",
       "remarks": "Configuration will be saved in the main user configuration file, that is config.cfg which can either be placed in the quake/ezquake/configs in your quakedir, or in your home dir in /ezquake, depending on cfg_use_home setting.",
       "type": "boolean",
@@ -982,11 +982,10 @@
     "cfg_save_unchanged": {
       "default": "0",
       "group-id": "4",
-      "remarks": "config file.",
       "type": "boolean",
       "values": [
         {
-          "description": "Makes cfg_save only write variables that are not default valued to the",
+          "description": "Makes cfg_save only write variables that are not default valued to the config file.",
           "name": "false"
         },
         {
@@ -998,7 +997,7 @@
     "cfg_save_userinfo": {
       "default": "2",
       "group-id": "4",
-      "remarks": "Note: 'cfg_save_userinfo 1' is best for teamfortress so you don't get kicked for changing bottom color. cfg_save will never save the password variable, even though technically it is a userinfo variable.",
+      "remarks": "Note: 'cfg_save_userinfo 1' is best for teamfortress so you don't get kicked for changing bottom color.\ncfg_save will never save the password variable, even though technically it is a userinfo variable.",
       "type": "enum",
       "values": [
         {
@@ -1006,7 +1005,7 @@
           "name": "0"
         },
         {
-          "description": "Save all userinfo variables except spectator/topcolor/bottomcolor/teamcolor/skin/team/rate/msg/w and b_switch",
+          "description": "Save all userinfo variables except spectator, topcolor, bottomcolor, teamcolor, skin, team, rate, msg, w and b_switch.",
           "name": "1"
         },
         {
@@ -1017,13 +1016,13 @@
     },
     "cfg_use_gamedir": {
       "default": "0",
-      "desc": "If set & gamedir is not 'qw', configurations will be saved to subdirectory based on gamedir. Useful if configurations differ depending on gametype (e.g. team fortress)",
+      "desc": "If set & gamedir is not 'qw', configurations will be saved to subdirectory based on gamedir.\nUseful if configurations differ depending on gametype (e.g. team fortress)",
       "group-id": "4",
       "type": "boolean"
     },
     "cfg_use_home": {
       "default": "0",
-      "desc": "When turned on, configutaion will be saved into user's profile (home) directory.",
+      "desc": "When turned on, configuration will be saved into user's profile (home) directory.",
       "group-id": "4",
       "remarks": "This affects only cfg_save and cfg_load commands.",
       "type": "boolean",
@@ -1061,9 +1060,9 @@
     },
     "cl_backspeed": {
       "default": "400",
-      "desc": "This allows you to set your backward speed. Obviously this is also limited by the server, usually to \"320\".",
+      "desc": "This allows you to set your backward speed.\nObviously this is also limited by the server, usually to \"320\".",
       "group-id": "9",
-      "remarks": "Sign of the value is ignored",
+      "remarks": "Sign of the value is ignored.",
       "type": "float"
     },
     "cl_bob": {
@@ -1107,13 +1106,13 @@
     },
     "cl_c2sImpulseBackup": {
       "default": "3",
-      "desc": "Used with cl_c2spps, it controls how many backup copies of packets with non-zero impulses are to be sent to the server. The recommended value is 3, but you can try 2 or even 1 to reduce traffic if you don't have any packet loss.",
+      "desc": "Used with cl_c2spps, it controls how many backup copies of packets with non-zero impulses are to be sent to the server.\nThe recommended value is 3, but you can try 2 or even 1 to reduce traffic if you don't have any packet loss.",
       "group-id": "21",
       "type": "integer"
     },
     "cl_c2spps": {
       "default": "0",
-      "desc": "Packet filtering (a la Qizmo's .c2spps command). Use this to reduce network traffic if you're playing on a 28800 (or worse) connection and can't set cl_maxfps 72 because it causes lag.  Also consider use of FPS independent physics in conjunction with cl_physfps.",
+      "desc": "Packet filtering (a la Qizmo's .c2spps command).\nUse this to reduce network traffic if you're playing on a 28800 (or worse) connection and can't set cl_maxfps 72 because it causes lag.\nAlso consider use of FPS independent physics in conjunction with cl_physfps.",
       "group-id": "21",
       "type": "integer"
     },
@@ -1146,14 +1145,14 @@
     },
     "cl_camera_tpp_distance": {
       "default": "-56",
-      "desc": "Sets distance of 3rd person camera from tracked player.  You can use negative values too.",
+      "desc": "Sets distance of 3rd person camera from tracked player.\nYou can use negative values too.",
       "group-id": "46",
       "remarks": "For use with cl_camera_tpp. See cl_camera_tpp_height too.",
       "type": "float"
     },
     "cl_camera_tpp_height": {
       "default": "24",
-      "desc": "Sets vertical position of 3rd person camera.  You can use negative values too.",
+      "desc": "Sets vertical position of 3rd person camera.\nYou can use negative values too.",
       "group-id": "46",
       "remarks": "Set cl_camera_tpp 1 first.",
       "type": "float"
@@ -1196,9 +1195,9 @@
     },
     "cl_chunksperframe": {
       "default": "5",
-      "desc": "Affects the download speed when using chunked downloads, more chunks per frame results in higher download speed",
+      "desc": "Affects the download speed when using chunked downloads, more chunks per frame results in higher download speed.",
       "group-id": "21",
-      "remarks": "Servers can limit the amount of chunks sent per frame",
+      "remarks": "Servers can limit the amount of chunks sent per frame.",
       "type": "integer"
     },
     "cl_clock": {
@@ -1253,19 +1252,19 @@
     },
     "cl_clock_y": {
       "default": "-1",
-      "desc": "Vertical coordinates of the clock. If < 0, the coordinates are calculated from bottom up, e.g. -1 means the screen line just above the scoreboard.",
+      "desc": "Vertical coordinates of the clock.\nIf < 0, the coordinates are calculated from bottom up, e.g. -1 means the screen line just above the scoreboard.",
       "group-id": "40",
       "type": "float"
     },
     "cl_cmdline": {
       "default": "",
-      "desc": "Read-only variable showing you what were the commandline options used to launch the client",
+      "desc": "Read-only variable showing you what were the commandline options used to launch the client.",
       "group-id": "2",
       "type": "string"
     },
     "cl_confirmquit": {
       "default": "0",
-      "desc": "This sets whether to confirm on quit (1) or quit with no confirmation (0).",
+      "desc": "This sets whether to confirm on quit or quit with no confirmation.",
       "group-id": "40",
       "type": "boolean",
       "values": [
@@ -1299,9 +1298,9 @@
     },
     "cl_curlybraces": {
       "default": "0",
-      "desc": "Enables new syntax to be used for Quake scripting allowing you to enclose commands into curly braces",
+      "desc": "Enables new syntax to be used for Quake scripting allowing you to enclose commands into curly braces.",
       "group-id": "5",
-      "remarks": "See scripting manual for further info",
+      "remarks": "See scripting manual for further info.",
       "type": "boolean",
       "values": [
         {
@@ -1411,7 +1410,7 @@
       "default": "0",
       "desc": "Client will delay incoming and outgoing packets, allowing user to increase his ping in the game.",
       "group-id": "21",
-      "remarks": "Specified in ms.  If delay is 20ms, incoming packets will be delayed by 10ms, outgoing packets too. It's preferred to use the least value that gives the desired ping.",
+      "remarks": "Specified in ms. If delay is 20ms, incoming packets will be delayed by 10ms, outgoing packets too. It's preferred to use the least value that gives the desired ping.",
       "type": "integer"
     },
     "cl_delay_packet_deviation": {
@@ -1423,25 +1422,19 @@
     },
     "cl_delay_packet_target": {
       "default": "0",
-      "desc": "Targets a particular ping, rather than specifying the additional delay.  Adds half the ping to the outgoing packet and the remainder to incoming",
+      "desc": "Targets a particular ping, rather than specifying the additional delay.\nAdds half the ping to the outgoing packet and the remainder to incoming.",
       "group-id": "21",
       "type": "integer"
     },
     "cl_demo_qwd_delta": {
       "default": "1",
-      "desc": "Whether or not to write delta packets for entities into .qwd files.  Older clients may not be able to play these back.",
-      "group-id": "7",
-      "type": "boolean"
-    },
-    "cl_demo_qwd_delta": {
-      "default": "1",
-      "desc": "Whether or not to write delta packets for entities into .qwd files.  Older clients may not be able to play these back.",
+      "desc": "Whether or not to write delta packets for entities into .qwd files.\nOlder clients may not be able to play these back.",
       "group-id": "7",
       "type": "boolean"
     },
     "cl_demoPingInterval": {
       "default": "5",
-      "desc": "How often to request ping updates when recording demos. This variable doesn't affect ping updates when the scoreboard is shown (they are always one update per 2 seconds).",
+      "desc": "How often to request ping updates when recording demos.\nThis variable doesn't affect ping updates when the scoreboard is shown (they are always one update per 2 seconds).",
       "group-id": "7",
       "type": "integer",
       "values": [
@@ -1487,8 +1480,18 @@
       "default": ".33",
       "desc": "Reduces flash grenade effect when watching demos.",
       "group-id": "39",
-      "remarks": "Values from 0 to 1 are possible. 0 - flash effects disabled, 1 - original.",
-      "type": "float"
+      "remarks": "Values from 0 to 1 are possible.",
+      "type": "float",
+      "values": [
+        {
+          "description": "Flash effects disabled",
+          "name": "0"
+    },
+        {
+          "description": "Original",
+          "name": "1"
+        }
+      ]
     },
     "cl_demospeed": {
       "default": "1",
@@ -1504,7 +1507,7 @@
     },
     "cl_earlypackets": {
       "default": "1",
-      "desc": "Read network data independently on physical frames. When using independent physics, network data will be read as early as possible, compared to the old way when it was read only on every physframe (77 times per second).",
+      "desc": "Read network data independently on physical frames.\nWhen using independent physics, network data will be read as early as possible, compared to the old way when it was read only on every physframe (77 times per second).",
       "group-id": "21",
       "type": "boolean",
       "values": [
@@ -1522,7 +1525,7 @@
       "default": "",
       "desc": "Automatically prefixes all team messages with a shorter version of your nick unless the message has a \"fake\" part already (so no configs are broken).",
       "group-id": "3",
-      "remarks": "Applies for say_team and messagemode2",
+      "remarks": "Applies for say_team and messagemode2.",
       "type": "string"
     },
     "cl_fakename_suffix": {
@@ -1533,7 +1536,7 @@
     },
     "cl_fakeshaft": {
       "default": "0",
-      "desc": "Smoothes out shaft movement, 0 means no smoothing at all, 1 = 100% smoothing; a value of about 0.5 is recommended for modem players.  Note that this only affects the visual display of the shaft beam; the 'true' beam remains in the original location.",
+      "desc": "Smoothes out shaft movement.\n0 = no smoothing at all\n1 = 100% smoothing\nA value of about 0.5 is recommended for modem players.\n\nNote that this only affects the visual display of the shaft beam; the 'true' beam remains in the original location.",
       "group-id": "8",
       "type": "float"
     },
@@ -1601,9 +1604,9 @@
     },
     "cl_forwardspeed": {
       "default": "400",
-      "desc": "This allows you to set your forward speed. Obviously this is also limited by the server, usually to \"320\".",
+      "desc": "This allows you to set your forward speed.\nObviously this is also limited by the server, usually to \"320\".",
       "group-id": "9",
-      "remarks": "Sign of the value is ignored",
+      "remarks": "Sign of the value is ignored.",
       "type": "float"
     },
     "cl_fp_messages": {
@@ -1649,7 +1652,7 @@
     },
     "cl_gameclock_offset": {
       "default": "0",
-      "desc": "Allows using gameclock in custom mods that don't support standard KT-like clock synchronization",
+      "desc": "Allows using gameclock in custom mods that don't support standard KT-like clock synchronization.",
       "group-id": "40",
       "remarks": "Some Capture The Flag or Team Fortress mods can take a use of this.",
       "type": "integer"
@@ -1703,9 +1706,9 @@
     },
     "cl_hud": {
       "default": "1",
-      "desc": "Enables/Disables strings-hud. Strings hud is not mqwcl hud. It gives you ability put any string (or value of some variable) on your hud.",
+      "desc": "Enables/Disables strings-hud.\nStrings hud is not mqwcl hud. It gives you ability put any string (or value of some variable) on your hud.",
       "group-id": "40",
-      "remarks": "Strings hud banned for ruleset smackdown",
+      "remarks": "Strings hud banned for ruleset smackdown.",
       "type": "boolean",
       "values": [
         {
@@ -1735,7 +1738,7 @@
     },
     "cl_iDrive": {
       "default": "0",
-      "desc": "Emulates \"strafe script\". When turned on you will always move to some direction when holding both keys +moveleft and +moveright (or +forward and +back). If you have this turned on, it will be reported in your f_ruleset reply with as (+i) flag. Cannot be changed during the gameplay.",
+      "desc": "Emulates \"strafe script\". When turned on you will always move to some direction when holding both keys +moveleft and +moveright (or +forward and +back).\nIf you have this turned on, it will be reported in your f_ruleset reply with as (+i) flag.\nCannot be changed during the gameplay.",
       "group-id": "9",
       "type": "boolean",
       "values": [
@@ -1751,13 +1754,13 @@
     },
     "cl_independentPhysics": {
       "default": "1",
-      "desc": "This enables independent physics. This means that you can achieve more FPS in the game than allowed by the server. The amount of FPS used to communicate with the server is set by /cl_physfps and the amount of graphics FPS is set by /cl_maxfps. Note that you must have vid_vsync 0.",
+      "desc": "This enables independent physics. This means that you can achieve more FPS in the game than allowed by the server.\nThe amount of FPS used to communicate with the server is set by /cl_physfps and the amount of graphics FPS is set by /cl_maxfps.\nNote that you must have vid_vsync 0.",
       "group-id": "8",
       "remarks": "This variable can only be switched from 0<->1 when disconnected from a server (Qizmo/eztv are also servers).",
       "type": "boolean",
       "values": [
         {
-          "description": "Disable independent physics,",
+          "description": "Disable independent physics.",
           "name": "false"
         },
         {
@@ -1776,18 +1779,18 @@
           "name": "0"
         },
         {
-          "description": "You will be able to bind all numpad keys independently of standard keys.  Use kp_enter, kp_8 etc to differentiate from standard keys.",
+          "description": "You will be able to bind all numpad keys independently of standard keys.\nUse kp_enter, kp_8 etc to differentiate from standard keys.",
           "name": "1"
         },
         {
-          "description": "As 'cl_keypad 0' in game, 'cl_keypad 1' when in menus/console etc",
+          "description": "As 'cl_keypad 0' in game, 'cl_keypad 1' when in menus/console etc.",
           "name": "2"
         }
       ]
     },
     "cl_lerp_monsters": {
       "default": "1",
-      "desc": "Enables linear interpolation on Quake monsters and creatures",
+      "desc": "Enables linear interpolation on Quake monsters and creatures.",
       "group-id": "8",
       "type": "boolean",
       "values": [
@@ -1862,12 +1865,12 @@
       "default": "2.0",
       "desc": "This variable is the multiplier for how fast you move when running (+speed) in relation to when walking (-speed).",
       "group-id": "9",
-      "remarks": "Sign of the value is ignored",
+      "remarks": "Sign of the value is ignored.",
       "type": "float"
     },
     "cl_multiview": {
       "default": "0",
-      "desc": "This client adds a multiview component to mvd playback. Upto four views can be displayed at once. Use this variable to turn multiview on.",
+      "desc": "This client adds a multiview component to mvd playback. Up to four views can be displayed at once. Use this variable to turn multiview on.",
       "group-id": "40",
       "type": "enum",
       "values": [
@@ -1966,7 +1969,7 @@
       "default": "bottom center",
       "desc": "Sets the position of the multiview mini-HUDs.",
       "group-id": "40",
-      "remarks": "This only applies to the mini-HUD when cl_mvdisplayhud has a value greater than 1. Otherwise old mini-HUD will be used (just strings).",
+      "remarks": "This only applies to the mini-HUD when cl_mvdisplayhud has a value greater than 1.\nOtherwise old mini-HUD will be used (just strings).",
       "type": "enum",
       "values": [
         {
@@ -2124,7 +2127,7 @@
     },
     "cl_name_as_skin": {
       "default": "0",
-      "desc": "Allows you to override user skin settings and use player's name or ID as a his (her) skin",
+      "desc": "Allows you to override user skin settings and use player's name or ID as a his (her) skin.",
       "group-id": "44",
       "remarks": "There are many other skin settings that can override, e.g. all enemy*skin, team*skin settings override this setting.",
       "type": "enum",
@@ -2154,12 +2157,12 @@
       "default": "0",
       "desc": "Experimental rockets/grenades/spikes smoothing code.\nDefault value 0.1 means: use 90% of our 'vision' and 10% of server 'vision'. Should be OK for most case, but floating ping (see remarks)",
       "group-id": "8",
-      "remarks": "Range between 0 and 1.  This smoothing algorithm works well only with stable ping.",
+      "remarks": "Range between 0 and 1. This smoothing algorithm works well only with stable ping.",
       "type": "float"
     },
     "cl_nodelta": {
       "default": "0",
-      "desc": "Control the network packet delta compression. When you get blue lines in your netgraph, you should set 'cl_nodelta 1'.",
+      "desc": "Control the network packet delta compression.\nWhen you get blue lines in your netgraph, you should set 'cl_nodelta 1'.",
       "group-id": "21",
       "type": "boolean",
       "values": [
@@ -2195,7 +2198,7 @@
     },
     "cl_nolerp": {
       "default": "0",
-      "desc": "Allows you to disable the linear interpolation (lerp) of objects in the game. Information about objects' states arrive periodically via the net connection. By default between these moments the client tries to interpolate where the object are. After the new packet arrives client corrects the position of the object. If the interpolation is disabled, client will leave object in the state described in the last received packet until a new one arrives.",
+      "desc": "Allows you to disable the linear interpolation (lerp) of objects in the game.\nInformation about objects' states arrive periodically via the net connection. By default between these moments the client tries to interpolate where the object are. After the new packet arrives client corrects the position of the object.\nIf the interpolation is disabled, client will leave object in the state described in the last received packet until a new one arrives.",
       "group-id": "8",
       "type": "boolean",
       "values": [
@@ -2211,7 +2214,7 @@
     },
     "cl_nolerp_on_entity": {
       "default": "0",
-      "desc": "Disables linear interpolation only when player is standing on an entity. It is a workaround to remove jittering of floating platforms under feets.",
+      "desc": "Disables linear interpolation only when player is standing on an entity.\nIt is a workaround to remove jittering of floating platforms under feets.",
       "group-id": "8",
       "remarks": "No effect if fps independent physics is turned off. See cl_nolerp.",
       "type": "boolean",
@@ -2244,13 +2247,13 @@
     },
     "cl_novweps": {
       "default": "0",
-      "desc": "If set, disables support for zquake vwep extension",
+      "desc": "If set, disables support for zquake vwep extension.",
       "group-id": "8",
       "type": "boolean"
     },
     "cl_onload": {
       "default": "menu",
-      "desc": "Tells what will be the start-up screen of the client",
+      "desc": "Tells what will be the start-up screen of the client.",
       "group-id": "40",
       "type": "enum",
       "values": [
@@ -2282,7 +2285,7 @@
           "name": "false"
         },
         {
-          "description": "Enable displaying team fortress related statistics in the scoreboard (flag touches, steals, caps, etc)",
+          "description": "Enable displaying team fortress related statistics in the scoreboard (flag touches, steals, caps, etc).",
           "name": "true"
         }
       ]
@@ -2290,7 +2293,7 @@
     "cl_parseFunChars": {
       "default": "1",
       "group-id": "3",
-      "remarks": "Full list:\n$R - red lamp\n$G - green lamp\n$B - blue lamp\n$Y - yellow lamp\n$\\ - carridge return\n$( - big left bracket\n$= - big equal sign\n$) - big right bracket\n$. - red middle dot\n$, - white dot (names only)\n$< - small left bracket\n$- - small equal sign\n$> - small right bracket\n$a - big grey block\n$: - line feed\n$b - filled red block\n$d - right pointing red arrow\n$[ - gold left square bracket\n$] - gold right square bracket\n$^ - white ^ (names only)\n^x - red x (names only)\n$0-9 - yellow number\n$xyy - char with hex code yy\n(In order to use the lamps, you'll need the Ocrana pak).",
+      "remarks": "Full list:\n$R - red lamp\n$G - green lamp\n$B - blue lamp\n$Y - yellow lamp\n$\\ - carriage return\n$( - big left bracket\n$= - big equal sign\n$) - big right bracket\n$. - red middle dot\n$, - white dot (names only)\n$< - small left bracket\n$- - small equal sign\n$> - small right bracket\n$a - big grey block\n$: - line feed\n$b - filled red block\n$d - right pointing red arrow\n$[ - gold left square bracket\n$] - gold right square bracket\n$^ - white ^ (names only)\n^x - red x (names only)\n$0-9 - yellow number\n$xyy - char with hex code yy\n(In order to use the lamps, you'll need the Ocrana pak).",
       "type": "boolean",
       "values": [
         {
@@ -2340,7 +2343,7 @@
     },
     "cl_pext": {
       "default": "1",
-      "desc": "If set, enable support for FTE's protocol extensions",
+      "desc": "If set, enable support for FTE's protocol extensions.",
       "group-id": "21",
       "type": "boolean"
     },
@@ -2362,13 +2365,13 @@
     },
     "cl_pext_alpha": {
       "default": "1",
-      "desc": "If set, enable support for FTE's alpha attribute protocol extension",
+      "desc": "If set, enable support for FTE's alpha attribute protocol extension.",
       "group-id": "21",
       "type": "boolean"
     },
     "cl_pext_chunkeddownloads": {
       "default": "1",
-      "desc": "Enables protocol extension called \\\"Chunked downloads\\\". Allows you to download maps and demos from servers faster.",
+      "desc": "Enables protocol extension called \"Chunked downloads\". Allows you to download maps and demos from servers faster.",
       "group-id": "21",
       "type": "boolean",
       "values": [
@@ -2390,9 +2393,9 @@
     },
     "cl_pext_lagteleport": {
       "default": "0",
-      "desc": "Enable support for MVDSV to correct movement commands when travelling through teleports. See https://www.quakeworld.nu/forum/topic/7239 for more details.",
+      "desc": "Enable support for MVDSV to correct movement commands when travelling through teleports.\nSee https://www.quakeworld.nu/forum/topic/7239 for more details.",
       "group-id": "21",
-      "remarks": "You must reconnect to the server for changes to take effect",
+      "remarks": "You must reconnect to the server for changes to take effect.",
       "type": "boolean",
       "values": [
         {
@@ -2423,7 +2426,7 @@
     },
     "cl_pext_other": {
       "default": "0",
-      "desc": "Allows other protocol extensions other than Chunked downloads",
+      "desc": "Allows other protocol extensions other than Chunked downloads.",
       "group-id": "21",
       "type": "boolean",
       "values": [
@@ -2450,13 +2453,13 @@
     },
     "cl_physfps": {
       "default": "0",
-      "desc": "Sets the amount of FPS used to communicate with the server. This variable is used when cl_independentphysics 1 is set, and controls the FPS sent/received to/from the server. The graphical FPS is limited by cl_maxfps (vid_vsync must be 0). When set to 0, the current cl_maxfps value is used. When cl_maxfps is set to 0 too, client displays as much FPS as server and data rate allows.",
+      "desc": "Sets the amount of FPS used to communicate with the server.\nThis variable is used when cl_independentphysics 1 is set, and controls the FPS sent/received to/from the server.\nThe graphical FPS is limited by cl_maxfps (vid_vsync must be 0).\n\nWhen set to 0, the current cl_maxfps value is used.\nWhen cl_maxfps is set to 0 too, client displays as much FPS as server and data rate allows.",
       "group-id": "8",
       "type": "float"
     },
     "cl_physfps_spectator": {
       "default": "30",
-      "desc": "Amount of updates the client will send/receive while being spectator. Lower values make the client smooth-out the field of view movement greatly.",
+      "desc": "Amount of updates the client will send/receive while being spectator.\nLower values make the client smooth-out the field of view movement greatly.",
       "group-id": "8",
       "remarks": "This can increase your ping (only) when you are a spectator.",
       "type": "integer"
@@ -2523,13 +2526,13 @@
     },
     "cl_restrictions": {
       "default": "0",
-      "desc": "Triggers and re/msg trigger restrictions for spectator and demoplay modes",
+      "desc": "Triggers and re/msg trigger restrictions for spectator and demoplay modes.",
       "group-id": "3",
       "remarks": "FuhQuake always behave as cl_restrictions 1. QW262 by default it have cl_restrictions 1.",
       "type": "boolean",
       "values": [
         {
-          "description": "Allow triggersand huds",
+          "description": "Allow triggers and huds",
           "name": "false"
         },
         {
@@ -2542,7 +2545,7 @@
       "default": "20",
       "desc": "You can turn off the 'dodging' or 'rolling' effect for your own point of view while still see other player models affected by cl_rollangle.",
       "group-id": "53",
-      "remarks": "0 disables, 1 is standard.  Disabled by ruleset smackdown",
+      "remarks": "0 disables, 1 is standard. Disabled by ruleset smackdown.",
       "type": "integer"
     },
     "cl_rollangle": {
@@ -2577,7 +2580,7 @@
       "default": "0",
       "desc": "Allows you to filter your own outgoing messages out of markup that is used in this client to send colored text.",
       "group-id": "49",
-      "remarks": "Colored text is not supported by some other clients. See cl_sayfilter_sendboth for compatibility mode with other clients. If you want to filter incoming messages out of colors, use scr_coloredtext.",
+      "remarks": "Colored text is not supported by some other clients. See cl_sayfilter_sendboth for compatibility mode with other clients.\nIf you want to filter incoming messages out of colors, use scr_coloredtext.",
       "type": "enum",
       "values": [
         {
@@ -2596,9 +2599,9 @@
     },
     "cl_sayfilter_sendboth": {
       "default": "0",
-      "desc": "When used with cl_sayfilter_coloredtext, sends two versions of the teamplay colored messages: colored one with \"#c\" at the end and uncolored version of the message with \"#u\" at the end of the message",
+      "desc": "When used with cl_sayfilter_coloredtext, sends two versions of the teamplay colored messages: colored one with \"#c\" at the end and uncolored version of the message with \"#u\" at the end of the message.",
       "group-id": "49",
-      "remarks": "FuhQuake users then can use \"filter #u\" to see only uncolored messages, ezQuake users can set \"filter #c\" to see only colored messages",
+      "remarks": "FuhQuake users then can use \"filter #u\" to see only uncolored messages, ezQuake users can set \"filter #c\" to see only colored messages.",
       "type": "boolean",
       "values": [
         {
@@ -2671,9 +2674,9 @@
     },
     "cl_sidespeed": {
       "default": "400",
-      "desc": "This allows you to set your strafe speed. Obviously this is also limited by the server, usually to \"320\".",
+      "desc": "This allows you to set your strafe speed.\nObviously this is also limited by the server, usually to \"320\".",
       "group-id": "9",
-      "remarks": "Sign of the value is ignored",
+      "remarks": "Sign of the value is ignored.",
       "type": "float"
     },
     "cl_smartjump": {
@@ -2726,7 +2729,7 @@
     },
     "cl_sv_packetsync": {
       "default": "1",
-      "desc": "Determines if internal server should process packets as soon as received from client",
+      "desc": "Determines if internal server should process packets as soon as received from client.",
       "group-id": "43",
       "remarks": "Should only affect playing on local server, when cl_delay_packet is enabled.\nRecommend to disable for older mods which fake players (frogbots) and leave enabled for KTX.",
       "type": "boolean"
@@ -2759,16 +2762,16 @@
     },
     "cl_upspeed": {
       "default": "400",
-      "desc": "This allows you to set the speed with which you move up and down in liquids or in spectator mode. Obviously this is also limited by the server, usually to 320*0.7 = 224 when being in liquid and to 500 in spectator mode.",
+      "desc": "This allows you to set the speed with which you move up and down in liquids or in spectator mode.\nObviously this is also limited by the server, usually to 320*0.7 = 224 when being in liquid and to 500 in spectator mode.",
       "group-id": "9",
-      "remarks": "Sign of the value is ignored",
+      "remarks": "Sign of the value is ignored.",
       "type": "float"
     },
     "cl_useimagesinfraglog": {
       "default": "0",
-      "desc": "Turns on using images in the frags tracker window to show which weapon did take the role in the frag",
+      "desc": "Turns on using images in the frags tracker window to show which weapon did take the role in the frag.",
       "group-id": "47",
-      "remarks": "See Tracer Stats manual page for further info",
+      "remarks": "See Tracer Stats manual page for further info.",
       "type": "boolean",
       "values": [
         {
@@ -2806,7 +2809,7 @@
       "default": "1",
       "desc": "Enables the check on client startup for handling URLs starting with qw://",
       "group-id": "40",
-      "remarks": "When enabled and the client is not associated with handling of qw:// URLs, user will be prompted if he wishes to associate the client with the protocol",
+      "remarks": "When enabled and the client is not associated with handling of qw:// URLs, user will be prompted if he wishes to associate the client with the protocol.",
       "type": "enum",
       "values": [
         {
@@ -3009,9 +3012,9 @@
     },
     "cl_weaponpreselect": {
       "default": "0",
-      "desc": "When using the weapon command, this variable allows weapon preselection instead of standard immediate weapon selection. Preselection means that the preselected weapon will be switch right before +attack command, that is right before you shoot from your weapon.",
+      "desc": "When using the weapon command, this variable allows weapon preselection instead of standard immediate weapon selection.\nPreselection means that the preselected weapon will be switch right before +attack command, that is right before you shoot from your weapon.",
       "group-id": "9",
-      "remarks": "Usefull in most teamplay games where you don't want to carry your best weapon in your hands but want to be ready to instantly shoot from it. Note: Doesn't work for impulse command, you have to use new weapon command.",
+      "remarks": "Usefull in most teamplay games where you don't want to carry your best weapon in your hands but want to be ready to instantly shoot from it.\nNote: Doesn't work for impulse command, you have to use new weapon command.",
       "type": "enum",
       "values": [
         {
@@ -3225,7 +3228,7 @@
       "default": "2",
       "desc": "Console completion variants format.",
       "group-id": "5",
-      "remarks": "Modern - plain list with colorization. Old - somehow grouped list without colorization.",
+      "remarks": " - Modern: plain list with colorization.\n - Old: somehow grouped list without colorization.",
       "type": "enum",
       "values": [
         {
@@ -3258,14 +3261,14 @@
       "default": "2",
       "desc": "Number of spaces to pad command completion variants.",
       "group-id": "5",
-      "remarks": "con_completion_format must be > 1",
+      "remarks": "con_completion_format must be > 1.",
       "type": "integer"
     },
     "con_deadkey": {
       "default": "1",
-      "desc": "Set this if the console toggle button is also a deadkey.  The operating system will be sent a backspace character as the console is toggled.",
+      "desc": "Set this if the console toggle button is also a deadkey. The operating system will be sent a backspace character as the console is toggled.",
       "group-id": "5",
-      "remarks": "Windows only",
+      "remarks": "Windows only.",
       "type": "boolean"
     },
     "con_fragmessages": {
@@ -3291,16 +3294,16 @@
     },
     "con_funchars_mode": {
       "default": "0",
-      "desc": "Orange text, LEDs and special chars with [Ctrl] key - kind of MQWCL behaviour when set to 1",
+      "desc": "Orange text, LEDs and special chars with [Ctrl] key - kind of MQWCL behaviour when set to 1.",
       "group-id": "5",
       "type": "boolean",
       "values": [
         {
-          "description": "FuhQuake behaviour - [Ctrl] + key for yellow numbers and LEDs",
+          "description": "FuhQuake behaviour: [Ctrl] + key for yellow numbers and LEDs",
           "name": "false"
         },
         {
-          "description": "MQWCL behaviour - [Ctrl] + [Y] turns on yellow number input",
+          "description": "MQWCL behaviour: [Ctrl] + [Y] turns on yellow number input",
           "name": "true"
         }
       ]
@@ -3309,7 +3312,7 @@
       "default": "1",
       "desc": "Hides the input of own chat text in the console.",
       "group-id": "5",
-      "remarks": "cl_chatmode must be 1 or 2",
+      "remarks": "cl_chatmode must be 1 or 2.",
       "type": "boolean",
       "values": [
         {
@@ -3361,7 +3364,7 @@
     },
     "con_mm2_only": {
       "default": "0",
-      "desc": "If set, notification area is limited to mm2 (/say_team) messages",
+      "desc": "If set, notification area is limited to mm2 (/say_team) messages.",
       "group-id": "47",
       "type": "boolean",
       "values": [
@@ -3377,9 +3380,9 @@
     },
     "con_notify": {
       "default": "1",
-      "desc": "Toggles the display of the notification area",
+      "desc": "Toggles the display of the notification area.",
       "group-id": "5",
-      "remarks": "Notification area is the place where chat and game messages are displayed",
+      "remarks": "Notification area is the place where chat and game messages are displayed.",
       "type": "boolean",
       "values": [
         {
@@ -3396,7 +3399,7 @@
       "default": "4",
       "desc": "This variable sets the maximum number of notify lines (default 4, max 15) to be used at the top of the screen.",
       "group-id": "5",
-      "remarks": "Only affects con_notify",
+      "remarks": "Only affects con_notify.",
       "type": "integer"
     },
     "con_notifytime": {
@@ -3409,7 +3412,7 @@
       "default": "93",
       "desc": "ASCII code of prompt character.",
       "group-id": "5",
-      "remarks": "Value must be between 32 and 255",
+      "remarks": "Value must be between 32 and 255.",
       "type": "integer"
     },
     "con_proportional": {
@@ -3428,7 +3431,7 @@
       "default": "0",
       "desc": "When enabled, allows you to use the tilde key also in the console and when typing messages.",
       "group-id": "5",
-      "remarks": "To exit the console with con_tilde_mode 1, use Escape",
+      "remarks": "To exit the console with con_tilde_mode 1, use Escape.",
       "type": "enum",
       "values": [
         {
@@ -3482,7 +3485,7 @@
     },
     "coop": {
       "default": "0",
-      "desc": "Whether the next \"map\" command should start a coop (cooperative) game. Only works when deathmatch var is 0, otherwise coop will be forced off and a deathmatch game will start.\n\nYou need a file, spprogs.dat, in your quake/qw/ folder for coop games to work.",
+      "desc": "Whether the next \"map\" command should start a coop (cooperative) game.\nOnly works when deathmatch var is 0, otherwise coop will be forced off and a deathmatch game will start.\n\nYou need a file, spprogs.dat, in your quake/qw/ folder for coop games to work.",
       "group-id": "43",
       "type": "boolean",
       "values": [
@@ -3568,7 +3571,7 @@
       "default": "0",
       "desc": "When using built-in crosshairs, increases the resolution of the crosshair, giving a crisper image on screen.",
       "group-id": "6",
-      "remarks": "Max value 5.  Increasing this value will require lowering of /crosshairsize to give same size image on screen.",
+      "remarks": "Max value 5. Increasing this value will require lowering of /crosshairsize to give same size image on screen.",
       "type": "enum",
       "values": [
         {
@@ -3599,7 +3602,7 @@
     },
     "crosshairscalemethod": {
       "default": "0",
-      "desc": "Determines how crosshair images are scaled",
+      "desc": "Determines how crosshair images are scaled.",
       "group-id": "6",
       "remarks": "When changing this value, /crosshairscale & /crosshairsize should be adjusted accordingly.",
       "type": "boolean",
@@ -3730,9 +3733,27 @@
     },
     "deathmatch": {
       "default": "3",
-      "desc": "Chooses between basic multiplayer gameplay modes; 1 = weapons disappear after pickup (used in 4on4), 2 = weapons stay after pickup, ammo/armor does not (not used), 3 = weapons stay after pickup (used in 1on1), 4 = arena mode (players have all weapons and full health/armor)",
+      "desc": "Chooses between basic multiplayer gameplay modes.",
       "group-id": "43",
-      "type": "integer"
+      "type": "integer",
+      "values": [
+        {
+          "description": "Weapons disappear after pickup (used in 4on4)",
+          "name": "1"
+    },
+        {
+          "description": "Weapons stay after pickup, ammo/armor does not (not used)",
+          "name": "2"
+        },
+        {
+          "description": "Weapons stay after pickup (used in 1on1)",
+          "name": "3"
+        },
+        {
+          "description": "Arena mode: players have all weapons and full health/armor",
+          "name": "4"
+        }
+      ]
     },
     "default_fov": {
       "default": "90",
@@ -3743,9 +3764,9 @@
     },
     "demo_autotrack": {
       "default": "0",
-      "desc": "Enables server-side autotrack to be accepted",
+      "desc": "Enables server-side autotrack to be accepted.",
       "group-id": "7",
-      "remarks": "Server-side autotrack is recorded in MVD demos and in QTV stream allowing all the observers of the match observe the same player at the same time",
+      "remarks": "Server-side autotrack is recorded in MVD demos and in QTV stream allowing all the observers of the match observe the same player at the same time.",
       "type": "boolean",
       "values": [
         {
@@ -3760,9 +3781,9 @@
     },
     "demo_benchmarkdumps": {
       "default": "1",
-      "desc": "Allows you to automatically dump timedemo benchmark results into $log_dir/timedemo.log file. The output is in XML markup format and contains info about your operating system, hardware configuration, client version, rendering, screen resolution and the result FPS.",
+      "desc": "Allows you to automatically dump timedemo benchmark results into $log_dir/timedemo.log file.\nThe output is in XML markup format and contains info about your operating system, hardware configuration, client version, rendering, screen resolution and the result FPS.",
       "group-id": "7",
-      "remarks": "See timedemo command description for more info. Note: The result file is not a well-formed XML file.",
+      "remarks": "See timedemo command description for more info.\nNote: The result file is not a well-formed XML file.",
       "type": "boolean",
       "values": [
         {
@@ -3776,22 +3797,22 @@
       ]
     },
     "demo_browser_democolor": {
-      "desc": "Color of the demo entries in the demo browser",
+      "desc": "Color of the demo entries in the demo browser.",
       "group-id": "25",
       "type": "string"
     },
     "demo_browser_dircolor": {
-      "desc": "Color of the dir entries in the demo browser",
+      "desc": "Color of the dir entries in the demo browser.",
       "group-id": "25",
       "type": "string"
     },
     "demo_browser_interline": {
-      "desc": "Size of the space between entries in the demo browser",
+      "desc": "Size of the space between entries in the demo browser.",
       "group-id": "25",
       "type": "integer"
     },
     "demo_browser_scrollnames": {
-      "desc": "Toggle scrolling of the filenames in the demo browser",
+      "desc": "Toggle scrolling of the filenames in the demo browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -3806,12 +3827,12 @@
       ]
     },
     "demo_browser_selectedcolor": {
-      "desc": "Color of the selected entries in the demo browser",
+      "desc": "Color of the selected entries in the demo browser.",
       "group-id": "25",
       "type": "string"
     },
     "demo_browser_showdate": {
-      "desc": "Toggle the date column in the demo browser",
+      "desc": "Toggle the date column in the demo browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -3826,7 +3847,7 @@
       ]
     },
     "demo_browser_showsize": {
-      "desc": "Toggle the file size column in the demo browser",
+      "desc": "Toggle the file size column in the demo browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -3841,7 +3862,7 @@
       ]
     },
     "demo_browser_showstatus": {
-      "desc": "Toggle the display of the status bar in the demo browser",
+      "desc": "Toggle the display of the status bar in the demo browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -3856,7 +3877,7 @@
       ]
     },
     "demo_browser_showtime": {
-      "desc": "Toggle the time column in the demo browser",
+      "desc": "Toggle the time column in the demo browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -3876,7 +3897,7 @@
       "type": "string"
     },
     "demo_browser_stripnames": {
-      "desc": "Toggle stripping of the filenames in the demo browser",
+      "desc": "Toggle stripping of the filenames in the demo browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -3891,13 +3912,13 @@
       ]
     },
     "demo_browser_zipcolor": {
-      "desc": "Color of the zip entries in the demo browser",
+      "desc": "Color of the zip entries in the demo browser.",
       "group-id": "25",
       "type": "string"
     },
     "demo_capture_background_threads": {
       "default": "0",
-      "desc": "Determines how many background threads should be used writing images to disk",
+      "desc": "Determines how many background threads should be used writing images to disk.",
       "group-id": "7",
       "type": "integer"
     },
@@ -3943,7 +3964,7 @@
       "type": "float"
     },
     "demo_capture_quiet": {
-      "desc": "Stops sound being played during demo capture",
+      "desc": "Stops sound being played during demo capture.",
       "group-id": "7",
       "type": "boolean"
     },
@@ -3955,7 +3976,7 @@
     },
     "demo_capture_vid_maxlen": {
       "default": "0",
-      "desc": "If set, multiple files will be created.  This variable determines length of each file in MB",
+      "desc": "If set, multiple files will be created. This variable determines length of each file in MB.",
       "group-id": "7",
       "remarks": "The .avi format has issues with files over 2GB in size.",
       "type": "integer"
@@ -4005,14 +4026,14 @@
     },
     "demo_jump_rewind": {
       "default": "-10",
-      "desc": "Specifies the automatic rewind time before /demo_jump_mark or /demo_jump_status triggers normal playback",
+      "desc": "Specifies the automatic rewind time before /demo_jump_mark or /demo_jump_status triggers normal playback.",
       "group-id": "40",
       "remarks": "Time in seconds, must be negative.",
       "type": "float"
     },
     "demo_playlist_loop": {
       "default": "0",
-      "desc": "will toggle playlist looping",
+      "desc": "will toggle playlist looping.",
       "group-id": "40",
       "type": "boolean",
       "values": [
@@ -4028,13 +4049,13 @@
     },
     "demo_playlist_track_name": {
       "default": "",
-      "desc": "will set the default track name in the demo playlist for mvd demos \nExample: jogi, will always track the player jogi or versions of it (jogihoogi, angryjogi, etc)",
+      "desc": "will set the default track name in the demo playlist for mvd demos.\nExample: jogi, will always track the player jogi or versions of it (jogihoogi, angryjogi, etc).",
       "group-id": "40",
       "type": "string"
     },
     "developer": {
       "default": "0",
-      "desc": "Enables debug mode which prints more messages into the console than for normal user",
+      "desc": "Enables debug mode which prints more messages into the console than for normal user.",
       "group-id": "2",
       "type": "boolean",
       "values": [
@@ -4092,7 +4113,7 @@
           "name": "4"
         },
         {
-          "description": "Lt Brown",
+          "description": "Light Brown",
           "name": "5"
         },
         {
@@ -4100,7 +4121,7 @@
           "name": "6"
         },
         {
-          "description": "Lt Peach",
+          "description": "Light Peach",
           "name": "7"
         },
         {
@@ -4108,7 +4129,7 @@
           "name": "8"
         },
         {
-          "description": "Dk Purple",
+          "description": "Dark Purple",
           "name": "9"
         },
         {
@@ -4131,7 +4152,7 @@
     },
     "enemyforceskins": {
       "default": "0",
-      "desc": "Allows you to set different skin for every enemy player even if they all have same skin names set or use names of skins that you do not have in your Quake dir",
+      "desc": "Allows you to set different skin for every enemy player even if they all have same skin names set or use names of skins that you do not have in your Quake dir.",
       "group-id": "44",
       "remarks": "Read \"Player skins\" manual page for more info on skin rules.",
       "type": "enum",
@@ -4180,8 +4201,64 @@
       "type": "integer",
       "values": [
         {
-          "description": "-1 to turn this off, values from 0 to 13 for standard Quake colors",
-          "name": "*"
+          "description": "Disabled",
+          "name": "-1"
+        },
+        {
+          "description": "White",
+          "name": "0"
+        },
+        {
+          "description": "Brown",
+          "name": "1"
+        },
+        {
+          "description": "Lavender",
+          "name": "2"
+        },
+        {
+          "description": "Khaki",
+          "name": "3"
+        },
+        {
+          "description": "Red",
+          "name": "4"
+        },
+        {
+          "description": "Light Brown",
+          "name": "5"
+        },
+        {
+          "description": "Peach",
+          "name": "6"
+        },
+        {
+          "description": "Light Peach",
+          "name": "7"
+        },
+        {
+          "description": "Purple",
+          "name": "8"
+        },
+        {
+          "description": "Dark Purple",
+          "name": "9"
+        },
+        {
+          "description": "Tan",
+          "name": "10"
+        },
+        {
+          "description": "Green",
+          "name": "11"
+        },
+        {
+          "description": "Yellow",
+          "name": "12"
+        },
+        {
+          "description": "Blue",
+          "name": "13"
         }
       ]
     },
@@ -4192,7 +4269,7 @@
     },
     "file_browser_archive_color": {
       "default": "255 170 0 255",
-      "desc": "Color of archive files when ",
+      "desc": "Color of archive files in the file browser.",
       "group-id": "17",
       "type": "string"
     },
@@ -4210,13 +4287,13 @@
     },
     "file_browser_interline": {
       "default": "0",
-      "desc": "Spacing between each row in the file browser.  0-6",
+      "desc": "Spacing between each row in the file browser. 0-6.",
       "group-id": "17",
       "type": "string"
     },
     "file_browser_scrollnames": {
       "default": "1",
-      "desc": "If set, the currently selected file will scroll to let you see the full name",
+      "desc": "If set, the currently selected file will scroll to let you see the full name.",
       "group-id": "17",
       "type": "boolean"
     },
@@ -4228,25 +4305,25 @@
     },
     "file_browser_show_date": {
       "default": "1",
-      "desc": "Toggles whether the file modified date is shown in the file browser",
+      "desc": "Toggles whether the file modified date is shown in the file browser.",
       "group-id": "17",
       "type": "boolean"
     },
     "file_browser_show_size": {
       "default": "1",
-      "desc": "Toggles whether the filesize is shown in the file browser",
+      "desc": "Toggles whether the filesize is shown in the file browser.",
       "group-id": "17",
       "type": "boolean"
     },
     "file_browser_show_status": {
       "default": "1",
-      "desc": "Toggles whether a statusbar is shown in the file browser",
+      "desc": "Toggles whether a statusbar is shown in the file browser.",
       "group-id": "17",
       "type": "boolean"
     },
     "file_browser_show_time": {
       "default": "0",
-      "desc": "Toggles whether the file modified time is shown in the file browser",
+      "desc": "Toggles whether the file modified time is shown in the file browser.",
       "group-id": "17",
       "type": "boolean"
     },
@@ -4385,7 +4462,7 @@
       "default": "90",
       "desc": "This variable defines your field of vision, which determines how close your vision field is to the objects.",
       "group-id": "53",
-      "remarks": "The default value is 90, however many players prefer using a higher FOV.  Note that this would typically be scaled up when using a monitor with widescreen aspect ratio.",
+      "remarks": "The default value is 90, however many players prefer using a higher FOV.\nNote that this would typically be scaled up when using a monitor with widescreen aspect ratio.",
       "type": "float"
     },
     "frag_log_type": {
@@ -4395,9 +4472,9 @@
     },
     "fraglimit": {
       "default": "0",
-      "desc": "Amount of frags any player has to reach before the match is over",
+      "desc": "Amount of frags any player has to reach before the match is over.",
       "group-id": "43",
-      "remarks": "When set to 0, there won't be any limit",
+      "remarks": "When set to 0, there won't be any limit.",
       "type": "integer"
     },
     "freelook": {
@@ -4418,7 +4495,7 @@
     },
     "fs_cache": {
       "default": "1",
-      "desc": "Enables Quake File System caching of files lists",
+      "desc": "Enables Quake File System caching of files lists.",
       "group-id": "48",
       "type": "boolean",
       "values": [
@@ -4436,7 +4513,7 @@
       "default": "",
       "desc": "Indicates the gender of the player.",
       "group-id": "37",
-      "remarks": "This relies on server/mod support to function correctly",
+      "remarks": "This relies on server/mod support to function correctly.",
       "type": "enum",
       "values": [
         {
@@ -4506,7 +4583,7 @@
       "default": "2.0",
       "desc": "Value in range 0-25.  Offset drawing of entity models, to stop z-fighting.",
       "group-id": "35",
-      "remarks": "disabled for qcon (feature makes it possible to fix z-fighting causing flickering areas on Intel cards most often)",
+      "remarks": "disabled for qcon (feature makes it possible to fix z-fighting causing flickering areas on Intel cards most often).",
       "type": "float"
     },
     "gl_buildingsparks": {
@@ -4533,7 +4610,7 @@
     },
     "gl_charsets_min": {
       "default": "1",
-      "desc": "Speeds up start-up time by only searching for minimum number of charsets during start-up",
+      "desc": "Speeds up start-up time by only searching for minimum number of charsets during start-up.",
       "group-id": "5",
       "type": "boolean",
       "values": [
@@ -4549,7 +4626,7 @@
     },
     "gl_clear": {
       "default": "0",
-      "desc": "This variable will toggle the clearing of the screen between each frame. This\ncan be helpful when specing a game and flying out of the map or during map \ndevelopment when the map maker must fly outside of the map to look has his map\nfrom the outside. Enabling this command will clear the areas which are not \nrendered outside of the map thus preventing the flickering effect when images \nrepeat themselves repeatedly. However it causes problems when playing and \ngoing through the surfaces of a liquid (for example when diving into liquid), as\nyou will see a red flash where the liquid texture would normally be repeated.",
+      "desc": "This variable will toggle the clearing of the screen between each frame.\nThis can be helpful when specing a game and flying out of the map or during map development when the map maker must fly outside of the map to look has his map from the outside.\nEnabling this command will clear the areas which are not rendered outside of the map thus preventing the flickering effect when images repeat themselves repeatedly. However it causes problems when playing and going through the surfaces of a liquid (for example when diving into liquid), as you will see a red flash where the liquid texture would normally be repeated.",
       "group-id": "35",
       "type": "boolean",
       "values": [
@@ -4565,7 +4642,7 @@
     },
     "gl_clearColor": {
       "default": "0 0 0",
-      "desc": "Sets clear color (gl_clear 1)",
+      "desc": "Sets clear color (gl_clear 1).",
       "group-id": "35",
       "type": "string"
     },
@@ -4586,9 +4663,9 @@
     },
     "gl_colorlights": {
       "default": "1",
-      "desc": "Switch on/off color of lighting from glowing items (quad, pent, flags in TF, etc)",
+      "desc": "Switch on/off color of lighting from glowing items (quad, pent, flags in TF, etc).",
       "group-id": "15",
-      "remarks": "This implementation does not give a speed increase when gl_colorlights is set to 0, but it does not require a map restart for changes to take effect",
+      "remarks": "This implementation does not give a speed increase when gl_colorlights is set to 0, but it does not require a map restart for changes to take effect.",
       "type": "boolean",
       "values": [
         {
@@ -4615,7 +4692,7 @@
     },
     "gl_coronas": {
       "default": "0",
-      "desc": "Adds coronas to some effects:Explosions - Basically just a bright flash since the default explosions didn't feel powerful enough.\nMuzzleflashes.\nLightning.\nFire - Torches have glows.\nRocket Lights.",
+      "desc": "Adds coronas to some effects:\n\n - Explosions: Basically just a bright flash since the default explosions didn't feel powerful enough.\n - Muzzleflashes.\n - Lightning.\n - Fire: Torches have glows.\n - Rocket Lights.",
       "group-id": "15",
       "type": "float"
     },
@@ -4637,7 +4714,7 @@
     },
     "gl_cshiftpercent": {
       "default": "100",
-      "desc": "This variable sets the percentage value for palette shifting effects (damage flash, powerup blend). (needs gl_polyblend 1)",
+      "desc": "This variable sets the percentage value for palette shifting effects (damage flash, powerup blend). (needs gl_polyblend 1).",
       "group-id": "39",
       "type": "float"
     },
@@ -4764,7 +4841,7 @@
     "gl_externalTextures_bmodels": {
       "default": "1",
       "group-id": "50",
-      "remarks": "non-world .bsp models (any .bsp that isn't the actual map.  Ex. health and ammo boxes).",
+      "remarks": "non-world .bsp models (any .bsp that isn't the actual map. Ex. health and ammo boxes).",
       "type": "boolean",
       "values": [
         {
@@ -4831,7 +4908,7 @@
     },
     "gl_finish": {
       "default": "0",
-      "desc": "This variable toggles the calling of the gl_finish() OpenGL function after each \nrendered frame.",
+      "desc": "This variable toggles the calling of the gl_finish() OpenGL function after each rendered frame.",
       "group-id": "35",
       "type": "boolean",
       "values": [
@@ -4867,43 +4944,43 @@
     },
     "gl_fog": {
       "default": "0",
-      "desc": "Turns fog effect on and off (GL-Only). See /gl_fogstart /gl_fogend /gl_fogsky and /fog too.",
+      "desc": "Turns fog effect on and off (GL-Only).\nSee /gl_fogstart /gl_fogend /gl_fogsky and /fog too.",
       "group-id": "51",
       "type": "float"
     },
     "gl_fogblue": {
       "default": "0.4",
-      "desc": "Blue factor in the color of the fog",
+      "desc": "Blue factor in the color of the fog.",
       "group-id": "51",
       "type": "float"
     },
     "gl_fogend": {
       "default": "800.0",
-      "desc": "Sets ending distance for rendering the fog. When fog is turned on, you cannot see behind this distance limit. See /gl_fog and /gl_fogstart too.",
+      "desc": "Sets ending distance for rendering the fog.\nWhen fog is turned on, you cannot see behind this distance limit.\nSee /gl_fog and /gl_fogstart too.",
       "group-id": "51",
       "type": "float"
     },
     "gl_foggreen": {
       "default": "0.5",
-      "desc": "Green factor in the color of the fog",
+      "desc": "Green factor in the color of the fog.",
       "group-id": "51",
       "type": "float"
     },
     "gl_fogred": {
       "default": "0.6",
-      "desc": "Red factor in the color of the fog",
+      "desc": "Red factor in the color of the fog.",
       "group-id": "51",
       "type": "float"
     },
     "gl_fogsky": {
       "default": "1",
-      "desc": "When turned on, fog effect affects sky too. We suggest turning this on otherwise fog looks ridiculous and unrealistic.",
+      "desc": "When turned on, fog effect affects sky too.\nWe suggest turning this on otherwise fog looks ridiculous and unrealistic.",
       "group-id": "51",
       "type": "float"
     },
     "gl_fogstart": {
       "default": "50.0",
-      "desc": "Sets starting distance for rendering the fog. The greater the number is, the better visibility in game is and the fog is \"thinner\".",
+      "desc": "Sets starting distance for rendering the fog.\nThe greater the number is, the better visibility in game is and the fog is \"thinner\".",
       "group-id": "51",
       "type": "float"
     },
@@ -4964,7 +5041,7 @@
     },
     "gl_lighting_vertex": {
       "default": "0",
-      "desc": "Alias models no longer have the same level of light on all sides. This may not work correctly if colored lighting is disabled.",
+      "desc": "Alias models no longer have the same level of light on all sides.\nThis may not work correctly if colored lighting is disabled.",
       "group-id": "15",
       "type": "float"
     },
@@ -5031,7 +5108,7 @@
     },
     "gl_loadlitfiles": {
       "default": "1",
-      "desc": "Controls when external 24-bit lighting will be used.  24-bit/colored lighting is either embedded in newer .bsp files, or loaded from external .lit files.",
+      "desc": "Controls when external 24-bit lighting will be used.\n24-bit/colored lighting is either embedded in newer .bsp files, or loaded from external .lit files.",
       "group-id": "15",
       "type": "enum",
       "values": [
@@ -5074,19 +5151,19 @@
     },
     "gl_max_size": {
       "default": "32768",
-      "desc": "This variable determines the detail level for loaded textures. When set to \"1\",\nthe objects and walls will be textured with 1x1 pixel textures.",
+      "desc": "This variable determines the detail level for loaded textures.\nWhen set to \"1\", the objects and walls will be textured with 1x1 pixel textures.",
       "group-id": "50",
       "type": "float"
     },
     "gl_miptexLevel": {
       "default": "0",
-      "desc": "It is essentially a GL 'equivalent' to d_mipcap in software.  It has no affect when loading external 24bit textures.",
+      "desc": "It is essentially a GL 'equivalent' to d_mipcap in software. It has no affect when loading external 24bit textures.",
       "group-id": "50",
       "type": "float"
     },
     "gl_modulate": {
       "default": "1",
-      "desc": "Affects lightmap.  Values from 0.5 to 3 are valid.",
+      "desc": "Affects lightmap. Values from 0.5 to 3 are valid.",
       "group-id": "35",
       "type": "float"
     },
@@ -5098,31 +5175,31 @@
     },
     "gl_motion_blur_dead": {
       "default": "0.5",
-      "desc": "Level of blending of current scene with previous, when the player is dead",
+      "desc": "Level of blending of current scene with previous, when the player is dead.",
       "group-id": "8",
       "type": "float"
     },
     "gl_motion_blur_fps": {
       "default": "77",
-      "desc": "How often to copy the current frame to apply motion blur effect.  Defaults to 77.",
+      "desc": "How often to copy the current frame to apply motion blur effect. Defaults to 77.",
       "group-id": "8",
       "type": "integer"
     },
     "gl_motion_blur_hurt": {
       "default": "0.5",
-      "desc": "Level of blending of current scene with previous, when the player has recently been hurt",
+      "desc": "Level of blending of current scene with previous, when the player has recently been hurt.",
       "group-id": "8",
       "type": "float"
     },
     "gl_motion_blur_norm": {
       "default": "0.5",
-      "desc": "Level of blending of current scene with previous, when the player is alive and not recently hurt",
+      "desc": "Level of blending of current scene with previous, when the player is alive and not recently hurt.",
       "group-id": "8",
       "type": "float"
     },
     "gl_multisamples": {
       "default": "0",
-      "desc": "The number of samples used around each pixel for anti-aliasing.  Range 0-16",
+      "desc": "The number of samples used around each pixel for anti-aliasing. Range 0-16.",
       "group-id": "52",
       "type": "integer"
     },
@@ -5217,7 +5294,7 @@
       "default": "0",
       "desc": "Controls outlining of models and map.",
       "group-id": "35",
-      "remarks": "Outlining of the world is only valid when cheats are enabled",
+      "remarks": "Outlining of the world is only valid when cheats are enabled.",
       "type": "enum",
       "values": [
         {
@@ -5409,7 +5486,7 @@
       "default": "0 124 0",
       "desc": "Changes the color of the tracer1 trail, which allows you to customize the rockettrail color (see remarks).",
       "group-id": "36",
-      "remarks": "If you set r_rockettrail 6 and gl_part_trails 1, this variable will change your rockettrail color",
+      "remarks": "If you set r_rockettrail 6 and gl_part_trails 1, this variable will change your rockettrail color.",
       "type": "string",
       "values": [
         {
@@ -5422,21 +5499,21 @@
       "default": "3.75",
       "desc": "Changes the size of the tracer1 trail, which allows you to customize the rockettrail size (see remarks).",
       "group-id": "36",
-      "remarks": "If you set r_rockettrail 6 and gl_part_trails 1, this variable will change your rockettrail size",
+      "remarks": "If you set r_rockettrail 6 and gl_part_trails 1, this variable will change your rockettrail size.",
       "type": "float"
     },
     "gl_part_tracer1_time": {
       "default": "0.5",
       "desc": "Changes the duration of the tracer1 trail, which allows you to customize the rockettrail (see remarks).",
       "group-id": "36",
-      "remarks": "If you set r_rockettrail 6 and gl_part_trails 1, this variable will change your rockettrail duration",
+      "remarks": "If you set r_rockettrail 6 and gl_part_trails 1, this variable will change your rockettrail duration.",
       "type": "float"
     },
     "gl_part_tracer2_color": {
       "default": "255 77 0",
       "desc": "Changes the color of the tracer2 trail, which allows you to customize the rockettrail color (see remarks).",
       "group-id": "36",
-      "remarks": "If you set r_rockettrail 7 and gl_part_trails 1, this variable will change your rockettrail color",
+      "remarks": "If you set r_rockettrail 7 and gl_part_trails 1, this variable will change your rockettrail color.",
       "type": "string",
       "values": [
         {
@@ -5449,14 +5526,14 @@
       "default": "3.75",
       "desc": "Changes the size of the tracer2 trail, which allows you to customize the rockettrail size (see remarks).",
       "group-id": "36",
-      "remarks": "If you set r_rockettrail 7 and gl_part_trails 1, this variable will change your rockettrail size",
+      "remarks": "If you set r_rockettrail 7 and gl_part_trails 1, this variable will change your rockettrail size.",
       "type": "float"
     },
     "gl_part_tracer2_time": {
       "default": "0.5",
       "desc": "Changes the duration of the tracer2 trail, which allows you to customize the rockettrail (see remarks).",
       "group-id": "36",
-      "remarks": "If you set r_rockettrail 7 and gl_part_trails 1, this variable will change your rockettrail duration",
+      "remarks": "If you set r_rockettrail 7 and gl_part_trails 1, this variable will change your rockettrail duration.",
       "type": "float"
     },
     "gl_part_trails": {
@@ -5476,13 +5553,13 @@
     },
     "gl_particle_blobs": {
       "default": "0",
-      "desc": "Determines size of blob explosions.  If set to 0, standard non-particle explosions will be used instead.",
+      "desc": "Determines size of blob explosions.\nIf set to 0, standard non-particle explosions will be used instead.",
       "group-id": "36",
       "type": "float"
     },
     "gl_particle_blood": {
       "default": "0",
-      "desc": "Determines size of blood effect.  If set to 0, standard blood effect will be used instead.",
+      "desc": "Determines size of blood effect.\nIf set to 0, standard blood effect will be used instead.",
       "group-id": "36",
       "type": "float"
     },
@@ -5500,7 +5577,7 @@
     },
     "gl_particle_deatheffect": {
       "default": "0",
-      "desc": "Adds extra blood effects to gibs",
+      "desc": "Adds extra blood effects to gibs.",
       "group-id": "36",
       "type": "enum",
       "values": [
@@ -5526,25 +5603,25 @@
     },
     "gl_particle_fasttrails": {
       "default": "0",
-      "desc": "Changes particle trails indicating motion",
+      "desc": "Changes particle trails indicating motion.",
       "group-id": "36",
       "type": "float"
     },
     "gl_particle_fire": {
       "default": "0",
-      "desc": "Replaces torches with a particle flame effect. Includes people being burnt by the pyro in TF.",
+      "desc": "Replaces torches with a particle flame effect.\nIncludes people being burnt by the pyro in TF.",
       "group-id": "36",
       "type": "float"
     },
     "gl_particle_firecolor": {
       "default": "",
-      "desc": "Color of the fire particle",
+      "desc": "Color of the fire particle.",
       "group-id": "36",
       "type": "string"
     },
     "gl_particle_fulldetail": {
       "default": "0",
-      "desc": "Allows full detail depth for gl_particle_* effects",
+      "desc": "Allows full detail depth for gl_particle_* effects.",
       "group-id": "36",
       "type": "boolean"
     },
@@ -5571,9 +5648,19 @@
     },
     "gl_particle_shockwaves": {
       "default": "0",
-      "desc": "0 - Turns off explosion shockwaves.\n1 - Turns on explosion shockwaves.",
+      "desc": "Controls explosion shockwaves.",
       "group-id": "36",
-      "type": "float"
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Disabled",
+          "name": "false"
+    },
+        {
+          "description": "Enabled",
+          "name": "true"
+        }
+      ]
     },
     "gl_particle_shockwaves_flat": {
       "default": "0",
@@ -5641,7 +5728,7 @@
     },
     "gl_picmip": {
       "default": "0",
-      "desc": "This variable determines the the level of detail for textures used on walls. You\ncan use this variable to lower the texture detail used on walls thus increasing\nthe game's performance.",
+      "desc": "This variable determines the the level of detail for textures used on walls.\nYou can use this variable to lower the texture detail used on walls thus increasing the game's performance.",
       "group-id": "50",
       "remarks": "X = etc..",
       "type": "float",
@@ -5662,7 +5749,7 @@
     },
     "gl_playermip": {
       "default": "0",
-      "desc": "Determines the level of detail of player models. This variable is useful if you are \nexperience game slowdown during multiplayer games when there are lots of players on \nyour screen by shrinking the texture detail, but this will make the player models more blurry.",
+      "desc": "Determines the level of detail of player models.\nThis variable is useful if you are experiencing slowdowns during multiplayer games when there are lots of players on your screen by shrinking the texture detail, but this will make the player models more blurry.",
       "group-id": "50",
       "remarks": "X = etc.",
       "type": "enum",
@@ -5699,7 +5786,7 @@
     },
     "gl_powerupshells": {
       "default": "1",
-      "desc": "Enables a flashing layer over players carrying powerups",
+      "desc": "Enables a flashing layer over players carrying powerups.",
       "group-id": "8",
       "type": "boolean",
       "values": [
@@ -5735,7 +5822,7 @@
     },
     "gl_powerupshells_size": {
       "default": "5",
-      "desc": "Size of the powerupshells effect layer",
+      "desc": "Size of the powerupshells effect layer.",
       "group-id": "8",
       "type": "integer"
     },
@@ -5743,7 +5830,7 @@
       "default": "1",
       "desc": "Determines if GLSL will be used to render skybox/skydome surfaces.\nr_fastsky does not use this setting.",
       "group-id": "35",
-      "remarks": "Applies to classic OpenGL renderer only",
+      "remarks": "Applies to classic OpenGL renderer only.",
       "renderers": [
         "classic"
       ],
@@ -5753,7 +5840,7 @@
       "default": "1",
       "desc": "Determines if GLSL will be used to render skybox/skydome surfaces.\nr_fastturb does not use this setting.",
       "group-id": "35",
-      "remarks": "Applies to classic OpenGL renderer only",
+      "remarks": "Applies to classic OpenGL renderer only.",
       "renderers": [
         "classic"
       ],
@@ -5761,9 +5848,27 @@
     },
     "gl_rl_globe": {
       "default": "0",
-      "desc": "Helps customize rocket light independant of gl_flashblend.\n0 - treated as feature off.\n1 - rocket light looks like with gl_flashblend 2, but no dynamic lighting.\n2 - rocket light looks like with gl_flashblend 0 or 1.\n3 - rocket light looks like with gl_flashblend 2, with dynamic lighting, exactly the same.",
+      "desc": "Helps customize rocket light independant of gl_flashblend.",
       "group-id": "15",
-      "type": "integer"
+      "type": "integer",
+      "values": [
+        {
+          "description": "Rocket light controlled by gl_flashblend",
+          "name": "0"
+    },
+        {
+          "description": "Rocket light looks like with gl_flashblend 2, but no dynamic lighting",
+          "name": "1"
+        },
+        {
+          "description": "Rocket light looks like with gl_flashblend 0 or 1",
+          "name": "2"
+        },
+        {
+          "description": "Rocket light looks like with gl_flashblend 2, with dynamic lighting",
+          "name": "2"
+        }
+      ]
     },
     "gl_scaleModelSimpleTextures": {
       "default": "0",
@@ -5881,7 +5986,7 @@
     },
     "gl_simpleitems_size": {
       "default": "16",
-      "desc": "Size of simple items.  Max size 16.",
+      "desc": "Size of simple items. Max size 16.",
       "group-id": "8",
       "type": "integer"
     },
@@ -5902,13 +6007,13 @@
     },
     "gl_squareparticles": {
       "default": "0",
-      "desc": "Toggles between circle and square particles",
+      "desc": "Toggles between circle and square particles.",
       "group-id": "36",
       "type": "boolean"
     },
     "gl_subdivide_size": {
       "default": "64",
-      "desc": "This variable sets the division value for the sky brushes. The higher the value \nthe better the performance, but the smoothness of the sky suffers.",
+      "desc": "This variable sets the division value for the sky brushes.\n The higher the value the better the performance, but the smoothness of the sky suffers.",
       "group-id": "50",
       "type": "float"
     },
@@ -5988,7 +6093,7 @@
     "gl_texturemode": {
       "default": "GL_LINEAR_MIPMAP_LINEAR",
       "group-id": "50",
-      "remarks": "GL_NEAREST* modes are often used with gl_miptexlevel 3",
+      "remarks": "GL_NEAREST* modes are often used with gl_miptexlevel 3.",
       "type": "enum",
       "values": [
         {
@@ -6020,7 +6125,7 @@
     "gl_texturemode_viewmodels": {
       "default": "GL_LINEAR",
       "group-id": "50",
-      "remarks": "GL_NEAREST* modes are often used with gl_miptexlevel 3",
+      "remarks": "GL_NEAREST* modes are often used with gl_miptexlevel 3.",
       "type": "enum",
       "values": [
         {
@@ -6074,7 +6179,7 @@
     },
     "gl_turbalpha": {
       "default": "1",
-      "desc": "This variable determines the level of opacity for liquids, which requires the use of maps that were VISed with transparent water. When using maps that have not been VISed in such a way, you have to use \"r_novis 1\". If \"r_novis\" is set to \"1\" or when using a map VISed with transparent water and using setting \"gl_turbalpha\" to a value lower than \"1\", the player will be able to see objects and walls through liquids if the server allows that. This is a very nice feature to have in the game, for more information refer to the \"r_novis\" command. You can use any value between \"0\" and \"1\" for \"gl_turbalpha\", here are some examples:",
+      "desc": "This variable determines the level of opacity for liquids, which requires the use of maps that were VISed with transparent water.\nWhen using maps that have not been VISed in such a way, you have to use \"r_novis 1\".\nIf \"r_novis\" is set to \"1\" or when using a map VISed with transparent water and using setting \"gl_turbalpha\" to a value lower than \"1\", the player will be able to see objects and walls through liquids if the server allows that.\nThis is a very nice feature to have in the game, for more information refer to the \"r_novis\" command.\n\nYou can use any value between \"0\" and \"1\" for \"gl_turbalpha\", here are some examples:",
       "group-id": "51",
       "type": "float",
       "values": [
@@ -6123,7 +6228,7 @@
     },
     "gl_turbfogDensity": {
       "default": "1",
-      "desc": "Control of density of liquid (water, lava, slime...) fog",
+      "desc": "Control of density of liquid (water, lava, slime...) fog.",
       "group-id": "51",
       "type": "float",
       "values": [
@@ -6178,15 +6283,30 @@
     },
     "gl_weather_rain": {
       "default": "0",
-      "desc": "Turns on rain out of doors, the density of rain is equal to whatever gl_weather_rain is set to.\nIf you set gl_weather_rain_fast to 1, you can turn off all splashes, if you set it to 2, you will turn off only the water splashes.\nWorks on all non-iD maps except death32c, dakyne and some others.",
+      "desc": "Turns on rain outdoors.\nRain density is equal to whatever gl_weather_rain is set to.",
       "group-id": "51",
-      "type": "float"
+      "type": "float",
+      "remarks": "Works on all custom maps except death32c, dakyne and some others."
     },
     "gl_weather_rain_fast": {
       "default": "0",
-      "desc": "Adjusts speed of rain.",
+      "desc": "Adjusts rain effects performance.",
       "group-id": "51",
-      "type": "float"
+      "type": "float",
+      "values": [
+        {
+          "description": "Default",
+          "name": "0"
+    },
+        {
+          "description": "Turn off all splashes",
+          "name": "1"
+        },
+        {
+          "description": "Turn off only water splashes",
+          "name": "2"
+        }
+      ]
     },
     "halflifebsp": {
       "default": "0",
@@ -6288,22 +6408,22 @@
       "type": "string"
     },
     "hud_ammo1_align_x": {
-      "desc": "Sets horizontal align of number of shells",
+      "desc": "Sets horizontal align of number of shells.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo1_align_y": {
-      "desc": "Sets vertical align of number of shells",
+      "desc": "Sets vertical align of number of shells.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo1_digits": {
-      "desc": "Sets number of digits for number of shells",
+      "desc": "Sets number of digits for number of shells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo1_frame": {
-      "desc": "Sets frame visibility and style for number of shells",
+      "desc": "Sets frame visibility and style for number of shells.",
       "group-id": "19",
       "type": "float"
     },
@@ -6317,62 +6437,62 @@
       "type": "float"
     },
     "hud_ammo1_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_ammo1_place": {
-      "desc": "Sets relative positioning for number of shells",
+      "desc": "Sets relative positioning for number of shells.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo1_pos_x": {
-      "desc": "Sets horizontal position of number of shells",
+      "desc": "Sets horizontal position of number of shells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo1_pos_y": {
-      "desc": "Sets vertical position of number of shells",
+      "desc": "Sets vertical position of number of shells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo1_scale": {
-      "desc": "Sets size of number of shells",
+      "desc": "Sets size of number of shells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo1_show": {
-      "desc": "Switches showing of number of shells",
+      "desc": "Switches showing of number of shells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo1_style": {
-      "desc": "Switches graphical style of number of shells",
+      "desc": "Switches graphical style of number of shells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo2_align": {
-      "desc": "Sets align of number of nails",
+      "desc": "Sets align of number of nails.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo2_align_x": {
-      "desc": "Sets horizontal align of number of nails",
+      "desc": "Sets horizontal align of number of nails.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo2_align_y": {
-      "desc": "Sets vertical align of number of nails",
+      "desc": "Sets vertical align of number of nails.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo2_digits": {
-      "desc": "Sets number of digits for number of nails",
+      "desc": "Sets number of digits for number of nails.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo2_frame": {
-      "desc": "Sets frame visibility and style for number of nails",
+      "desc": "Sets frame visibility and style for number of nails.",
       "group-id": "19",
       "type": "float"
     },
@@ -6386,62 +6506,62 @@
       "type": "float"
     },
     "hud_ammo2_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_ammo2_place": {
-      "desc": "Sets relative positioning for number of nails",
+      "desc": "Sets relative positioning for number of nails.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo2_pos_x": {
-      "desc": "Sets horizontal position of number of nails",
+      "desc": "Sets horizontal position of number of nails.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo2_pos_y": {
-      "desc": "Sets vertical position of number of nails",
+      "desc": "Sets vertical position of number of nails.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo2_scale": {
-      "desc": "Sets size of number of nails",
+      "desc": "Sets size of number of nails.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo2_show": {
-      "desc": "Switches showing of number of nails",
+      "desc": "Switches showing of number of nails.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo2_style": {
-      "desc": "Switches graphical style of number of nails",
+      "desc": "Switches graphical style of number of nails.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo3_align": {
-      "desc": "Sets align of number of rockets",
+      "desc": "Sets align of number of rockets.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo3_align_x": {
-      "desc": "Sets horizontal align of number of rockets",
+      "desc": "Sets horizontal align of number of rockets.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo3_align_y": {
-      "desc": "Sets vertical align of number of rockets",
+      "desc": "Sets vertical align of number of rockets.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo3_digits": {
-      "desc": "Sets number of digits for",
+      "desc": "Sets number of digits for number of rockets.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo3_frame": {
-      "desc": "Sets frame visibility and style for",
+      "desc": "Sets frame visibility and style for number of rockets.",
       "group-id": "19",
       "type": "float"
     },
@@ -6455,62 +6575,62 @@
       "type": "float"
     },
     "hud_ammo3_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_ammo3_place": {
-      "desc": "Sets relative positioning for",
+      "desc": "Sets relative positioning for number of rockets.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo3_pos_x": {
-      "desc": "Sets horizontal position of number of rockets",
+      "desc": "Sets horizontal position of number of rockets.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo3_pos_y": {
-      "desc": "Sets vertical position of number of rockets",
+      "desc": "Sets vertical position of number of rockets.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo3_scale": {
-      "desc": "Sets size of number of rockets",
+      "desc": "Sets size of number of rockets.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo3_show": {
-      "desc": "Switches showing of number of rockets",
+      "desc": "Switches showing of number of rockets.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo3_style": {
-      "desc": "Switches graphical style of number of rockets",
+      "desc": "Switches graphical style of number of rockets.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo4_align": {
-      "desc": "Sets align of number of cells",
+      "desc": "Sets align of number of cells.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo4_align_x": {
-      "desc": "Sets horizontal align of number of cells",
+      "desc": "Sets horizontal align of number of cells.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo4_align_y": {
-      "desc": "Sets vertical align of number of cells",
+      "desc": "Sets vertical align of number of cells.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo4_digits": {
-      "desc": "Sets number of digits for number of cells",
+      "desc": "Sets number of digits for number of cells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo4_frame": {
-      "desc": "Sets frame visibility and style for number of cells",
+      "desc": "Sets frame visibility and style for number of cells.",
       "group-id": "19",
       "type": "float"
     },
@@ -6524,62 +6644,62 @@
       "type": "float"
     },
     "hud_ammo4_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_ammo4_place": {
-      "desc": "Sets relative positioning for number of cells",
+      "desc": "Sets relative positioning for number of cells.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo4_pos_x": {
-      "desc": "Sets horizontal position of number of cells",
+      "desc": "Sets horizontal position of number of cells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo4_pos_y": {
-      "desc": "Sets vertical position of number of cells",
+      "desc": "Sets vertical position of number of cells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo4_scale": {
-      "desc": "Sets size of number of cells",
+      "desc": "Sets size of number of cells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo4_show": {
-      "desc": "Switches showing of number of cells",
+      "desc": "Switches showing of number of cells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo4_style": {
-      "desc": "Switches graphical style of number of cells",
+      "desc": "Switches graphical style of number of cells.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo_align": {
-      "desc": "Sets align of current ammo value",
+      "desc": "Sets align of current ammo value.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo_align_x": {
-      "desc": "Sets horizontal align of current ammo value",
+      "desc": "Sets horizontal align of current ammo value.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo_align_y": {
-      "desc": "Sets vertical align of current ammo value",
+      "desc": "Sets vertical align of current ammo value.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo_digits": {
-      "desc": "Sets number of digits for current ammo value",
+      "desc": "Sets number of digits for current ammo value.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo_frame": {
-      "desc": "Sets frame visibility and style for current ammo value",
+      "desc": "Sets frame visibility and style for current ammo value.",
       "group-id": "19",
       "type": "float"
     },
@@ -6593,62 +6713,62 @@
       "type": "float"
     },
     "hud_ammo_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_ammo_place": {
-      "desc": "Sets relative positioning for current ammo value",
+      "desc": "Sets relative positioning for current ammo value.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ammo_pos_x": {
-      "desc": "Sets horizontal position of current ammo value",
+      "desc": "Sets horizontal position of current ammo value.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo_pos_y": {
-      "desc": "Sets vertical position of current ammo value",
+      "desc": "Sets vertical position of current ammo value.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo_scale": {
-      "desc": "Sets size of current ammo value",
+      "desc": "Sets size of current ammo value.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo_show": {
-      "desc": "Switches showing of current ammo value",
+      "desc": "Switches showing of current ammo value.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ammo_style": {
-      "desc": "Switches graphical style of current ammo value",
+      "desc": "Switches graphical style of current ammo value.",
       "group-id": "19",
       "type": "float"
     },
     "hud_armor_align": {
-      "desc": "Sets align of armor level",
+      "desc": "Sets align of armor level.",
       "group-id": "19",
       "type": "string"
     },
     "hud_armor_align_x": {
-      "desc": "Sets horizontal align of armor level",
+      "desc": "Sets horizontal align of armor level.",
       "group-id": "19",
       "type": "string"
     },
     "hud_armor_align_y": {
-      "desc": "Sets vertical align of armor level",
+      "desc": "Sets vertical align of armor level.",
       "group-id": "19",
       "type": "string"
     },
     "hud_armor_digits": {
-      "desc": "Sets number of digits for armor level",
+      "desc": "Sets number of digits for armor level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_armor_frame": {
-      "desc": "Sets frame visibility and style for armor level",
+      "desc": "Sets frame visibility and style for armor level.",
       "group-id": "19",
       "type": "float"
     },
@@ -6662,7 +6782,7 @@
       "type": "float"
     },
     "hud_armor_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -6671,32 +6791,32 @@
       "type": ""
     },
     "hud_armor_place": {
-      "desc": "Sets relative positioning for armor level",
+      "desc": "Sets relative positioning for armor level.",
       "group-id": "19",
       "type": "string"
     },
     "hud_armor_pos_x": {
-      "desc": "Sets horizontal position of armor level",
+      "desc": "Sets horizontal position of armor level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_armor_pos_y": {
-      "desc": "Sets vertical position of armor level",
+      "desc": "Sets vertical position of armor level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_armor_scale": {
-      "desc": "Sets size of armor level",
+      "desc": "Sets size of armor level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_armor_show": {
-      "desc": "Switches showing of armor level",
+      "desc": "Switches showing of armor level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_armor_style": {
-      "desc": "Switches graphical style of armor level",
+      "desc": "Switches graphical style of armor level.",
       "group-id": "19",
       "type": "float"
     },
@@ -6707,7 +6827,7 @@
       "type": "string",
       "values": [
         {
-          "description": "horizontal: left, center, right, before, after; vertical: top, center, bottom, console, before, after",
+          "description": "horizontal: left, center, right, before, after\nvertical: top, center, bottom, console, before, after",
           "name": "*"
         }
       ]
@@ -6773,7 +6893,7 @@
       "type": "float"
     },
     "hud_armordamage_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -6871,8 +6991,25 @@
     "hud_bar_armor_direction": {
       "desc": "Direction of colored part inside HUD element that designates amount of armor.",
       "group-id": "19",
-      "remarks": "0 - left->right\n1 - right->left\n2 - down -> up\n3 - up -> down",
-      "type": "integer"
+      "type": "integer",
+      "values": [
+        {
+          "description": "left->right",
+          "name": "0"
+        },
+        {
+          "description": "right->left",
+          "name": "1"
+        },
+        {
+          "description": "down -> up",
+          "name": "2"
+        },
+        {
+          "description": "up -> down",
+          "name": "3"
+        }
+      ]
     },
     "hud_bar_armor_frame": {
       "group-id": "19",
@@ -6945,8 +7082,25 @@
     "hud_bar_health_direction": {
       "desc": "Direction of colored part inside HUD element that designates amount of health.",
       "group-id": "19",
-      "remarks": "0 - left->right\n1 - right->left\n2 - down -> up\n3 - up -> down",
-      "type": "integer"
+      "type": "integer",
+      "values": [
+        {
+          "description": "left->right",
+          "name": "0"
+        },
+        {
+          "description": "right->left",
+          "name": "1"
+        },
+        {
+          "description": "down -> up",
+          "name": "2"
+        },
+        {
+          "description": "up -> down",
+          "name": "3"
+        }
+      ]
     },
     "hud_bar_health_frame": {
       "group-id": "19",
@@ -6989,27 +7143,27 @@
       "type": ""
     },
     "hud_clock_align_x": {
-      "desc": "Sets horizontal align of clock",
+      "desc": "Sets horizontal align of clock.",
       "group-id": "19",
       "type": "string"
     },
     "hud_clock_align_y": {
-      "desc": "Sets vertical align of clock",
+      "desc": "Sets vertical align of clock.",
       "group-id": "19",
       "type": "string"
     },
     "hud_clock_big": {
-      "desc": "Switches unsing larger version of clock",
+      "desc": "Switches unsing larger version of clock.",
       "group-id": "19",
       "type": "float"
     },
     "hud_clock_blink": {
-      "desc": "Switches blinking colon of clock",
+      "desc": "Switches blinking colon of clock.",
       "group-id": "19",
       "type": "float"
     },
     "hud_clock_content": {
-      "desc": "Controls what time to display",
+      "desc": "Controls what time to display.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -7028,7 +7182,7 @@
       ]
     },
     "hud_clock_format": {
-      "desc": "Controls in what format the clock is displayed",
+      "desc": "Controls in what format the clock is displayed.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -7051,7 +7205,7 @@
       ]
     },
     "hud_clock_frame": {
-      "desc": "Sets frame visibility and style for clock",
+      "desc": "Sets frame visibility and style for clock.",
       "group-id": "19",
       "type": "float"
     },
@@ -7065,37 +7219,37 @@
       "type": "float"
     },
     "hud_clock_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_clock_place": {
-      "desc": "Sets relative positioning for clock",
+      "desc": "Sets relative positioning for clock.",
       "group-id": "19",
       "type": "string"
     },
     "hud_clock_pos_x": {
-      "desc": "Sets horizontal position of clock",
+      "desc": "Sets horizontal position of clock.",
       "group-id": "19",
       "type": "float"
     },
     "hud_clock_pos_y": {
-      "desc": "Sets vertical position of clock",
+      "desc": "Sets vertical position of clock.",
       "group-id": "19",
       "type": "float"
     },
     "hud_clock_scale": {
-      "desc": "Size of the clock HUD element",
+      "desc": "Size of the clock HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_clock_show": {
-      "desc": "Switches showing of clock",
+      "desc": "Switches showing of clock.",
       "group-id": "19",
       "type": "float"
     },
     "hud_clock_style": {
-      "desc": "Switches graphical style of clock",
+      "desc": "Switches graphical style of clock.",
       "group-id": "19",
       "type": "float"
     },
@@ -7125,7 +7279,7 @@
       ]
     },
     "hud_democlock_blink": {
-      "desc": "Enables democlock colon blinking",
+      "desc": "Enables democlock colon blinking.",
       "group-id": "19",
       "type": "boolean",
       "values": [
@@ -7140,7 +7294,7 @@
       ]
     },
     "hud_democlock_frame": {
-      "desc": "Opacity of the background of the democlock HUD element",
+      "desc": "Opacity of the background of the democlock HUD element.",
       "group-id": "19",
       "type": "float"
     },
@@ -7154,32 +7308,32 @@
       "type": "float"
     },
     "hud_democlock_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_democlock_place": {
-      "desc": "Placement of the democlock HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
+      "desc": "Placement of the democlock HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
     },
     "hud_democlock_pos_x": {
-      "desc": "Horizontal relative position of the democlock HUD element",
+      "desc": "Horizontal relative position of the democlock HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_democlock_pos_y": {
-      "desc": "Vertical relative position of the democlock HUD element",
+      "desc": "Vertical relative position of the democlock HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_democlock_scale": {
-      "desc": "Size of the democlock HUD element",
+      "desc": "Size of the democlock HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_democlock_show": {
-      "desc": "Visibility of the democlock HUD element",
+      "desc": "Visibility of the democlock HUD element.",
       "group-id": "19",
       "type": "boolean",
       "values": [
@@ -7194,12 +7348,12 @@
       ]
     },
     "hud_democlock_style": {
-      "desc": "Toggles democlock render styles",
+      "desc": "Toggles democlock render styles.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_digits_trim": {
-      "desc": "Changes how large numbers are treated in Head Up Display",
+      "desc": "Changes how large numbers are treated in Head Up Display.",
       "group-id": "19",
       "remarks": "Applies to all HUD elements with 'digits' property.",
       "type": "enum",
@@ -7267,7 +7421,7 @@
       ]
     },
     "hud_editor_allowresize": {
-      "desc": "Allow resizing HUD elements in HUD editor mode",
+      "desc": "Allow resizing HUD elements in HUD editor mode.",
       "group-id": "19",
       "remarks": "This can also be toggled when in the HUD editor by using the F2 button.",
       "type": "boolean",
@@ -7283,17 +7437,17 @@
       ]
     },
     "hud_face_align_x": {
-      "desc": "Sets horizontal align of player face",
+      "desc": "Sets horizontal align of player face.",
       "group-id": "19",
       "type": "string"
     },
     "hud_face_align_y": {
-      "desc": "Sets vertical align of player face",
+      "desc": "Sets vertical align of player face.",
       "group-id": "19",
       "type": "string"
     },
     "hud_face_frame": {
-      "desc": "Sets frame visibility and style for player face",
+      "desc": "Sets frame visibility and style for player face.",
       "group-id": "19",
       "type": "float"
     },
@@ -7307,49 +7461,49 @@
       "type": "float"
     },
     "hud_face_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_face_place": {
-      "desc": "Sets relative positioning for player face",
+      "desc": "Sets relative positioning for player face.",
       "group-id": "19",
       "type": "string"
     },
     "hud_face_pos_x": {
-      "desc": "Sets horizontal position of player face",
+      "desc": "Sets horizontal position of player face.",
       "group-id": "19",
       "type": "float"
     },
     "hud_face_pos_y": {
-      "desc": "Sets vertical position of player face",
+      "desc": "Sets vertical position of player face.",
       "group-id": "19",
       "type": "float"
     },
     "hud_face_scale": {
-      "desc": "Sets size of player face",
+      "desc": "Sets size of player face.",
       "group-id": "19",
       "type": "float"
     },
     "hud_face_show": {
-      "desc": "Switches showing of player face",
+      "desc": "Switches showing of player face.",
       "group-id": "19",
       "type": "float"
     },
     "hud_fps_align_x": {
-      "desc": "Sets horizontal align of fps counter",
+      "desc": "Sets horizontal align of fps counter.",
       "group-id": "19",
       "type": "string"
     },
     "hud_fps_align_y": {
-      "desc": "Sets vertical align of fps counter",
+      "desc": "Sets vertical align of fps counter.",
       "group-id": "19",
       "type": "string"
     },
     "hud_fps_decimals": {
-      "desc": "How many decimal number should the FPS HUD element contain",
+      "desc": "How many decimal number should the FPS HUD element contain.",
       "group-id": "29",
-      "remarks": "Code says always three decimals",
+      "remarks": "Code says always three decimals.",
       "type": "integer"
     },
     "hud_fps_drop": {
@@ -7358,7 +7512,7 @@
       "type": "float"
     },
     "hud_fps_frame": {
-      "desc": "Sets frame visibility and style for fps counter",
+      "desc": "Sets frame visibility and style for fps counter.",
       "group-id": "19",
       "type": "float"
     },
@@ -7376,32 +7530,32 @@
       "type": ""
     },
     "hud_fps_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_fps_place": {
-      "desc": "Sets relative positioning for fps counter",
+      "desc": "Sets relative positioning for fps counter.",
       "group-id": "19",
       "type": "string"
     },
     "hud_fps_pos_x": {
-      "desc": "Sets horizontal position of fps counter",
+      "desc": "Sets horizontal position of fps counter.",
       "group-id": "19",
       "type": "float"
     },
     "hud_fps_pos_y": {
-      "desc": "Sets vertical position of fps counter",
+      "desc": "Sets vertical position of fps counter.",
       "group-id": "19",
       "type": "float"
     },
     "hud_fps_show": {
-      "desc": "Switches showing of fps counter",
+      "desc": "Switches showing of fps counter.",
       "group-id": "19",
       "type": "float"
     },
     "hud_fps_show_min": {
-      "desc": "Switches showing of fps counter",
+      "desc": "Switches showing of fps counter.",
       "group-id": "19",
       "type": "float"
     },
@@ -7429,17 +7583,17 @@
       ]
     },
     "hud_fps_title": {
-      "desc": "Switches displaying the text \"fps\" of fps counter",
+      "desc": "Switches displaying the text \"fps\" of fps counter.",
       "group-id": "19",
       "type": "float"
     },
     "hud_frags_align_x": {
-      "desc": "Sets horizontal align of frags bar",
+      "desc": "Sets horizontal align of frags bar.",
       "group-id": "19",
       "type": "string"
     },
     "hud_frags_align_y": {
-      "desc": "Sets vertical align of frags bar",
+      "desc": "Sets vertical align of frags bar.",
       "group-id": "19",
       "type": "string"
     },
@@ -7455,12 +7609,12 @@
       ]
     },
     "hud_frags_cell_height": {
-      "desc": "Sets cell height of frags bar",
+      "desc": "Sets cell height of frags bar.",
       "group-id": "19",
       "type": "float"
     },
     "hud_frags_cell_width": {
-      "desc": "Sets cell width of frags bar",
+      "desc": "Sets cell width of frags bar.",
       "group-id": "19",
       "type": "float"
     },
@@ -7470,7 +7624,7 @@
       "type": "float"
     },
     "hud_frags_cols": {
-      "desc": "Sets number of columns of frags bar",
+      "desc": "Sets number of columns of frags bar.",
       "group-id": "19",
       "type": "float"
     },
@@ -7542,7 +7696,7 @@
       ]
     },
     "hud_frags_frame": {
-      "desc": "Sets frame visibility and style for frags bar",
+      "desc": "Sets frame visibility and style for frags bar.",
       "group-id": "19",
       "type": "float"
     },
@@ -7565,7 +7719,7 @@
       "type": ""
     },
     "hud_frags_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -7586,27 +7740,27 @@
       ]
     },
     "hud_frags_place": {
-      "desc": "Sets relative positioning for frags bar",
+      "desc": "Sets relative positioning for frags bar.",
       "group-id": "19",
       "type": "string"
     },
     "hud_frags_pos_x": {
-      "desc": "Sets horizontal position of frags bar",
+      "desc": "Sets horizontal position of frags bar.",
       "group-id": "19",
       "type": "float"
     },
     "hud_frags_pos_y": {
-      "desc": "Sets vertical position of frags bar",
+      "desc": "Sets vertical position of frags bar.",
       "group-id": "19",
       "type": "float"
     },
     "hud_frags_rows": {
-      "desc": "Sets number of rows in frags bar",
+      "desc": "Sets number of rows in frags bar.",
       "group-id": "19",
       "type": "float"
     },
     "hud_frags_show": {
-      "desc": "Switches showing of frags bar",
+      "desc": "Switches showing of frags bar.",
       "group-id": "19",
       "type": "float"
     },
@@ -7656,17 +7810,17 @@
       ]
     },
     "hud_frags_space_x": {
-      "desc": "Sets vertical spacing of frags bar",
+      "desc": "Sets vertical spacing of frags bar.",
       "group-id": "19",
       "type": "float"
     },
     "hud_frags_space_y": {
-      "desc": "Sets horizontal spacing of frags bar",
+      "desc": "Sets horizontal spacing of frags bar.",
       "group-id": "19",
       "type": "float"
     },
     "hud_frags_strip": {
-      "desc": "Switches stripped version of frags bar",
+      "desc": "Switches stripped version of frags bar.",
       "group-id": "19",
       "type": "float"
     },
@@ -7714,12 +7868,12 @@
       ]
     },
     "hud_frags_teamsort": {
-      "desc": "Switches sorting by teams in frags bar",
+      "desc": "Switches sorting by teams in frags bar.",
       "group-id": "19",
       "type": "float"
     },
     "hud_frags_vertical": {
-      "desc": "Switches vertical rendering of frags bar",
+      "desc": "Switches vertical rendering of frags bar.",
       "group-id": "19",
       "type": "float"
     },
@@ -7779,7 +7933,7 @@
       ]
     },
     "hud_gameclock_frame": {
-      "desc": "Opacity of the background of the gameclock HUD element",
+      "desc": "Opacity of the background of the gameclock HUD element.",
       "group-id": "19",
       "type": "float"
     },
@@ -7793,38 +7947,38 @@
       "type": "float"
     },
     "hud_gameclock_offset": {
-      "desc": "Allows using gameclock in custom mods that don't support standard KT-like clock synchronization",
+      "desc": "Allows using gameclock in custom mods that don't support standard KT-like clock synchronization.",
       "group-id": "19",
       "remarks": "Some Capture The Flag or Team Fortress mods can take a use of this.",
       "type": "integer"
     },
     "hud_gameclock_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gameclock_place": {
-      "desc": "Placement of the gameclock HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
+      "desc": "Placement of the gameclock HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gameclock_pos_x": {
-      "desc": "Horizontal relative position of the gameclock HUD element",
+      "desc": "Horizontal relative position of the gameclock HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gameclock_pos_y": {
-      "desc": "Vertical relative position of the gameclock HUD element",
+      "desc": "Vertical relative position of the gameclock HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gameclock_scale": {
-      "desc": "Size of the gameclock HUD element",
+      "desc": "Size of the gameclock HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gameclock_show": {
-      "desc": "Visibility of the gameclock HUD element",
+      "desc": "Visibility of the gameclock HUD element.",
       "group-id": "19",
       "type": "boolean",
       "values": [
@@ -7857,7 +8011,7 @@
       "default": "RYM myr",
       "desc": "Sets the content of the gamesummary hud element.",
       "group-id": "19",
-      "remarks": "MVD playback only.  if the letter is in upper-case, it refers to the first team, otherwise the second",
+      "remarks": "MVD playback only.  if the letter is in upper-case, it refers to the first team, otherwise the second.",
       "type": "string",
       "values": [
         {
@@ -7903,17 +8057,17 @@
       ]
     },
     "hud_group1_align_x": {
-      "desc": "Sets horizontal align of grouping object 1",
+      "desc": "Sets horizontal align of grouping object 1.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group1_align_y": {
-      "desc": "Sets vertical align of grouping object 1",
+      "desc": "Sets vertical align of grouping object 1.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group1_frame": {
-      "desc": "Sets frame visibility and style for grouping object 1",
+      "desc": "Sets frame visibility and style for grouping object 1.",
       "group-id": "19",
       "type": "float"
     },
@@ -7923,7 +8077,7 @@
       "type": "string"
     },
     "hud_group1_height": {
-      "desc": "Sets vertical size of grouping object 1",
+      "desc": "Sets vertical size of grouping object 1.",
       "group-id": "19",
       "type": "float"
     },
@@ -7932,67 +8086,67 @@
       "type": "float"
     },
     "hud_group1_name": {
-      "desc": "Sets name of grouping object 1",
+      "desc": "Sets name of grouping object 1.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group1_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group1_pic_alpha": {
-      "desc": "Transparency level of the background image of the group1 HUD element",
+      "desc": "Transparency level of the background image of the group1 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group1_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group1 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group1 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group1_picture": {
-      "desc": "Sets background picture of grouping object 1",
+      "desc": "Sets background picture of grouping object 1.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group1_place": {
-      "desc": "Sets relative positioning for grouping object 1",
+      "desc": "Sets relative positioning for grouping object 1.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group1_pos_x": {
-      "desc": "Sets horizontal position of grouping object 1",
+      "desc": "Sets horizontal position of grouping object 1.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group1_pos_y": {
-      "desc": "Sets vertical position of grouping object 1",
+      "desc": "Sets vertical position of grouping object 1.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group1_show": {
-      "desc": "Switches showing of grouping object 1",
+      "desc": "Switches showing of grouping object 1.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group1_width": {
-      "desc": "Sets horizontal size of grouping object 1",
+      "desc": "Sets horizontal size of grouping object 1.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group2_align_x": {
-      "desc": "Sets horizontal align of grouping object 2",
+      "desc": "Sets horizontal align of grouping object 2.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group2_align_y": {
-      "desc": "Sets vertical align of grouping object 2",
+      "desc": "Sets vertical align of grouping object 2.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group2_frame": {
-      "desc": "Sets frame visibility and style for grouping object 2",
+      "desc": "Sets frame visibility and style for grouping object 2.",
       "group-id": "19",
       "type": "float"
     },
@@ -8002,7 +8156,7 @@
       "type": "string"
     },
     "hud_group2_height": {
-      "desc": "Sets vertical size of grouping object 2",
+      "desc": "Sets vertical size of grouping object 2.",
       "group-id": "19",
       "type": "float"
     },
@@ -8011,67 +8165,67 @@
       "type": "float"
     },
     "hud_group2_name": {
-      "desc": "Sets name of grouping object 2",
+      "desc": "Sets name of grouping object 2.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group2_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group2_pic_alpha": {
-      "desc": "Transparency level of the background image of the group2 HUD element",
+      "desc": "Transparency level of the background image of the group2 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group2_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group2 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group2 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group2_picture": {
-      "desc": "Sets background picture of grouping object 2",
+      "desc": "Sets background picture of grouping object 2.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group2_place": {
-      "desc": "Sets relative positioning for grouping object 2",
+      "desc": "Sets relative positioning for grouping object 2.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group2_pos_x": {
-      "desc": "Sets horizontal position of grouping object 2",
+      "desc": "Sets horizontal position of grouping object 2.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group2_pos_y": {
-      "desc": "Sets vertical position of grouping object 2",
+      "desc": "Sets vertical position of grouping object 2.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group2_show": {
-      "desc": "Switches showing of grouping object 2",
+      "desc": "Switches showing of grouping object 2.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group2_width": {
-      "desc": "Sets horizontal size of grouping object 2",
+      "desc": "Sets horizontal size of grouping object 2.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group3_align_x": {
-      "desc": "Sets horizontal align of grouping object 3",
+      "desc": "Sets horizontal align of grouping object 3.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group3_align_y": {
-      "desc": "Sets vertical align of grouping object 3",
+      "desc": "Sets vertical align of grouping object 3.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group3_frame": {
-      "desc": "Sets frame visibility and style for grouping object 3",
+      "desc": "Sets frame visibility and style for grouping object 3.",
       "group-id": "19",
       "type": "float"
     },
@@ -8081,7 +8235,7 @@
       "type": "string"
     },
     "hud_group3_height": {
-      "desc": "Sets vertical size of grouping object 3",
+      "desc": "Sets vertical size of grouping object 3.",
       "group-id": "19",
       "type": "float"
     },
@@ -8090,67 +8244,67 @@
       "type": "float"
     },
     "hud_group3_name": {
-      "desc": "Sets name of grouping object 3",
+      "desc": "Sets name of grouping object 3.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group3_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group3_pic_alpha": {
-      "desc": "Transparency level of the background image of the group3 HUD element",
+      "desc": "Transparency level of the background image of the group3 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group3_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group3 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group3 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group3_picture": {
-      "desc": "Sets background picture of grouping object 3",
+      "desc": "Sets background picture of grouping object 3.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group3_place": {
-      "desc": "Sets relative positioning for grouping object 3",
+      "desc": "Sets relative positioning for grouping object 3.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group3_pos_x": {
-      "desc": "Sets horizontal position of grouping object 3",
+      "desc": "Sets horizontal position of grouping object 3.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group3_pos_y": {
-      "desc": "Sets vertical position of grouping object 3",
+      "desc": "Sets vertical position of grouping object 3.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group3_show": {
-      "desc": "Switches showing of grouping object 3",
+      "desc": "Switches showing of grouping object 3.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group3_width": {
-      "desc": "Sets horizontal size of grouping object 3",
+      "desc": "Sets horizontal size of grouping object 3.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group4_align_x": {
-      "desc": "Sets horizontal align of grouping object 4",
+      "desc": "Sets horizontal align of grouping object 4.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group4_align_y": {
-      "desc": "Sets vertical align of grouping object 4",
+      "desc": "Sets vertical align of grouping object 4.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group4_frame": {
-      "desc": "Sets frame visibility and style for grouping object 4",
+      "desc": "Sets frame visibility and style for grouping object 4.",
       "group-id": "19",
       "type": "float"
     },
@@ -8160,7 +8314,7 @@
       "type": "string"
     },
     "hud_group4_height": {
-      "desc": "Sets vertical size of grouping object 4",
+      "desc": "Sets vertical size of grouping object 4.",
       "group-id": "19",
       "type": "float"
     },
@@ -8169,67 +8323,67 @@
       "type": "float"
     },
     "hud_group4_name": {
-      "desc": "Sets name of grouping object 4",
+      "desc": "Sets name of grouping object 4.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group4_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group4_pic_alpha": {
-      "desc": "Transparency level of the background image of the group4 HUD element",
+      "desc": "Transparency level of the background image of the group4 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group4_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group4 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group4 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group4_picture": {
-      "desc": "Sets background picture of grouping object 4",
+      "desc": "Sets background picture of grouping object 4.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group4_place": {
-      "desc": "Sets relative positioning for grouping object 4",
+      "desc": "Sets relative positioning for grouping object 4.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group4_pos_x": {
-      "desc": "Sets horizontal position of grouping object 4",
+      "desc": "Sets horizontal position of grouping object 4.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group4_pos_y": {
-      "desc": "Sets vertical position of grouping object 4",
+      "desc": "Sets vertical position of grouping object 4.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group4_show": {
-      "desc": "Switches showing of grouping object 4",
+      "desc": "Switches showing of grouping object 4.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group4_width": {
-      "desc": "Sets horizontal size of grouping object 4",
+      "desc": "Sets horizontal size of grouping object 4.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group5_align_x": {
-      "desc": "Sets horizontal align of grouping object 5",
+      "desc": "Sets horizontal align of grouping object 5.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group5_align_y": {
-      "desc": "Sets vertical align of grouping object 5",
+      "desc": "Sets vertical align of grouping object 5.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group5_frame": {
-      "desc": "Sets frame visibility and style for grouping object 5",
+      "desc": "Sets frame visibility and style for grouping object 5.",
       "group-id": "19",
       "type": "float"
     },
@@ -8239,7 +8393,7 @@
       "type": "string"
     },
     "hud_group5_height": {
-      "desc": "Sets vertical size of grouping object 5",
+      "desc": "Sets vertical size of grouping object 5.",
       "group-id": "19",
       "type": "float"
     },
@@ -8248,67 +8402,67 @@
       "type": "float"
     },
     "hud_group5_name": {
-      "desc": "Sets name of grouping object 5",
+      "desc": "Sets name of grouping object 5.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group5_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group5_pic_alpha": {
-      "desc": "Transparency level of the background image of the group5 HUD element",
+      "desc": "Transparency level of the background image of the group5 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group5_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group5 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group5 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group5_picture": {
-      "desc": "Sets background picture of grouping object 5",
+      "desc": "Sets background picture of grouping object 5.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group5_place": {
-      "desc": "Sets relative positioning for grouping object 5",
+      "desc": "Sets relative positioning for grouping object 5.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group5_pos_x": {
-      "desc": "Sets horizontal position of grouping object 5",
+      "desc": "Sets horizontal position of grouping object 5.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group5_pos_y": {
-      "desc": "Sets vertical position of grouping object 5",
+      "desc": "Sets vertical position of grouping object 5.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group5_show": {
-      "desc": "Switches showing of grouping object 5",
+      "desc": "Switches showing of grouping object 5.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group5_width": {
-      "desc": "Sets horizontal size of grouping object 5",
+      "desc": "Sets horizontal size of grouping object 5.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group6_align_x": {
-      "desc": "Sets horizontal align of grouping object 6",
+      "desc": "Sets horizontal align of grouping object 6.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group6_align_y": {
-      "desc": "Sets vertical align of grouping object 6",
+      "desc": "Sets vertical align of grouping object 6.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group6_frame": {
-      "desc": "Sets frame visibility and style for grouping object 6",
+      "desc": "Sets frame visibility and style for grouping object 6.",
       "group-id": "19",
       "type": "float"
     },
@@ -8318,7 +8472,7 @@
       "type": "string"
     },
     "hud_group6_height": {
-      "desc": "Sets vertical size of grouping object 6",
+      "desc": "Sets vertical size of grouping object 6.",
       "group-id": "19",
       "type": "float"
     },
@@ -8327,67 +8481,67 @@
       "type": "float"
     },
     "hud_group6_name": {
-      "desc": "Sets name of grouping object 6",
+      "desc": "Sets name of grouping object 6.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group6_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group6_pic_alpha": {
-      "desc": "Transparency level of the background image of the group6 HUD element",
+      "desc": "Transparency level of the background image of the group6 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group6_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group6 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group6 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group6_picture": {
-      "desc": "Sets background picture of grouping object 6",
+      "desc": "Sets background picture of grouping object 6.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group6_place": {
-      "desc": "Sets relative positioning for grouping object 6",
+      "desc": "Sets relative positioning for grouping object 6.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group6_pos_x": {
-      "desc": "Sets horizontal position of grouping object 6",
+      "desc": "Sets horizontal position of grouping object 6.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group6_pos_y": {
-      "desc": "Sets vertical position of grouping object 6",
+      "desc": "Sets vertical position of grouping object 6.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group6_show": {
-      "desc": "Switches showing of grouping object 6",
+      "desc": "Switches showing of grouping object 6.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group6_width": {
-      "desc": "Sets horizontal size of grouping object 6",
+      "desc": "Sets horizontal size of grouping object 6.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group7_align_x": {
-      "desc": "Sets horizontal align of grouping object 7",
+      "desc": "Sets horizontal align of grouping object 7.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group7_align_y": {
-      "desc": "Sets vertical align of grouping object 7",
+      "desc": "Sets vertical align of grouping object 7.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group7_frame": {
-      "desc": "Sets frame visibility and style for grouping object 7",
+      "desc": "Sets frame visibility and style for grouping object 7.",
       "group-id": "19",
       "type": "float"
     },
@@ -8397,7 +8551,7 @@
       "type": "string"
     },
     "hud_group7_height": {
-      "desc": "Sets vertical size of grouping object 7",
+      "desc": "Sets vertical size of grouping object 7.",
       "group-id": "19",
       "type": "float"
     },
@@ -8406,67 +8560,67 @@
       "type": "float"
     },
     "hud_group7_name": {
-      "desc": "Sets name of grouping object 7",
+      "desc": "Sets name of grouping object 7.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group7_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group7_pic_alpha": {
-      "desc": "Transparency level of the background image of the group7 HUD element",
+      "desc": "Transparency level of the background image of the group7 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group7_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group7 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group7 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group7_picture": {
-      "desc": "Sets background picture of grouping object 7",
+      "desc": "Sets background picture of grouping object 7.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group7_place": {
-      "desc": "Sets relative positioning for grouping object 7",
+      "desc": "Sets relative positioning for grouping object 7.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group7_pos_x": {
-      "desc": "Sets horizontal position of grouping object 7",
+      "desc": "Sets horizontal position of grouping object 7.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group7_pos_y": {
-      "desc": "Sets vertical position of grouping object 7",
+      "desc": "Sets vertical position of grouping object 7.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group7_show": {
-      "desc": "Switches showing of grouping object 7",
+      "desc": "Switches showing of grouping object 7.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group7_width": {
-      "desc": "Sets horizontal size of grouping object 7",
+      "desc": "Sets horizontal size of grouping object 7.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group8_align_x": {
-      "desc": "Sets horizontal align of grouping object 8",
+      "desc": "Sets horizontal align of grouping object 8.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group8_align_y": {
-      "desc": "Sets vertical align of grouping object 8",
+      "desc": "Sets vertical align of grouping object 8.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group8_frame": {
-      "desc": "Sets frame visibility and style for grouping object 8",
+      "desc": "Sets frame visibility and style for grouping object 8.",
       "group-id": "19",
       "type": "float"
     },
@@ -8476,7 +8630,7 @@
       "type": "string"
     },
     "hud_group8_height": {
-      "desc": "Sets vertical size of grouping object 8",
+      "desc": "Sets vertical size of grouping object 8.",
       "group-id": "19",
       "type": "float"
     },
@@ -8485,67 +8639,67 @@
       "type": "float"
     },
     "hud_group8_name": {
-      "desc": "Sets name of grouping object 8",
+      "desc": "Sets name of grouping object 8.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group8_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group8_pic_alpha": {
-      "desc": "Transparency level of the background image of the group8 HUD element",
+      "desc": "Transparency level of the background image of the group8 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group8_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group8 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group8 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group8_picture": {
-      "desc": "Sets background picture of grouping object 8",
+      "desc": "Sets background picture of grouping object 8.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group8_place": {
-      "desc": "Sets relative positioning for grouping object 8",
+      "desc": "Sets relative positioning for grouping object 8.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group8_pos_x": {
-      "desc": "Sets horizontal position of grouping object 8",
+      "desc": "Sets horizontal position of grouping object 8.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group8_pos_y": {
-      "desc": "Sets vertical position of grouping object 8",
+      "desc": "Sets vertical position of grouping object 8.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group8_show": {
-      "desc": "Switches showing of grouping object 8",
+      "desc": "Switches showing of grouping object 8.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group8_width": {
-      "desc": "Sets horizontal size of grouping object 8",
+      "desc": "Sets horizontal size of grouping object 8.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group9_align_x": {
-      "desc": "Sets horizontal align of grouping object 9",
+      "desc": "Sets horizontal align of grouping object 9.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group9_align_y": {
-      "desc": "Sets vertical align of grouping object 9",
+      "desc": "Sets vertical align of grouping object 9.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group9_frame": {
-      "desc": "Sets frame visibility and style for grouping object 9",
+      "desc": "Sets frame visibility and style for grouping object 9.",
       "group-id": "19",
       "type": "float"
     },
@@ -8555,7 +8709,7 @@
       "type": "string"
     },
     "hud_group9_height": {
-      "desc": "Sets vertical size of grouping object 9",
+      "desc": "Sets vertical size of grouping object 9.",
       "group-id": "19",
       "type": "float"
     },
@@ -8564,67 +8718,67 @@
       "type": "float"
     },
     "hud_group9_name": {
-      "desc": "Sets name of grouping object 9",
+      "desc": "Sets name of grouping object 9.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group9_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group9_pic_alpha": {
-      "desc": "Transparency level of the background image of the group9 HUD element",
+      "desc": "Transparency level of the background image of the group9 HUD element.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group9_pic_scalemode": {
-      "desc": "Changes the style how the background picture is aligned and stretched for the group9 HUD element. Values from 0 to 5 are supported. See HUD manual for more info",
+      "desc": "Changes the style how the background picture is aligned and stretched for the group9 HUD element. Values from 0 to 5 are supported. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_group9_picture": {
-      "desc": "Sets background picture of grouping object 9",
+      "desc": "Sets background picture of grouping object 9.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group9_place": {
-      "desc": "Sets relative positioning for grouping object 9",
+      "desc": "Sets relative positioning for grouping object 9.",
       "group-id": "19",
       "type": "string"
     },
     "hud_group9_pos_x": {
-      "desc": "Sets horizontal position of grouping object 9",
+      "desc": "Sets horizontal position of grouping object 9.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group9_pos_y": {
-      "desc": "Sets vertical position of grouping object 9",
+      "desc": "Sets vertical position of grouping object 9.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group9_show": {
-      "desc": "Switches showing of grouping object 9",
+      "desc": "Switches showing of grouping object 9.",
       "group-id": "19",
       "type": "float"
     },
     "hud_group9_width": {
-      "desc": "Sets horizontal size of grouping object 9",
+      "desc": "Sets horizontal size of grouping object 9.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun2_align_x": {
-      "desc": "Sets horizontal align of shotgun icon",
+      "desc": "Sets horizontal align of shotgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun2_align_y": {
-      "desc": "Sets vertical align of shotgun icon",
+      "desc": "Sets vertical align of shotgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun2_frame": {
-      "desc": "Sets frame visibility and style for shotgun icon",
+      "desc": "Sets frame visibility and style for shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -8638,37 +8792,37 @@
       "type": "float"
     },
     "hud_gun2_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gun2_place": {
-      "desc": "Sets relative positioning for shotgun icon",
+      "desc": "Sets relative positioning for shotgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun2_pos_x": {
-      "desc": "Sets horizontal position of shotgun icon",
+      "desc": "Sets horizontal position of shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun2_pos_y": {
-      "desc": "Sets vertical position of shotgun icon",
+      "desc": "Sets vertical position of shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun2_scale": {
-      "desc": "Sets size of shotgun icon",
+      "desc": "Sets size of shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun2_show": {
-      "desc": "Switches showing of shotgun icon",
+      "desc": "Switches showing of shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun2_style": {
-      "desc": "Switches the graphical style of the shotgun icon",
+      "desc": "Switches the graphical style of the shotgun icon.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -8711,17 +8865,17 @@
       ]
     },
     "hud_gun3_align_x": {
-      "desc": "Sets horizontal align of super shotgun icon",
+      "desc": "Sets horizontal align of super shotgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun3_align_y": {
-      "desc": "Sets vertical align of super shotgun icon",
+      "desc": "Sets vertical align of super shotgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun3_frame": {
-      "desc": "Sets frame visibility and style for super shotgun icon",
+      "desc": "Sets frame visibility and style for super shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -8735,37 +8889,37 @@
       "type": "float"
     },
     "hud_gun3_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gun3_place": {
-      "desc": "Sets relative positioning for super shotgun icon",
+      "desc": "Sets relative positioning for super shotgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun3_pos_x": {
-      "desc": "Sets horizontal position of super shotgun icon",
+      "desc": "Sets horizontal position of super shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun3_pos_y": {
-      "desc": "Sets vertical position of super shotgun icon",
+      "desc": "Sets vertical position of super shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun3_scale": {
-      "desc": "Sets size of super shotgun icon",
+      "desc": "Sets size of super shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun3_show": {
-      "desc": "Switches showing of super shotgun icon",
+      "desc": "Switches showing of super shotgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun3_style": {
-      "desc": "Switches the graphical style of the super shotgun icon",
+      "desc": "Switches the graphical style of the super shotgun icon.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -8808,17 +8962,17 @@
       ]
     },
     "hud_gun4_align_x": {
-      "desc": "Sets horizontal align of nailgun icon",
+      "desc": "Sets horizontal align of nailgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun4_align_y": {
-      "desc": "Sets vertical align of nailgun icon",
+      "desc": "Sets vertical align of nailgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun4_frame": {
-      "desc": "Sets frame visibility and style for nailgun icon",
+      "desc": "Sets frame visibility and style for nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -8832,37 +8986,37 @@
       "type": "float"
     },
     "hud_gun4_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gun4_place": {
-      "desc": "Sets relative positioning for nailgun icon",
+      "desc": "Sets relative positioning for nailgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun4_pos_x": {
-      "desc": "Sets horizontal position of nailgun icon",
+      "desc": "Sets horizontal position of nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun4_pos_y": {
-      "desc": "Sets vertical position of nailgun icon",
+      "desc": "Sets vertical position of nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun4_scale": {
-      "desc": "Sets size of nailgun icon",
+      "desc": "Sets size of nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun4_show": {
-      "desc": "Switches showing of nailgun icon",
+      "desc": "Switches showing of nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun4_style": {
-      "desc": "Switches the graphical style of the nailgun icon",
+      "desc": "Switches the graphical style of the nailgun icon.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -8905,17 +9059,17 @@
       ]
     },
     "hud_gun5_align_x": {
-      "desc": "Sets horizontal align of super nailgun icon",
+      "desc": "Sets horizontal align of super nailgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun5_align_y": {
-      "desc": "Sets vertical align of super nailgun icon",
+      "desc": "Sets vertical align of super nailgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun5_frame": {
-      "desc": "Sets frame visibility and style for super nailgun icon",
+      "desc": "Sets frame visibility and style for super nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -8929,37 +9083,37 @@
       "type": "float"
     },
     "hud_gun5_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gun5_place": {
-      "desc": "Sets relative positioning for super nailgun icon",
+      "desc": "Sets relative positioning for super nailgun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun5_pos_x": {
-      "desc": "Sets horizontal position of super nailgun icon",
+      "desc": "Sets horizontal position of super nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun5_pos_y": {
-      "desc": "Sets vertical position of super nailgun icon",
+      "desc": "Sets vertical position of super nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun5_scale": {
-      "desc": "Sets size of super nailgun icon",
+      "desc": "Sets size of super nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun5_show": {
-      "desc": "Switches showing of super nailgun icon",
+      "desc": "Switches showing of super nailgun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun5_style": {
-      "desc": "Switches the graphical style of the super nailgun icon",
+      "desc": "Switches the graphical style of the super nailgun icon.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -9002,17 +9156,17 @@
       ]
     },
     "hud_gun6_align_x": {
-      "desc": "Sets horizontal align of grenade launcher icon",
+      "desc": "Sets horizontal align of grenade launcher icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun6_align_y": {
-      "desc": "Sets vertical align of grenade launcher icon",
+      "desc": "Sets vertical align of grenade launcher icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun6_frame": {
-      "desc": "Sets frame visibility and style for grenade launcher icon",
+      "desc": "Sets frame visibility and style for grenade launcher icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9026,37 +9180,37 @@
       "type": "float"
     },
     "hud_gun6_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gun6_place": {
-      "desc": "Sets relative positioning for grenade launcher icon",
+      "desc": "Sets relative positioning for grenade launcher icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun6_pos_x": {
-      "desc": "Sets horizontal position of grenade launcher icon",
+      "desc": "Sets horizontal position of grenade launcher icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun6_pos_y": {
-      "desc": "Sets vertical position of grenade launcher icon",
+      "desc": "Sets vertical position of grenade launcher icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun6_scale": {
-      "desc": "Sets size of grenade launcher icon",
+      "desc": "Sets size of grenade launcher icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun6_show": {
-      "desc": "Switches showing of grenade launcher icon",
+      "desc": "Switches showing of grenade launcher icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun6_style": {
-      "desc": "Switches the graphical style of the grenade launcher icon",
+      "desc": "Switches the graphical style of the grenade launcher icon.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -9099,17 +9253,17 @@
       ]
     },
     "hud_gun7_align_x": {
-      "desc": "Sets horizontal align of rocket launcher icon",
+      "desc": "Sets horizontal align of rocket launcher icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun7_align_y": {
-      "desc": "Sets vertical align of rocket launcher icon",
+      "desc": "Sets vertical align of rocket launcher icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun7_frame": {
-      "desc": "Sets frame visibility and style for rocket launcher icon",
+      "desc": "Sets frame visibility and style for rocket launcher icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9123,37 +9277,37 @@
       "type": "float"
     },
     "hud_gun7_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gun7_place": {
-      "desc": "Sets relative positioning for rocket launcher icon",
+      "desc": "Sets relative positioning for rocket launcher icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun7_pos_x": {
-      "desc": "Sets horizontal position of rocket launcher icon",
+      "desc": "Sets horizontal position of rocket launcher icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun7_pos_y": {
-      "desc": "Sets vertical position of rocket launcher icon",
+      "desc": "Sets vertical position of rocket launcher icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun7_scale": {
-      "desc": "Sets size of rocket launcher icon",
+      "desc": "Sets size of rocket launcher icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun7_show": {
-      "desc": "Switches showing of rocket launcher icon",
+      "desc": "Switches showing of rocket launcher icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun7_style": {
-      "desc": "Switches the graphical style of the rocket launcher icon",
+      "desc": "Switches the graphical style of the rocket launcher icon.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -9196,17 +9350,17 @@
       ]
     },
     "hud_gun8_align_x": {
-      "desc": "Sets horizontal align of lightning gun icon",
+      "desc": "Sets horizontal align of lightning gun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun8_align_y": {
-      "desc": "Sets vertical align of lightning gun icon",
+      "desc": "Sets vertical align of lightning gun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun8_frame": {
-      "desc": "Sets frame visibility and style for lightning gun icon",
+      "desc": "Sets frame visibility and style for lightning gun icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9220,37 +9374,37 @@
       "type": "float"
     },
     "hud_gun8_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gun8_place": {
-      "desc": "Sets relative positioning for lightning gun icon",
+      "desc": "Sets relative positioning for lightning gun icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun8_pos_x": {
-      "desc": "Sets horizontal position of lightning gun icon",
+      "desc": "Sets horizontal position of lightning gun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun8_pos_y": {
-      "desc": "Sets vertical position of lightning gun icon",
+      "desc": "Sets vertical position of lightning gun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun8_scale": {
-      "desc": "Sets size of lightning gun icon",
+      "desc": "Sets size of lightning gun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun8_show": {
-      "desc": "Switches showing of lightning gun icon",
+      "desc": "Switches showing of lightning gun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun8_style": {
-      "desc": "Switches the graphical style of the lightning gun icon",
+      "desc": "Switches the graphical style of the lightning gun icon.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -9293,22 +9447,22 @@
       ]
     },
     "hud_gun8_wide": {
-      "desc": "Switches wide and short of version of lightning gun icon",
+      "desc": "Switches wide and short of version of lightning gun icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun_align_x": {
-      "desc": "Sets horizontal align of current weapon icon",
+      "desc": "Sets horizontal align of current weapon icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun_align_y": {
-      "desc": "Sets vertical align of current weapon icon",
+      "desc": "Sets vertical align of current weapon icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun_frame": {
-      "desc": "Sets frame visibility and style for current weapon icon",
+      "desc": "Sets frame visibility and style for current weapon icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9322,37 +9476,37 @@
       "type": "float"
     },
     "hud_gun_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_gun_place": {
-      "desc": "Sets relative positioning for current weapon icon",
+      "desc": "Sets relative positioning for current weapon icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_gun_pos_x": {
-      "desc": "Sets horizontal position of current weapon icon",
+      "desc": "Sets horizontal position of current weapon icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun_pos_y": {
-      "desc": "Sets vertical position of current weapon icon",
+      "desc": "Sets vertical position of current weapon icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun_scale": {
-      "desc": "Sets size of current weapon icon",
+      "desc": "Sets size of current weapon icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun_show": {
-      "desc": "Switches showing of current weapon icon",
+      "desc": "Switches showing of current weapon icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_gun_style": {
-      "desc": "Switches graphical style of the current weapon's icon",
+      "desc": "Switches graphical style of the current weapon's icon.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -9383,32 +9537,32 @@
       ]
     },
     "hud_gun_wide": {
-      "desc": "Switches between wide and short version of current weapon icon",
+      "desc": "Switches between wide and short version of current weapon icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_health_align": {
-      "desc": "Sets align of health level",
+      "desc": "Sets align of health level.",
       "group-id": "19",
       "type": "string"
     },
     "hud_health_align_x": {
-      "desc": "Sets horizontal align of health level",
+      "desc": "Sets horizontal align of health level.",
       "group-id": "19",
       "type": "string"
     },
     "hud_health_align_y": {
-      "desc": "Sets vertical align of health level",
+      "desc": "Sets vertical align of health level.",
       "group-id": "19",
       "type": "string"
     },
     "hud_health_digits": {
-      "desc": "Sets number of digits for health level",
+      "desc": "Sets number of digits for health level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_health_frame": {
-      "desc": "Sets frame visibility and style for health level",
+      "desc": "Sets frame visibility and style for health level.",
       "group-id": "19",
       "type": "float"
     },
@@ -9422,37 +9576,37 @@
       "type": "float"
     },
     "hud_health_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_health_place": {
-      "desc": "Sets relative positioning for health level",
+      "desc": "Sets relative positioning for health level.",
       "group-id": "19",
       "type": "string"
     },
     "hud_health_pos_x": {
-      "desc": "Sets horizontal position of health level",
+      "desc": "Sets horizontal position of health level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_health_pos_y": {
-      "desc": "Sets vertical position of health level",
+      "desc": "Sets vertical position of health level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_health_scale": {
-      "desc": "Sets size of health level",
+      "desc": "Sets size of health level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_health_show": {
-      "desc": "Switches showing of health level",
+      "desc": "Switches showing of health level.",
       "group-id": "19",
       "type": "float"
     },
     "hud_health_style": {
-      "desc": "Switches graphical style of health level",
+      "desc": "Switches graphical style of health level.",
       "group-id": "19",
       "type": "float"
     },
@@ -9463,7 +9617,7 @@
       "type": "string",
       "values": [
         {
-          "description": "horizontal: left, center, right, before, after; vertical: top, center, bottom, console, before, after",
+          "description": "horizontal: left, center, right, before, after\nvertical: top, center, bottom, console, before, after",
           "name": "*"
         }
       ]
@@ -9529,7 +9683,7 @@
       "type": "float"
     },
     "hud_healthdamage_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -9597,17 +9751,17 @@
       ]
     },
     "hud_iammo1_align_x": {
-      "desc": "Sets horizontal align of shells icon",
+      "desc": "Sets horizontal align of shells icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo1_align_y": {
-      "desc": "Sets vertical align of shells icon",
+      "desc": "Sets vertical align of shells icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo1_frame": {
-      "desc": "Sets frame visibility and style for shells icon",
+      "desc": "Sets frame visibility and style for shells icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9621,52 +9775,52 @@
       "type": "float"
     },
     "hud_iammo1_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_iammo1_place": {
-      "desc": "Sets relative positioning for shells icon",
+      "desc": "Sets relative positioning for shells icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo1_pos_x": {
-      "desc": "Sets horizontal position of shells icon",
+      "desc": "Sets horizontal position of shells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo1_pos_y": {
-      "desc": "Sets vertical position of shells icon",
+      "desc": "Sets vertical position of shells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo1_scale": {
-      "desc": "Sets size of shells icon",
+      "desc": "Sets size of shells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo1_show": {
-      "desc": "Switches showing of shells icon",
+      "desc": "Switches showing of shells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo1_style": {
-      "desc": "Switches graphical style of shells icon",
+      "desc": "Switches graphical style of shells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo2_align_x": {
-      "desc": "Sets horizontal align of nails icon",
+      "desc": "Sets horizontal align of nails icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo2_align_y": {
-      "desc": "Sets vertical align of nails icon",
+      "desc": "Sets vertical align of nails icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo2_frame": {
-      "desc": "Sets frame visibility and style for nails icon",
+      "desc": "Sets frame visibility and style for nails icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9680,52 +9834,52 @@
       "type": "float"
     },
     "hud_iammo2_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_iammo2_place": {
-      "desc": "Sets relative positioning for nails icon",
+      "desc": "Sets relative positioning for nails icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo2_pos_x": {
-      "desc": "Sets horizontal position of nails icon",
+      "desc": "Sets horizontal position of nails icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo2_pos_y": {
-      "desc": "Sets vertical position of nails icon",
+      "desc": "Sets vertical position of nails icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo2_scale": {
-      "desc": "Sets size of nails icon",
+      "desc": "Sets size of nails icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo2_show": {
-      "desc": "Switches showing of nails icon",
+      "desc": "Switches showing of nails icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo2_style": {
-      "desc": "Switches graphical style of nails icon",
+      "desc": "Switches graphical style of nails icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo3_align_x": {
-      "desc": "Sets horizontal align of rockets icon",
+      "desc": "Sets horizontal align of rockets icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo3_align_y": {
-      "desc": "Sets vertical align of rockets icon",
+      "desc": "Sets vertical align of rockets icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo3_frame": {
-      "desc": "Sets frame visibility and style for rockets icon",
+      "desc": "Sets frame visibility and style for rockets icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9739,52 +9893,52 @@
       "type": "float"
     },
     "hud_iammo3_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_iammo3_place": {
-      "desc": "Sets relative positioning for rockets icon",
+      "desc": "Sets relative positioning for rockets icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo3_pos_x": {
-      "desc": "Sets horizontal position of rockets icon",
+      "desc": "Sets horizontal position of rockets icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo3_pos_y": {
-      "desc": "Sets vertical position of rockets icon",
+      "desc": "Sets vertical position of rockets icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo3_scale": {
-      "desc": "Sets size of rockets icon",
+      "desc": "Sets size of rockets icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo3_show": {
-      "desc": "Switches showing of rockets icon",
+      "desc": "Switches showing of rockets icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo3_style": {
-      "desc": "Switches graphical style of rockets icon",
+      "desc": "Switches graphical style of rockets icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo4_align_x": {
-      "desc": "Sets horizontal align of cells icon",
+      "desc": "Sets horizontal align of cells icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo4_align_y": {
-      "desc": "Sets vertical align of cells icon",
+      "desc": "Sets vertical align of cells icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo4_frame": {
-      "desc": "Sets frame visibility and style for cells icon",
+      "desc": "Sets frame visibility and style for cells icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9798,52 +9952,52 @@
       "type": "float"
     },
     "hud_iammo4_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_iammo4_place": {
-      "desc": "Sets relative positioning for cells icon",
+      "desc": "Sets relative positioning for cells icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo4_pos_x": {
-      "desc": "Sets horizontal position of cells icon",
+      "desc": "Sets horizontal position of cells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo4_pos_y": {
-      "desc": "Sets vertical position of cells icon",
+      "desc": "Sets vertical position of cells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo4_scale": {
-      "desc": "Sets size of cells icon",
+      "desc": "Sets size of cells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo4_show": {
-      "desc": "Switches showing of cells icon",
+      "desc": "Switches showing of cells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo4_style": {
-      "desc": "Switches graphical style of cells icon",
+      "desc": "Switches graphical style of cells icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo_align_x": {
-      "desc": "Sets horizontal align of current ammo icon",
+      "desc": "Sets horizontal align of current ammo icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo_align_y": {
-      "desc": "Sets vertical align of current ammo icon",
+      "desc": "Sets vertical align of current ammo icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo_frame": {
-      "desc": "Sets frame visibility and style for current ammo icon",
+      "desc": "Sets frame visibility and style for current ammo icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9857,52 +10011,52 @@
       "type": "float"
     },
     "hud_iammo_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_iammo_place": {
-      "desc": "Sets relative positioning for current ammo icon",
+      "desc": "Sets relative positioning for current ammo icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iammo_pos_x": {
-      "desc": "Sets horizontal position of current ammo icon",
+      "desc": "Sets horizontal position of current ammo icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo_pos_y": {
-      "desc": "Sets vertical position of current ammo icon",
+      "desc": "Sets vertical position of current ammo icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo_scale": {
-      "desc": "Sets size of current ammo icon",
+      "desc": "Sets size of current ammo icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo_show": {
-      "desc": "Switches showing of current ammo icon",
+      "desc": "Switches showing of current ammo icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iammo_style": {
-      "desc": "Switches graphical style of current ammo icon",
+      "desc": "Switches graphical style of current ammo icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iarmor_align_x": {
-      "desc": "Sets horizontal align of armor icon",
+      "desc": "Sets horizontal align of armor icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iarmor_align_y": {
-      "desc": "Sets vertical align of armor icon",
+      "desc": "Sets vertical align of armor icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iarmor_frame": {
-      "desc": "Sets frame visibility and style for armor icon",
+      "desc": "Sets frame visibility and style for armor icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9916,37 +10070,37 @@
       "type": "float"
     },
     "hud_iarmor_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_iarmor_place": {
-      "desc": "Sets relative positioning for armor icon",
+      "desc": "Sets relative positioning for armor icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_iarmor_pos_x": {
-      "desc": "Sets horizontal position of armor icon",
+      "desc": "Sets horizontal position of armor icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iarmor_pos_y": {
-      "desc": "Sets vertical position of armor icon",
+      "desc": "Sets vertical position of armor icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iarmor_scale": {
-      "desc": "Sets size of armor icon",
+      "desc": "Sets size of armor icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iarmor_show": {
-      "desc": "Switches showing of armor icon",
+      "desc": "Switches showing of armor icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_iarmor_style": {
-      "desc": "Switches graphical style of armor icon",
+      "desc": "Switches graphical style of armor icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -9959,9 +10113,9 @@
       "type": "string"
     },
     "hud_itemsclock_filter": {
-      "desc": "Space-separated list of items to NOT be shown",
+      "desc": "Space-separated list of items to NOT be shown.",
       "group-id": "19",
-      "remarks": "Options are: gl, rl, lg, quad, pent, ring, suit, mh, ga, ya, ra",
+      "remarks": "Options are: gl, rl, lg, quad, pent, ring, suit, mh, ga, ya, ra.",
       "type": "integer",
       "values": [
         {
@@ -9999,7 +10153,7 @@
       "type": ""
     },
     "hud_itemsclock_scale": {
-      "desc": "Sets size of items clock items relative to standard font size",
+      "desc": "Sets size of items clock items relative to standard font size.",
       "group-id": "19",
       "type": "float"
     },
@@ -10016,17 +10170,17 @@
       "type": ""
     },
     "hud_key1_align_x": {
-      "desc": "Sets horizontal align of silver key",
+      "desc": "Sets horizontal align of silver key.",
       "group-id": "19",
       "type": "string"
     },
     "hud_key1_align_y": {
-      "desc": "Sets vertical align of silver key",
+      "desc": "Sets vertical align of silver key.",
       "group-id": "19",
       "type": "string"
     },
     "hud_key1_frame": {
-      "desc": "Sets frame visibility and style for silver key",
+      "desc": "Sets frame visibility and style for silver key.",
       "group-id": "19",
       "type": "float"
     },
@@ -10040,52 +10194,52 @@
       "type": "float"
     },
     "hud_key1_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_key1_place": {
-      "desc": "Sets relative positioning for silver key",
+      "desc": "Sets relative positioning for silver key.",
       "group-id": "19",
       "type": "string"
     },
     "hud_key1_pos_x": {
-      "desc": "Sets horizontal position of silver key",
+      "desc": "Sets horizontal position of silver key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key1_pos_y": {
-      "desc": "Sets vertical position of silver key",
+      "desc": "Sets vertical position of silver key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key1_scale": {
-      "desc": "Sets size of silver key",
+      "desc": "Sets size of silver key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key1_show": {
-      "desc": "Switches showing of silver key",
+      "desc": "Switches showing of silver key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key1_style": {
-      "desc": "Switches graphical style of silver key",
+      "desc": "Switches graphical style of silver key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key2_align_x": {
-      "desc": "Sets horizontal align of gold key",
+      "desc": "Sets horizontal align of gold key.",
       "group-id": "19",
       "type": "string"
     },
     "hud_key2_align_y": {
-      "desc": "Sets vertical align of gold key",
+      "desc": "Sets vertical align of gold key.",
       "group-id": "19",
       "type": "string"
     },
     "hud_key2_frame": {
-      "desc": "Sets frame visibility and style for gold key",
+      "desc": "Sets frame visibility and style for gold key.",
       "group-id": "19",
       "type": "float"
     },
@@ -10099,37 +10253,37 @@
       "type": "float"
     },
     "hud_key2_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_key2_place": {
-      "desc": "Sets relative positioning for gold key",
+      "desc": "Sets relative positioning for gold key.",
       "group-id": "19",
       "type": "string"
     },
     "hud_key2_pos_x": {
-      "desc": "Sets horizontal position of gold key",
+      "desc": "Sets horizontal position of gold key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key2_pos_y": {
-      "desc": "Sets vertical position of gold key",
+      "desc": "Sets vertical position of gold key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key2_scale": {
-      "desc": "Sets size of gold key",
+      "desc": "Sets size of gold key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key2_show": {
-      "desc": "Switches showing of gold key",
+      "desc": "Switches showing of gold key.",
       "group-id": "19",
       "type": "float"
     },
     "hud_key2_style": {
-      "desc": "Switches graphical style of gold key",
+      "desc": "Switches graphical style of gold key.",
       "group-id": "19",
       "type": "float"
     },
@@ -10188,7 +10342,7 @@
       "type": "string"
     },
     "hud_mouserate_frame": {
-      "desc": "Opacity of the background of the mouserate HUD element",
+      "desc": "Opacity of the background of the mouserate HUD element.",
       "group-id": "28",
       "type": "float"
     },
@@ -10198,27 +10352,27 @@
       "type": "string"
     },
     "hud_mouserate_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "28",
       "type": "integer"
     },
     "hud_mouserate_place": {
-      "desc": "Placement of the mouserate HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
+      "desc": "Placement of the mouserate HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info.",
       "group-id": "28",
       "type": "string"
     },
     "hud_mouserate_pos_x": {
-      "desc": "Horizontal relative position of the mouserate HUD element",
+      "desc": "Horizontal relative position of the mouserate HUD element.",
       "group-id": "28",
       "type": "integer"
     },
     "hud_mouserate_pos_y": {
-      "desc": "Vertical relative position of the mouserate HUD element",
+      "desc": "Vertical relative position of the mouserate HUD element.",
       "group-id": "28",
       "type": "integer"
     },
     "hud_mouserate_show": {
-      "desc": "Visibility of the mouserate HUD element",
+      "desc": "Visibility of the mouserate HUD element.",
       "group-id": "28",
       "type": "boolean",
       "values": [
@@ -10234,23 +10388,23 @@
     },
     "hud_name_remove_prefixes": {
       "default": "",
-      "desc": "Space-separated list of prefixes to remove from player names before displaying in the tracker & teaminfo",
+      "desc": "Space-separated list of prefixes to remove from player names before displaying in the tracker & teaminfo.",
       "group-id": "40",
-      "remarks": "Useful if one team has clan prefixes that stop the names appearing fully",
+      "remarks": "Useful if one team has clan prefixes that stop the names appearing fully.",
       "type": "string"
     },
     "hud_net_align_x": {
-      "desc": "Sets horizontal align of net statistics",
+      "desc": "Sets horizontal align of net statistics.",
       "group-id": "19",
       "type": "string"
     },
     "hud_net_align_y": {
-      "desc": "Sets vertical align of net statistics",
+      "desc": "Sets vertical align of net statistics.",
       "group-id": "19",
       "type": "string"
     },
     "hud_net_frame": {
-      "desc": "Sets frame visibility and style for net statistics",
+      "desc": "Sets frame visibility and style for net statistics.",
       "group-id": "19",
       "type": "float"
     },
@@ -10264,52 +10418,52 @@
       "type": "float"
     },
     "hud_net_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_net_period": {
-      "desc": "Sets period for updating net statistics",
+      "desc": "Sets period for updating net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_net_place": {
-      "desc": "Sets relative positioning for net statistics",
+      "desc": "Sets relative positioning for net statistics.",
       "group-id": "19",
       "type": "string"
     },
     "hud_net_pos_x": {
-      "desc": "Sets horizontal position of net statistics",
+      "desc": "Sets horizontal position of net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_net_pos_y": {
-      "desc": "Sets vertical position of net statistics",
+      "desc": "Sets vertical position of net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_net_show": {
-      "desc": "Switches showing of net statistics",
+      "desc": "Switches showing of net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_align_x": {
-      "desc": "Sets horizontal align of everything about net",
+      "desc": "Sets horizontal align of everything about net.",
       "group-id": "19",
       "type": "string"
     },
     "hud_netgraph_align_y": {
-      "desc": "Sets vertical align of everything about net",
+      "desc": "Sets vertical align of everything about net.",
       "group-id": "19",
       "type": "string"
     },
     "hud_netgraph_alpha": {
-      "desc": "Sets transparency level of everything about net",
+      "desc": "Sets transparency level of everything about net.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_frame": {
-      "desc": "Sets frame visibility and style for everything about net",
+      "desc": "Sets frame visibility and style for everything about net.",
       "group-id": "19",
       "type": "float"
     },
@@ -10319,7 +10473,7 @@
       "type": "string"
     },
     "hud_netgraph_height": {
-      "desc": "Sets vertical size of everything about net",
+      "desc": "Sets vertical size of everything about net.",
       "group-id": "19",
       "type": "float"
     },
@@ -10333,57 +10487,57 @@
       "type": "float"
     },
     "hud_netgraph_lostscale": {
-      "desc": "lets you cut down those red, yellow, blue and gray bars, which are always full-height; possible values are the range from 0 to 1",
+      "desc": "lets you cut down those red, yellow, blue and gray bars, which are always full-height.\nPossible values are the range from 0 to 1.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_netgraph_place": {
-      "desc": "Sets relative positioning for everything about net",
+      "desc": "Sets relative positioning for everything about net.",
       "group-id": "19",
       "type": "string"
     },
     "hud_netgraph_ploss": {
-      "desc": "print packet loss or not everything about net",
+      "desc": "print packet loss or not everything about net.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_pos_x": {
-      "desc": "Sets horizontal position of everything about net",
+      "desc": "Sets horizontal position of everything about net.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_pos_y": {
-      "desc": "Sets vertical position of everything about net",
+      "desc": "Sets vertical position of everything about net.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_scale": {
-      "desc": "Sets size of everything about net",
+      "desc": "Sets size of everything about net.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_show": {
-      "desc": "Switches showing of everything about net",
+      "desc": "Switches showing of everything about net.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_swap_x": {
-      "desc": "reverse horizontally, like for placing at left edge of the screen",
+      "desc": "reverse horizontally, like for placing at left edge of the screen.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_swap_y": {
-      "desc": "reverse vertically, like for top edge",
+      "desc": "reverse vertically, like for top edge.",
       "group-id": "19",
       "type": "float"
     },
     "hud_netgraph_width": {
-      "desc": "Sets horizontal size of everything about net",
+      "desc": "Sets horizontal size of everything about net.",
       "group-id": "19",
       "type": "float"
     },
@@ -10536,17 +10690,17 @@
       "type": ""
     },
     "hud_pent_align_x": {
-      "desc": "Sets horizontal align of pentagram icon",
+      "desc": "Sets horizontal align of pentagram icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_pent_align_y": {
-      "desc": "Sets vertical align of pentagram icon",
+      "desc": "Sets vertical align of pentagram icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_pent_frame": {
-      "desc": "Sets frame visibility and style for pentagram icon",
+      "desc": "Sets frame visibility and style for pentagram icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -10560,57 +10714,57 @@
       "type": "float"
     },
     "hud_pent_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_pent_place": {
-      "desc": "Sets relative positioning for pentagram icon",
+      "desc": "Sets relative positioning for pentagram icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_pent_pos_x": {
-      "desc": "Sets horizontal position of pentagram icon",
+      "desc": "Sets horizontal position of pentagram icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_pent_pos_y": {
-      "desc": "Sets vertical position of pentagram icon",
+      "desc": "Sets vertical position of pentagram icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_pent_scale": {
-      "desc": "Sets size of pentagram icon",
+      "desc": "Sets size of pentagram icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_pent_show": {
-      "desc": "Switches showing of pentagram icon",
+      "desc": "Switches showing of pentagram icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_pent_style": {
-      "desc": "Switches graphical style of pentagram icon",
+      "desc": "Switches graphical style of pentagram icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ping_align_x": {
-      "desc": "Sets horizontal align of small net statistics",
+      "desc": "Sets horizontal align of small net statistics.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ping_align_y": {
-      "desc": "Sets vertical align of small net statistics",
+      "desc": "Sets vertical align of small net statistics.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ping_blink": {
-      "desc": "Enable yellow blinking dot, which shows when your ping is recalculated",
+      "desc": "Enable yellow blinking dot, which shows when your ping is recalculated.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ping_frame": {
-      "desc": "Sets frame visibility and style for small net statistics",
+      "desc": "Sets frame visibility and style for small net statistics.",
       "group-id": "19",
       "type": "float"
     },
@@ -10624,7 +10778,7 @@
       "type": "float"
     },
     "hud_ping_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -10634,42 +10788,42 @@
       "type": "float"
     },
     "hud_ping_place": {
-      "desc": "Sets relative positioning for small net statistics",
+      "desc": "Sets relative positioning for small net statistics.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ping_pos_x": {
-      "desc": "Sets horizontal position of small net statistics",
+      "desc": "Sets horizontal position of small net statistics;",
       "group-id": "19",
       "type": "float"
     },
     "hud_ping_pos_y": {
-      "desc": "Sets vertical position of small net statistics",
+      "desc": "Sets vertical position of small net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ping_show": {
-      "desc": "Switches showing of small net statistics",
+      "desc": "Switches showing of small net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ping_show_dev": {
-      "desc": "Switches showing of small net statistics",
+      "desc": "Switches showing of small net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ping_show_max": {
-      "desc": "Switches showing of small net statistics",
+      "desc": "Switches showing of small net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ping_show_min": {
-      "desc": "Switches showing of small net statistics",
+      "desc": "Switches showing of small net statistics.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ping_show_pl": {
-      "desc": "Switches showing of small net statistics",
+      "desc": "Switches showing of small net statistics.",
       "group-id": "19",
       "type": "float"
     },
@@ -10693,17 +10847,17 @@
       ]
     },
     "hud_quad_align_x": {
-      "desc": "Sets horizontal align of quad icon",
+      "desc": "Sets horizontal align of quad icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_quad_align_y": {
-      "desc": "Sets vertical align of quad icon",
+      "desc": "Sets vertical align of quad icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_quad_frame": {
-      "desc": "Sets frame visibility and style for quad icon",
+      "desc": "Sets frame visibility and style for quad icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -10717,37 +10871,37 @@
       "type": "float"
     },
     "hud_quad_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_quad_place": {
-      "desc": "Sets relative positioning for quad icon",
+      "desc": "Sets relative positioning for quad icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_quad_pos_x": {
-      "desc": "Sets horizontal position of quad icon",
+      "desc": "Sets horizontal position of quad icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_quad_pos_y": {
-      "desc": "Sets vertical position of quad icon",
+      "desc": "Sets vertical position of quad icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_quad_scale": {
-      "desc": "Sets size of quad icon",
+      "desc": "Sets size of quad icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_quad_show": {
-      "desc": "Switches showing of quad icon",
+      "desc": "Switches showing of quad icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_quad_style": {
-      "desc": "Switches graphical style of quad icon",
+      "desc": "Switches graphical style of quad icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -10792,7 +10946,7 @@
       ]
     },
     "hud_radar_frame": {
-      "desc": "Opacity of the background of the radar HUD element",
+      "desc": "Opacity of the background of the radar HUD element.",
       "group-id": "19",
       "type": "float"
     },
@@ -10871,13 +11025,13 @@
       "type": "float"
     },
     "hud_radar_itemfilter": {
-      "desc": "Decides what items should be shown on the radar. Such as ammo, health packs, backpacks and powerups",
+      "desc": "Decides what items should be shown on the radar. Such as ammo, health packs, backpacks and powerups.",
       "group-id": "19",
       "remarks": "Any character/whitespace can be used as a delimiter. Make sure you enter the value between quotes if you use whitespaces.",
       "type": "string",
       "values": [
         {
-          "description": "Valid values: backpack,health,armor,rockets,nails,cells,shells,quad,pent,ring,suit,mega",
+          "description": "Valid values: backpack, health, armor, rockets, nails, cells, shells, quad, pent, ring, suit, mega",
           "name": "*"
         }
       ]
@@ -10918,7 +11072,7 @@
       ]
     },
     "hud_radar_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -10935,28 +11089,28 @@
       ]
     },
     "hud_radar_place": {
-      "desc": "Placement of the radar HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
+      "desc": "Placement of the radar HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
     },
     "hud_radar_player_size": {
-      "desc": "The radius in of the players on the radar. ",
+      "desc": "The radius in of the players on the radar.",
       "group-id": "19",
       "remarks": "If show_height is turned on, then this ofcourse depends on what height the player is located at.",
       "type": "float"
     },
     "hud_radar_pos_x": {
-      "desc": "Horizontal relative position of the radar HUD element",
+      "desc": "Horizontal relative position of the radar HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_radar_pos_y": {
-      "desc": "Vertical relative position of the radar HUD element",
+      "desc": "Vertical relative position of the radar HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_radar_show": {
-      "desc": "Visibility of the radar HUD element",
+      "desc": "Visibility of the radar HUD element.",
       "group-id": "19",
       "type": "boolean",
       "values": [
@@ -11056,17 +11210,17 @@
       "type": "integer"
     },
     "hud_ring_align_x": {
-      "desc": "Sets horizontal align of ring icon",
+      "desc": "Sets horizontal align of ring icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ring_align_y": {
-      "desc": "Sets vertical align of ring icon",
+      "desc": "Sets vertical align of ring icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ring_frame": {
-      "desc": "Sets frame visibility and style for ring icon",
+      "desc": "Sets frame visibility and style for ring icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -11080,37 +11234,37 @@
       "type": "float"
     },
     "hud_ring_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_ring_place": {
-      "desc": "Sets relative positioning for ring icon",
+      "desc": "Sets relative positioning for ring icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_ring_pos_x": {
-      "desc": "Sets horizontal position of ring icon",
+      "desc": "Sets horizontal position of ring icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ring_pos_y": {
-      "desc": "Sets vertical position of ring icon",
+      "desc": "Sets vertical position of ring icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ring_scale": {
-      "desc": "Sets size of ring icon",
+      "desc": "Sets size of ring icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ring_show": {
-      "desc": "Switches showing of ring icon",
+      "desc": "Switches showing of ring icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_ring_style": {
-      "desc": "Switches graphical style of ring icon",
+      "desc": "Switches graphical style of ring icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -11205,8 +11359,17 @@
     "hud_score_bar_style": {
       "desc": "Style of score_bar HUD element.",
       "group-id": "19",
-      "remarks": "0 - use small chars (conchars)\n1 - use big chars (num* and anum* images)",
-      "type": "integer"
+      "type": "integer",
+      "values": [
+        {
+          "description": "Use small characterss (conchars)",
+          "name": "0"
+        },
+        {
+          "description": "Use big characters (num* and anum* images)",
+          "name": "1"
+        }
+      ]
     },
     "hud_score_difference_align": {
       "group-id": "19",
@@ -11473,7 +11636,7 @@
       "type": "float"
     },
     "hud_sigil1_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -11508,17 +11671,17 @@
       "type": "float"
     },
     "hud_sigil2_align_x": {
-      "desc": "Sets horizontal align of sigil 2 icon",
+      "desc": "Sets horizontal align of sigil 2 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil2_align_y": {
-      "desc": "Sets vertical align of sigil 2 icon",
+      "desc": "Sets vertical align of sigil 2 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil2_frame": {
-      "desc": "Sets frame visibility and style for sigil 2 icon",
+      "desc": "Sets frame visibility and style for sigil 2 icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -11532,52 +11695,52 @@
       "type": "float"
     },
     "hud_sigil2_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_sigil2_place": {
-      "desc": "Sets relative positioning for sigil 2 icon",
+      "desc": "Sets relative positioning for sigil 2 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil2_pos_x": {
-      "desc": "Sets horizontal position of sigil 2 icon",
+      "desc": "Sets horizontal position of sigil 2 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil2_pos_y": {
-      "desc": "Sets vertical position of sigil 2 icon",
+      "desc": "Sets vertical position of sigil 2 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil2_scale": {
-      "desc": "Sets size of sigil 2 icon",
+      "desc": "Sets size of sigil 2 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil2_show": {
-      "desc": "Switches showing of sigil 2 icon",
+      "desc": "Switches showing of sigil 2 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil2_style": {
-      "desc": "Switches graphical style of sigil 2 icon",
+      "desc": "Switches graphical style of sigil 2 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil3_align_x": {
-      "desc": "Sets horizontal align of sigil 3 icon",
+      "desc": "Sets horizontal align of sigil 3 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil3_align_y": {
-      "desc": "Sets vertical align of sigil 3 icon",
+      "desc": "Sets vertical align of sigil 3 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil3_frame": {
-      "desc": "Sets frame visibility and style for sigil 3 icon",
+      "desc": "Sets frame visibility and style for sigil 3 icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -11591,52 +11754,52 @@
       "type": "float"
     },
     "hud_sigil3_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_sigil3_place": {
-      "desc": "Sets relative positioning for sigil 3 icon",
+      "desc": "Sets relative positioning for sigil 3 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil3_pos_x": {
-      "desc": "Sets horizontal position of sigil 3 icon",
+      "desc": "Sets horizontal position of sigil 3 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil3_pos_y": {
-      "desc": "Sets vertical position of sigil 3 icon",
+      "desc": "Sets vertical position of sigil 3 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil3_scale": {
-      "desc": "Sets size of sigil 3 icon",
+      "desc": "Sets size of sigil 3 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil3_show": {
-      "desc": "Switches showing of sigil 3 icon",
+      "desc": "Switches showing of sigil 3 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil3_style": {
-      "desc": "Switches graphical style of sigil 3 icon",
+      "desc": "Switches graphical style of sigil 3 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil4_align_x": {
-      "desc": "Sets horizontal align of sigil 4 icon",
+      "desc": "Sets horizontal align of sigil 4 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil4_align_y": {
-      "desc": "Sets vertical align of sigil 4 icon",
+      "desc": "Sets vertical align of sigil 4 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil4_frame": {
-      "desc": "Sets frame visibility and style for sigil 4 icon",
+      "desc": "Sets frame visibility and style for sigil 4 icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -11650,42 +11813,42 @@
       "type": "float"
     },
     "hud_sigil4_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_sigil4_place": {
-      "desc": "Sets relative positioning for sigil 4 icon",
+      "desc": "Sets relative positioning for sigil 4 icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_sigil4_pos_x": {
-      "desc": "Sets horizontal position of sigil 4 icon",
+      "desc": "Sets horizontal position of sigil 4 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil4_pos_y": {
-      "desc": "Sets vertical position of sigil 4 icon",
+      "desc": "Sets vertical position of sigil 4 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil4_scale": {
-      "desc": "Sets size of sigil 4 icon",
+      "desc": "Sets size of sigil 4 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil4_show": {
-      "desc": "Switches showing of sigil 4 icon",
+      "desc": "Switches showing of sigil 4 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sigil4_style": {
-      "desc": "Switches graphical style of sigil 4 icon",
+      "desc": "Switches graphical style of sigil 4 icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_sortrules_includeself": {
-      "desc": "Determines how the current player is sorted",
+      "desc": "Determines how the current player is sorted.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -11704,7 +11867,7 @@
       ]
     },
     "hud_sortrules_playersort": {
-      "desc": "Determines how players are sorted",
+      "desc": "Determines how players are sorted.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -11727,7 +11890,7 @@
       ]
     },
     "hud_sortrules_teamsort": {
-      "desc": "Determines how teams are sorted",
+      "desc": "Determines how teams are sorted.",
       "group-id": "19",
       "type": "enum",
       "values": [
@@ -11782,7 +11945,7 @@
       "type": "integer"
     },
     "hud_speed2_frame": {
-      "desc": "Opacity of the background of the speed2 HUD element",
+      "desc": "Opacity of the background of the speed2 HUD element.",
       "group-id": "19",
       "type": "float"
     },
@@ -11796,7 +11959,7 @@
       "type": "float"
     },
     "hud_speed2_opacity": {
-      "desc": "Sets the opacity of the speed2 hud item. ",
+      "desc": "Sets the opacity of the speed2 hud item.",
       "group-id": "19",
       "type": "float",
       "values": [
@@ -11807,7 +11970,7 @@
       ]
     },
     "hud_speed2_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -11835,17 +11998,17 @@
       ]
     },
     "hud_speed2_place": {
-      "desc": "Placement of the speed2 HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
+      "desc": "Placement of the speed2 HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
     },
     "hud_speed2_pos_x": {
-      "desc": "Horizontal relative position of the speed2 HUD element",
+      "desc": "Horizontal relative position of the speed2 HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_speed2_pos_y": {
-      "desc": "Vertical relative position of the speed2 HUD element",
+      "desc": "Vertical relative position of the speed2 HUD element.",
       "group-id": "19",
       "type": "integer"
     },
@@ -11861,7 +12024,7 @@
       ]
     },
     "hud_speed2_show": {
-      "desc": "Visibility of the speed2 HUD element",
+      "desc": "Visibility of the speed2 HUD element.",
       "group-id": "19",
       "type": "boolean",
       "values": [
@@ -11887,7 +12050,7 @@
       ]
     },
     "hud_speed2_xyz": {
-      "desc": "Base the speed calculation on up/down movement also. ",
+      "desc": "Base the speed calculation on up/down movement also.",
       "group-id": "19",
       "type": "boolean",
       "values": [
@@ -11902,12 +12065,12 @@
       ]
     },
     "hud_speed_align_x": {
-      "desc": "Sets horizontal align of your current speed",
+      "desc": "Sets horizontal align of your current speed.",
       "group-id": "19",
       "type": "string"
     },
     "hud_speed_align_y": {
-      "desc": "Sets vertical align of your current speed",
+      "desc": "Sets vertical align of your current speed.",
       "group-id": "19",
       "type": "string"
     },
@@ -11942,7 +12105,7 @@
       "type": "integer"
     },
     "hud_speed_frame": {
-      "desc": "Sets frame visibility and style for your current speed",
+      "desc": "Sets frame visibility and style for your current speed.",
       "group-id": "19",
       "type": "float"
     },
@@ -11972,27 +12135,27 @@
       ]
     },
     "hud_speed_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_speed_place": {
-      "desc": "Sets relative positioning for your current speed",
+      "desc": "Sets relative positioning for your current speed.",
       "group-id": "19",
       "type": "string"
     },
     "hud_speed_pos_x": {
-      "desc": "Sets horizontal position of your current speed",
+      "desc": "Sets horizontal position of your current speed.",
       "group-id": "19",
       "type": "float"
     },
     "hud_speed_pos_y": {
-      "desc": "Sets vertical position of your current speed",
+      "desc": "Sets vertical position of your current speed.",
       "group-id": "19",
       "type": "float"
     },
     "hud_speed_show": {
-      "desc": "Switches showing of your current speed",
+      "desc": "Switches showing of your current speed.",
       "group-id": "19",
       "type": "float"
     },
@@ -12071,17 +12234,17 @@
       "type": "float"
     },
     "hud_suit_align_x": {
-      "desc": "Sets horizontal align of suit icon",
+      "desc": "Sets horizontal align of suit icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_suit_align_y": {
-      "desc": "Sets vertical align of suit icon",
+      "desc": "Sets vertical align of suit icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_suit_frame": {
-      "desc": "Sets frame visibility and style for suit icon",
+      "desc": "Sets frame visibility and style for suit icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -12095,37 +12258,37 @@
       "type": "float"
     },
     "hud_suit_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_suit_place": {
-      "desc": "Sets relative positioning for suit icon",
+      "desc": "Sets relative positioning for suit icon.",
       "group-id": "19",
       "type": "string"
     },
     "hud_suit_pos_x": {
-      "desc": "Sets horizontal position of suit icon",
+      "desc": "Sets horizontal position of suit icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_suit_pos_y": {
-      "desc": "Sets vertical position of suit icon",
+      "desc": "Sets vertical position of suit icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_suit_scale": {
-      "desc": "Sets size of suit icon",
+      "desc": "Sets size of suit icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_suit_show": {
-      "desc": "Switches showing of suit icon",
+      "desc": "Switches showing of suit icon.",
       "group-id": "19",
       "type": "float"
     },
     "hud_suit_style": {
-      "desc": "Switches graphical style of suit icon",
+      "desc": "Switches graphical style of suit icon.",
       "group-id": "19",
       "type": "float"
     },
@@ -12326,7 +12489,7 @@
       ]
     },
     "hud_teamfrags_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -12515,7 +12678,7 @@
       "type": "string"
     },
     "hud_teamholdbar_frame": {
-      "desc": "Opacity of the background of the teamholdbar HUD element",
+      "desc": "Opacity of the background of the teamholdbar HUD element.",
       "group-id": "19",
       "type": "float"
     },
@@ -12562,27 +12725,27 @@
       "type": "float"
     },
     "hud_teamholdbar_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_teamholdbar_place": {
-      "desc": "Placement of the teamholdbar HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
+      "desc": "Placement of the teamholdbar HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
     },
     "hud_teamholdbar_pos_x": {
-      "desc": "Horizontal relative position of the teamholdbar HUD element",
+      "desc": "Horizontal relative position of the teamholdbar HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_teamholdbar_pos_y": {
-      "desc": "Vertical relative position of the teamholdbar HUD element",
+      "desc": "Vertical relative position of the teamholdbar HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_teamholdbar_show": {
-      "desc": "Visibility of the teamholdbar HUD element",
+      "desc": "Visibility of the teamholdbar HUD element.",
       "group-id": "19",
       "type": "boolean",
       "values": [
@@ -12659,7 +12822,7 @@
       "type": "string"
     },
     "hud_teamholdinfo_frame": {
-      "desc": "Opacity of the background of the teamholdinfo HUD element",
+      "desc": "Opacity of the background of the teamholdinfo HUD element.",
       "group-id": "19",
       "type": "float"
     },
@@ -12718,27 +12881,27 @@
       "type": "float"
     },
     "hud_teamholdinfo_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_teamholdinfo_place": {
-      "desc": "Placement of the teamholdinfo HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info",
+      "desc": "Placement of the teamholdinfo HUD element. HUD elements can be place into various screen areas or other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
     },
     "hud_teamholdinfo_pos_x": {
-      "desc": "Horizontal relative position of the teamholdinfo HUD element",
+      "desc": "Horizontal relative position of the teamholdinfo HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_teamholdinfo_pos_y": {
-      "desc": "Vertical relative position of the teamholdinfo HUD element",
+      "desc": "Vertical relative position of the teamholdinfo HUD element.",
       "group-id": "19",
       "type": "integer"
     },
     "hud_teamholdinfo_show": {
-      "desc": "Visibility of the teamholdinfo HUD element",
+      "desc": "Visibility of the teamholdinfo HUD element.",
       "group-id": "19",
       "type": "boolean",
       "values": [
@@ -12843,7 +13006,7 @@
       "type": ""
     },
     "hud_teaminfo_show": {
-      "desc": "Display information about your team and optionally enemies",
+      "desc": "Display information about your team and optionally enemies.",
       "group-id": "19",
       "remarks": "Enemy information can be enabled through hud_teaminfo_show_enemies 1.",
       "type": "boolean",
@@ -12964,7 +13127,7 @@
       "type": "float"
     },
     "hud_tracking_order": {
-      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info",
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
       "group-id": "19",
       "type": "integer"
     },
@@ -13080,7 +13243,7 @@
     },
     "ignore_mode": {
       "default": "0",
-      "desc": "Someone is on your ignore list, you won't see any messagemode (/say hello) messages from them \n(even if they are a spec).",
+      "desc": "Someone is on your ignore list, you won't see any messagemode (/say hello) messages from them (even if they are a spec).",
       "group-id": "3",
       "type": "boolean",
       "values": [
@@ -13166,19 +13329,19 @@
     },
     "image_jpeg_quality_level": {
       "default": "75",
-      "desc": "You can set quality of jpeg screenshots with 'image_jpeg_quality_level x' \nwhere x is an integer from 0 to 100 inclusive. The larger x is, \nthe better the quality of a jpeg screenshot, but also the bigger the size.",
+      "desc": "You can set quality of jpeg screenshots with 'image_jpeg_quality_level x' where x is an integer from 0 to 100 inclusive.\nThe larger x is, the better the quality of a jpeg screenshot, but also the bigger the size.",
       "group-id": "41",
       "type": "float"
     },
     "image_png_compression_level": {
       "default": "1",
-      "desc": "You can set the amount of png compression with 'image_png_compression_level x' \nwhere x is an integer from 0 to 9 inclusive. 0 gives no compression and 9 gives \nmaximum compression (and slowest writing time).",
+      "desc": "You can set the amount of png compression with 'image_png_compression_level x' where x is an integer from 0 to 9 inclusive.\n0 gives no compression and 9 gives maximum compression (and slowest writing time).",
       "group-id": "41",
       "type": "float"
     },
     "in_builtinkeymap": {
       "default": "0",
-      "desc": "Allows you to use old Quake keyboard mapping",
+      "desc": "Allows you to use old Quake keyboard mapping.",
       "group-id": "9",
       "type": "boolean",
       "values": [
@@ -13209,15 +13372,15 @@
       ]
     },
     "in_di_bufsize": {
-      "desc": "Size of the direct input buffer",
+      "desc": "Size of the direct input buffer.",
       "group-id": "28",
-      "remarks": "On some circumstances the default size does not have to be sufficient",
+      "remarks": "On some circumstances the default size does not have to be sufficient.",
       "type": "integer"
     },
     "in_evdevice": {
-      "desc": "Specify device for evdev mouse. Should be absolute path like /dev/input/event0\nuse in_evdevlist command to get lost of devices",
+      "desc": "Specify device for evdev mouse.\nShould be absolute path like /dev/input/event0.\nUse in_evdevlist command to get lost of devices.",
       "group-id": "28",
-      "remarks": "You should have read access to your device.\nsudo chmod 644 /dev/input/event* should help you if you have trouble",
+      "remarks": "You should have read access to your device.\nsudo chmod 644 /dev/input/event* should help you if you have trouble.",
       "type": "string",
       "values": [
         {
@@ -13228,7 +13391,7 @@
     },
     "in_grab_windowed_mouse": {
       "default": "1",
-      "desc": "If set, will grab mouse input when not fullscreen",
+      "desc": "If set, will grab mouse input when not fullscreen.",
       "group-id": "11",
       "type": "boolean"
     },
@@ -13240,13 +13403,13 @@
     },
     "in_ignore_unfocused_keyb": {
       "default": "0",
-      "desc": "If set, will ignore keyboard events received immediately after regaining focus.  Should stop shortcut keys from firing in-game",
+      "desc": "If set, will ignore keyboard events received immediately after regaining focus.  Should stop shortcut keys from firing in-game.",
       "group-id": "11",
       "remarks": "X11 systems only.",
       "type": "boolean"
     },
     "in_m_os_parameters": {
-      "desc": "Allows you to use your system mouse settings in the client",
+      "desc": "Allows you to use your system mouse settings in the client.",
       "group-id": "28",
       "type": "enum",
       "values": [
@@ -13269,7 +13432,7 @@
       ]
     },
     "in_m_smooth": {
-      "desc": "Enables advanced mouse smoothing. You have to be using Direct Input for this to work.",
+      "desc": "Enables advanced mouse smoothing.\nYou have to be using Direct Input for this to work.",
       "group-id": "28",
       "type": "boolean",
       "values": [
@@ -13284,7 +13447,7 @@
       ]
     },
     "in_mmt": {
-      "desc": "Multithreaded mouse.\nFor most users in_mmt 1 + evdev gives the most smooth input",
+      "desc": "Multithreaded mouse.\nFor most users in_mmt 1 + evdev gives the most smooth input.",
       "group-id": "28",
       "remarks": "Linux only and evdev (in_mouse 3) only.",
       "type": "boolean",
@@ -13325,9 +13488,9 @@
     },
     "in_raw": {
       "default": "1",
-      "desc": "Whether or not ezQuake will use raw input to sample mouse events",
+      "desc": "Whether or not ezQuake will use raw input to sample mouse events.",
       "group-id": "11",
-      "remarks": "It is recommended to leave this set",
+      "remarks": "It is recommended to leave this set.",
       "type": "boolean",
       "values": [
         {
@@ -13341,7 +13504,7 @@
       ]
     },
     "in_raw_allbuttons": {
-      "desc": "Forces RAW Input handler to treat more incoming signals as mouse buttons. Helps if you cannot get some mouse buttons working in the game.",
+      "desc": "Forces RAW Input handler to treat more incoming signals as mouse buttons.\nHelps if you cannot get some mouse buttons working in the game.",
       "group-id": "28",
       "type": "boolean",
       "values": [
@@ -13359,7 +13522,7 @@
       "default": "2",
       "desc": "Controls under which mode(s) the cursor will be released back to the operating system when not fullscreen.",
       "group-id": "11",
-      "remarks": "To specify more then one mode, add the values together.\n\nTo always release the cursor, set in_grab_windowed_mouse 0",
+      "remarks": "To specify more than one mode, add the values together.\n\nTo always release the cursor, set in_grab_windowed_mouse 0.",
       "type": "enum",
       "values": [
         {
@@ -13438,7 +13601,7 @@
       ]
     },
     "keymap_name": {
-      "desc": "This holds the name of the current keymappings; it has (currently) only informational purposes. If no keymapping is active, it will contain the name \"Default\". If a keymapping will be active and no name has been set, \"Custom\" will be used as name. It can easily be set with \"keymap_name <layoutname>\"",
+      "desc": "This holds the name of the current keymappings; it has (currently) only informational purposes.\nIf no keymapping is active, it will contain the name \"Default\".\nIf a keymapping will be active and no name has been set, \"Custom\" will be used as name. It can easily be set with \"keymap_name <layoutname>\"",
       "group-id": "28",
       "type": "float"
     },
@@ -13486,25 +13649,25 @@
     },
     "lookstrafe": {
       "default": "0",
-      "desc": "This variable toggles the automatic strafing when the +klook command is used.\nWhen set to \"1\" and the player used the +klook command, the keys that are bound \nto the +left and +right commands will now act as if they were bound to +moveleft \nand +moveright. This command was put it in order to allow keyboard player to \ncombine the +strafe and +klook commands into one.\nThis command also has effect on the mouse controls. When set to \"1\" moving the \nmouse left and right will make the player move left and right instead of making \nhim turn left and right.",
+      "desc": "This variable toggles the automatic strafing when the +klook command is used.\nWhen set to \"1\" and the player used the +klook command, the keys that are bound to the +left and +right commands will now act as if they were bound to +moveleft and +moveright.\nThis command was put it in order to allow keyboard player to combine the +strafe and +klook commands into one.\nThis command also has effect on the mouse controls. When set to \"1\" moving the mouse left and right will make the player move left and right instead of making him turn left and right.",
       "group-id": "10",
       "type": "float"
     },
     "m_accel": {
       "default": "0",
-      "desc": "Values >0 will amplify mouse movement proportional to velocity. Small values have great effect. A lot of good Quake Live players use around the 0.1-0.2 mark, but this depends on your mouse CPI and polling rate.",
+      "desc": "Values >0 will amplify mouse movement proportional to velocity.\nSmall values have great effect.\nA lot of good Quake Live players use around the 0.1-0.2 mark, but this depends on your mouse CPI and polling rate.",
       "group-id": "11",
       "type": "float"
     },
     "m_accel_offset": {
       "default": "0",
-      "desc": "Acceleration will not be active until the mouse movement exceeds this speed (counts per millisecond). Negative values are supported, which has the effect of causing higher rates of acceleration to happen at lower velocities.",
+      "desc": "Acceleration will not be active until the mouse movement exceeds this speed (counts per millisecond).\nNegative values are supported, which has the effect of causing higher rates of acceleration to happen at lower velocities.",
       "group-id": "11",
       "type": "float"
     },
     "m_accel_power": {
       "default": "2",
-      "desc": "Values 1 or below are dumb. 2 is linear and the default. Above 2 begins to amplify exponentially and you will get more acceleration at higher velocities. Great if you want low accel for slow movements, and high accel for fast movements. Good in combination with a sensitivity cap (m_accel_senscap)",
+      "desc": "Values 1 or below are dumb.\n2 is linear and the default.\nAbove 2 begins to amplify exponentially and you will get more acceleration at higher velocities. Great if you want low accel for slow movements, and high accel for fast movements. Good in combination with a sensitivity cap (m_accel_senscap)",
       "group-id": "11",
       "type": "float"
     },
@@ -13516,7 +13679,7 @@
     },
     "m_filter": {
       "default": "0",
-      "desc": "This variable toggles mouse input filtering. When set to \"1\", the values which\nare received from the mouse's input will first be averaged together and then \nthat value will be used in the game. \nThe reason for this command is that some mice had problems with sending sporadic\ncoordinates which make the input from the mouse jerky, also when using a serial \nor PS/2 mouse, the Windows operating system will only sample mouse input every \n25ms, that is 40 times a second (for USB mice the sample rate is 125 Hz, that is\nevery 8 ms). When set to \"1\" this variable will smooth out the input but it will \ncause latency between the movement of the mouse and the actual response in the \ngame. When using a PS/2 mouse it is thus first recommended to try to increase \nthe sampling rate either by changing it via your mouse driver or by using the \nps2rate program which can be downloaded at ps2rate homepage . \nIf you are playing the game at frame rates above 40 FPS and if you can't \nincrease the sampling rate of your PS/2 rate or if you are playing with a serial \nmouse it is recommended that you enable this toggle.",
+      "desc": "This variable toggles mouse input filtering.\nWhen set to \"1\", the values which are received from the mouse's input will first be averaged together and then that value will be used in the game.\nThe reason for this command is that some mice had problems with sending sporadic coordinates which make the input from the mouse jerky, also when using a serial or PS/2 mouse, the Windows operating system will only sample mouse input every 25ms, that is 40 times a second (for USB mice the sample rate is 125 Hz, that is every 8 ms).\nWhen set to \"1\" this variable will smooth out the input but it will cause latency between the movement of the mouse and the actual response in the game.\nWhen using a PS/2 mouse it is thus first recommended to try to increase the sampling rate either by changing it via your mouse driver or by using the ps2rate program which can be downloaded at ps2rate homepage.\nIf you are playing the game at frame rates above 40 FPS and if you can't increase the sampling rate of your PS/2 rate or if you are playing with a serial mouse it is recommended that you enable this toggle.",
       "group-id": "11",
       "type": "float"
     },
@@ -13536,13 +13699,13 @@
     },
     "m_forward": {
       "default": "1",
-      "desc": "This variable controls how fast the player should move forward and back when the \nmouse is moved forward and back. This command has no effect if the +mlook \ncommand is in effect because when the mouse is moved forward and back the \nplayer looks up and down instead of moving forward and back. Some players might \nwant to set this variable to \"0\" if they happen not to use +mlook constantly and \nthey only want to use the mouse to turn the player. Setting this variable to \"0\"\nwill prevent the inadvertent movement of the player forward and back while \ntrying to make precise turns with the mouse.",
+      "desc": "This variable controls how fast the player should move forward and back when the mouse is moved forward and back.\nThis command has no effect if the +mlook command is in effect because when the mouse is moved forward and back the player looks up and down instead of moving forward and back.\nSome players might want to set this variable to \"0\" if they happen not to use +mlook constantly and they only want to use the mouse to turn the player.\nSetting this variable to \"0\" will prevent the inadvertent movement of the player forward and back while trying to make precise turns with the mouse.",
       "group-id": "11",
       "type": "float"
     },
     "m_pitch": {
       "default": "0.022",
-      "desc": "This variable sets the level of precision when the mouse is used to make the \nplayer look up and down while the +mlook command is in effect. By default this \nvariable is set in such a way that moving the mouse forward makes the player \nlook up and moving the mouse backward makes the player look down. Some people \nprefer to have this movement inverted just like it is inverted for airplane \ncontrols. If you wish to use this inverted mouse movement then you should set \nthis variable to a negative value (for example \"-0.022\"). It is a matter of \npreference which movement method is used by players. Also lowering the value \nfor this variable will increase the level of precision when the mouse is used \nto make the player look up and down. This variable can be used separately from \nthe sensitivity variable to provide greater control over the mouse sensitivity \nfor movement along the pitch. It is advisable to keep the value for this \nvariable constant at 0.022 or -0.022 and instead use the sensitivity variable \nto change the overall sensitivity of the mouse. Also, some script writers lower \nthe value for this variable along with a lowered value for the fov variable in \norder to provide more precision when the fov variable is used to zoom.",
+      "desc": "This variable sets the level of precision when the mouse is used to make the player look up and down while the +mlook command is in effect.\nBy default this variable is set in such a way that moving the mouse forward makes the player look up and moving the mouse backward makes the player look down.\nSome people prefer to have this movement inverted just like it is inverted for airplane controls.\nIf you wish to use this inverted mouse movement then you should set this variable to a negative value (for example \"-0.022\"). It is a matter of preference which movement method is used by players.\nAlso lowering the value for this variable will increase the level of precision when the mouse is used to make the player look up and down.\nThis variable can be used separately from the sensitivity variable to provide greater control over the mouse sensitivity for movement along the pitch. It is advisable to keep the value for this variable constant at 0.022 or -0.022 and instead use the sensitivity variable to change the overall sensitivity of the mouse.\nAlso, some script writers lower the value for this variable along with a lowered value for the fov variable in order to provide more precision when the fov variable is used to zoom.",
       "group-id": "11",
       "type": "float"
     },
@@ -13568,19 +13731,19 @@
     },
     "m_side": {
       "default": "0.8",
-      "desc": "When the +strafe command is active or when \"lookspring\" is set to \"1\" this \nvariable is used to control the sensitivity when the mouse is moved left and \nright to make the player move left and right.",
+      "desc": "When the +strafe command is active or when \"lookspring\" is set to \"1\" this variable is used to control the sensitivity when the mouse is moved left and right to make the player move left and right.",
       "group-id": "11",
       "type": "float"
     },
     "m_yaw": {
       "default": "0.022",
-      "desc": "This variable controls how fast the player turns left and right when the mouse \nis moved left and right. It is recommended that this variable be left alone and\ninstead the \"sensitivity\" variable is used to change the level of precision. \nIf you set this variable to a negative value you will reverse the mouse \nmovement. Some script writers use this variable to increase the level of \nprecision when the \"fov\" variable is used to zoom the screen.",
+      "desc": "This variable controls how fast the player turns left and right when the mouse is moved left and right.\nIt is recommended that this variable be left alone and instead the \"sensitivity\" variable is used to change the level of precision.\nIf you set this variable to a negative value you will reverse the mouse movement.\nSome script writers use this variable to increase the level of precision when the \"fov\" variable is used to zoom the screen.",
       "group-id": "11",
       "type": "float"
     },
     "mapname": {
       "default": "",
-      "desc": "Contains the name of the current map",
+      "desc": "Contains the name of the current map.",
       "group-id": "2",
       "type": "string"
     },
@@ -13681,7 +13844,7 @@
     },
     "match_auto_sshot": {
       "default": "0",
-      "desc": "Set to 1 to automatically take a screenshot of the final scoreboard when a match ends. If your console is down or you are in the menus, then the client will remove the console/menu for a split second so it can take a screenshot of the scoreboard without any interference.",
+      "desc": "Set to 1 to automatically take a screenshot of the final scoreboard when a match ends.\nIf your console is down or you are in the menus, then the client will remove the console/menu for a split second so it can take a screenshot of the scoreboard without any interference.",
       "group-id": "16",
       "type": "boolean",
       "values": [
@@ -13714,7 +13877,7 @@
     },
     "match_challenge": {
       "default": "0",
-      "desc": "When enabled, sends announcements to duel ladder server about match start and match end. Can be activated by special startup *.qw file or by opening special qw: URL.",
+      "desc": "When enabled, sends announcements to duel ladder server about match start and match end.\nCan be activated by special startup *.qw file or by opening special qw: URL.",
       "group-id": "16",
       "type": "boolean",
       "values": [
@@ -13943,7 +14106,7 @@
     },
     "maxclients": {
       "default": "24",
-      "desc": "Highest number of players allowed on the server",
+      "desc": "Highest number of players allowed on the server.",
       "group-id": "43",
       "type": "integer"
     },
@@ -13954,7 +14117,7 @@
     },
     "maxspectators": {
       "default": "8",
-      "desc": "Highest number of spectators allowed to connect to the server",
+      "desc": "Highest number of spectators allowed to connect to the server.",
       "group-id": "43",
       "type": "integer"
     },
@@ -13965,7 +14128,7 @@
     },
     "menu_advanced": {
       "default": "0",
-      "desc": "Shows/hides advanced options entries in the Options menu",
+      "desc": "Shows/hides advanced options entries in the Options menu.",
       "group-id": "17",
       "type": "boolean",
       "values": [
@@ -13981,13 +14144,13 @@
     },
     "menu_botmatch_gamedir": {
       "default": "fbca",
-      "desc": "The gamedir that ezQuake will switch to when starting a botmatch through the multiplayer menu",
+      "desc": "The gamedir that ezQuake will switch to when starting a botmatch through the multiplayer menu.",
       "group-id": "17",
       "type": "string"
     },
     "menu_botmatch_mod_old": {
       "default": "1",
-      "desc": "If set, starting a botmatch through multiplayer menu will disable features that cause problems for older mods that spawn bots as non-clients",
+      "desc": "If set, starting a botmatch through multiplayer menu will disable features that cause problems for older mods that spawn bots as non-clients.",
       "group-id": "17",
       "type": "boolean"
     },
@@ -14071,7 +14234,7 @@
     },
     "mtu": {
       "default": "",
-      "desc": "Maximum transmission unit size.  Suggests maximum packet size to server, if supported",
+      "desc": "Maximum transmission unit size.\nSuggests maximum packet size to server, if supported.",
       "group-id": "37",
       "type": "integer"
     },
@@ -14118,9 +14281,9 @@
     },
     "mvd_autotrack": {
       "default": "0",
-      "desc": "Turns auto-tracking function ON / OFF. This feature can be used while watching MultiView Demo. The client will choose and switch to the best player point of view using appropriate algorithm.",
+      "desc": "Turns auto-tracking function ON / OFF.\nThis feature can be used while watching MultiView Demo. The client will choose and switch to the best player point of view using appropriate algorithm.",
       "group-id": "20",
-      "remarks": "You can change the switching algorithm properties using mvd_autotrack_1on1, mvd_autotrack_2on2, etc. variables. The setting no. 4. cannot be customized and is independent on other autotrack client settings, except of mvd_autotrack_lockteam",
+      "remarks": "You can change the switching algorithm properties using mvd_autotrack_1on1, mvd_autotrack_2on2, etc. variables. The setting no. 4. cannot be customized and is independent on other autotrack client settings, except of mvd_autotrack_lockteam.",
       "type": "enum",
       "values": [
         {
@@ -14140,7 +14303,7 @@
           "name": "3"
         },
         {
-          "description": "Simple algorithm which prefers pent+rl over quad+rl, quad+rl over pent, quad over noquad, weapon over no weapon player; cannot be customized",
+          "description": "Simple algorithm which prefers pent+rl over quad+rl, quad+rl over pent, quad over noquad, weapon over no weapon player\nCannot be customized",
           "name": "4"
         }
       ]
@@ -14270,21 +14433,21 @@
     },
     "mvd_info_x": {
       "default": "0",
-      "desc": "You can adjust horizontal placement of Players' info table",
+      "desc": "You can adjust horizontal placement of Players' info table.",
       "group-id": "20",
       "remarks": "See scr_mvdinfo and scr_mvdinfo_setup description for more details.",
       "type": "float"
     },
     "mvd_info_y": {
       "default": "0",
-      "desc": "You can adjust vertical placement of Players' info table",
+      "desc": "You can adjust vertical placement of Players' info table.",
       "group-id": "20",
       "remarks": "See scr_mvdinfo and scr_mvdinfo_setup description for more details.",
       "type": "float"
     },
     "mvd_moreinfo": {
       "default": "0",
-      "desc": "When playing MultiView Demo (MVD), you can turn on more messages printed in the console, like those you might know from moreinfo command in ktpro. E.g.: Nabbe picked up quad.",
+      "desc": "When playing MultiView Demo (MVD), you can turn on more messages printed in the console, like those you might know from moreinfo command in ktpro.\nE.g.: Nabbe picked up quad.",
       "group-id": "20",
       "type": "boolean",
       "values": [
@@ -14300,7 +14463,7 @@
     },
     "mvd_multitrack_1": {
       "default": "%f",
-      "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 1",
+      "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 1.",
       "group-id": "20",
       "remarks": "For a full description read the manual.",
       "type": "string"
@@ -14313,7 +14476,7 @@
     },
     "mvd_multitrack_2": {
       "default": "%W",
-      "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 2",
+      "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 2.",
       "group-id": "20",
       "remarks": "For a full description read the manual.",
       "type": "string"
@@ -14326,7 +14489,7 @@
     },
     "mvd_multitrack_3": {
       "default": "%h",
-      "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 3",
+      "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 3.",
       "group-id": "20",
       "remarks": "For a full description read the manual.",
       "type": "string"
@@ -14339,7 +14502,7 @@
     },
     "mvd_multitrack_4": {
       "default": "%A",
-      "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 4",
+      "desc": "Will be used if mvd_autotrack = 3 and cl_multiview is enabled.\nIts an algorythm for selecting the best player on viewport 4.",
       "group-id": "20",
       "remarks": "For a full description read the manual.",
       "type": "string"
@@ -14388,7 +14551,7 @@
     },
     "mvd_pc_view_1": {
       "default": "",
-      "desc": "Sets the powerup camera for viewport 1",
+      "desc": "Sets the powerup camera for viewport 1.",
       "group-id": "20",
       "type": "enum",
       "values": [
@@ -14424,7 +14587,7 @@
     },
     "mvd_pc_view_2": {
       "default": "",
-      "desc": "Sets the powerup camera for viewport 2",
+      "desc": "Sets the powerup camera for viewport 2.",
       "group-id": "20",
       "type": "enum",
       "values": [
@@ -14460,7 +14623,7 @@
     },
     "mvd_pc_view_3": {
       "default": "",
-      "desc": "Sets the powerup camera for viewport 3",
+      "desc": "Sets the powerup camera for viewport 3.",
       "group-id": "20",
       "type": "enum",
       "values": [
@@ -14496,7 +14659,7 @@
     },
     "mvd_pc_view_4": {
       "default": "",
-      "desc": "Sets the powerup camera for viewport 4",
+      "desc": "Sets the powerup camera for viewport 4.",
       "group-id": "20",
       "type": "enum",
       "values": [
@@ -14534,7 +14697,7 @@
       "default": "0",
       "desc": "Will enable powerupcams, cams will be enabled on every viewport 5 seconds before the powerup spawns.",
       "group-id": "20",
-      "remarks": "For setting up the viewports cams look at \nmvd_pc_view_1-4\nand for setting the locations of the cams look at\nmvd_pc_quad_1-3\nmvd_pc_pent_1-3\n",
+      "remarks": "For setting up the viewports cams look at mvd_pc_view_1-4.\nFor setting the locations of the cams look at\nmvd_pc_quad_1-3 and mvd_pc_pent_1-3.",
       "type": "boolean",
       "values": [
         {
@@ -14554,7 +14717,7 @@
     },
     "mvd_status": {
       "default": "0",
-      "desc": "Shows information of the player you are currently tracking.\nInformation includes.\ntaken/dropped items and powerups\nlast 3 runs (including the current one) run is from powerup-took/spawn to powerup-end/death",
+      "desc": "Shows information of the player you are currently tracking.\n\nInformation includes:\n - Taken/dropped items and powerups.\n - Last 3 runs (including the current one)\nRun is from powerup-took/spawn to powerup-end/death.",
       "group-id": "20",
       "type": "boolean",
       "values": [
@@ -14570,13 +14733,13 @@
     },
     "mvd_status_x": {
       "default": "0",
-      "desc": "Adjusts the horizontal placement of mvd_status table",
+      "desc": "Adjusts the horizontal placement of mvd_status table.",
       "group-id": "20",
       "type": "float"
     },
     "mvd_status_y": {
       "default": "0",
-      "desc": "Adjusts the vertical placement of mvd_status table",
+      "desc": "Adjusts the vertical placement of mvd_status table.",
       "group-id": "20",
       "type": "float"
     },
@@ -14650,9 +14813,9 @@
     },
     "password": {
       "default": "",
-      "desc": "Password players have to use to connect to local server",
+      "desc": "Password players have to use to connect to local server.",
       "group-id": "43",
-      "remarks": "Server-side",
+      "remarks": "Server-side.",
       "type": "string"
     },
     "pausable": {
@@ -14672,9 +14835,9 @@
     },
     "pm_airstep": {
       "default": "",
-      "desc": "Airstep player-move-extension. Changes the physics of the game and allows to do jumps on stairs.",
+      "desc": "Airstep player-move-extension.\nChanges the physics of the game and allows to do jumps on stairs.",
       "group-id": "43",
-      "remarks": "Server-side",
+      "remarks": "Server-side.",
       "type": "boolean",
       "values": [
         {
@@ -14688,19 +14851,19 @@
       ]
     },
     "pm_bunnyspeedcap": {
-      "desc": "This is experimental code intended to restore class balance in TF. If you set \nthis cvar to something like 1.5 or 2, a solider will not be able to bunnyhop as \nfast as a scout does :) Note that this cvar is optional and disabled by default, \nso it will in NO WAY affect gameplay unless you set it explicitly to anything \nbut 0.",
+      "desc": "This is experimental code intended to restore class balance in TF.\nIf you set this cvar to something like 1.5 or 2, a solider will not be able to bunnyhop as fast as a scout does :)\nNote that this cvar is optional and disabled by default, so it will in NO WAY affect gameplay unless you set it explicitly to anything but 0.",
       "group-id": "34",
       "type": "float"
     },
     "pm_ktjump": {
       "default": "1",
-      "desc": "If enabled (the standard), when the player jumps, velocity will always be at least 270 (standard jump).  Without this set, jumping when moving down a slope would result in lower velocity.",
+      "desc": "If enabled (the standard), when the player jumps, velocity will always be at least 270 (standard jump).\nWithout this set, jumping when moving down a slope would result in lower velocity.",
       "group-id": "34",
       "type": "float"
     },
     "pm_pground": {
       "default": "",
-      "desc": "Enables 'persistent onground flag' physics tweak.  Its only use is that it makes pm_airstep work better.",
+      "desc": "Enables 'persistent onground flag' physics tweak.\nIts only use is that it makes pm_airstep work better.",
       "group-id": "34",
       "remarks": "This extension makes use of Z_EXT_PF_ONGROUND to ensure correct movement prediction by clients. Prediction errors shouldn't be very noticeable anyway even with old clients.",
       "type": "integer"
@@ -14749,15 +14912,15 @@
     },
     "qport": {
       "default": "0",
-      "desc": "Local port the client uses to connect to servers",
+      "desc": "Local port the client uses to connect to servers.",
       "group-id": "2",
       "type": "integer"
     },
     "qtv_adjustbuffer": {
       "default": "1",
-      "desc": "Enables balancing of the buffer length of the QTV stream. When turned on, the size of the stream buffer (the delay from the actual action) will be auto-adjusted (by changing the playback speed when necessary) so that it stays on the same level most of the time.",
+      "desc": "Enables balancing of the buffer length of the QTV stream.\nWhen turned on, the size of the stream buffer (the delay from the actual action) will be auto-adjusted (by changing the playback speed when necessary) so that it stays on the same level most of the time.",
       "group-id": "38",
-      "remarks": "When turned on, the speed of the playback may change sometimes - that's how the buffer length is balanced. But usually you want to have this turned on when you are watching a shoutcast-commentated game because you want to stay synchronized with the commentary.\nSee qtv_buffer hud element for monitoring",
+      "remarks": "When turned on, the speed of the playback may change sometimes - that's how the buffer length is balanced. But usually you want to have this turned on when you are watching a shoutcast-commentated game because you want to stay synchronized with the commentary.\nSee qtv_buffer hud element for monitoring.",
       "type": "enum",
       "values": [
         {
@@ -14776,7 +14939,7 @@
     },
     "qtv_adjusthighstart": {
       "default": "1",
-      "desc": "The level on which QTV buffer auto-adjusting will start. E.g. when set to 1.5, (and qtv_adjustbuffer is 1), QTV buffer auto-adjusting will start when buffer length reached 150% of it's normal length (determined by qtv_buffertime setting)",
+      "desc": "The level on which QTV buffer auto-adjusting will start.\nE.g. when set to 1.5, (and qtv_adjustbuffer is 1), QTV buffer auto-adjusting will start when buffer length reached 150% of it's normal length (determined by qtv_buffertime setting)",
       "group-id": "38",
       "type": "float",
       "values": [
@@ -14788,7 +14951,7 @@
     },
     "qtv_adjustlowstart": {
       "default": "0.3",
-      "desc": "The bottom level on which QTV buffer auto-adjusting will start. E.g. when set to 0.5, (and qtv_adjustbuffer is 1), QTV buffer auto-adjusting will start when buffer length reached 50% of it's normal length (determined by qtv_buffertime setting)",
+      "desc": "The bottom level on which QTV buffer auto-adjusting will start.\nE.g. when set to 0.5, (and qtv_adjustbuffer is 1), QTV buffer auto-adjusting will start when buffer length reached 50% of it's normal length (determined by qtv_buffertime setting)",
       "group-id": "38",
       "type": "float",
       "values": [
@@ -14800,9 +14963,9 @@
     },
     "qtv_adjustmaxspeed": {
       "default": "999",
-      "desc": "The fastest possible playback speed when QTV buffer becomes excessive and auto-adjusting starts. The higher the speed is, the faster the QTV buffer length will go down to normal levels.",
+      "desc": "The fastest possible playback speed when QTV buffer becomes excessive and auto-adjusting starts.\nThe higher the speed is, the faster the QTV buffer length will go down to normal levels.",
       "group-id": "38",
-      "remarks": "Works in conjunction with qtv_adjustbuffer 1",
+      "remarks": "Works in conjunction with qtv_adjustbuffer 1.",
       "type": "float",
       "values": [
         {
@@ -14813,7 +14976,7 @@
     },
     "qtv_adjustminspeed": {
       "default": "0",
-      "desc": "The slowest possible playback speed when QTV buffer adjusting takes action. The slower the speed is, the faster the QTV buffer will fill up.",
+      "desc": "The slowest possible playback speed when QTV buffer adjusting takes action.\nThe slower the speed is, the faster the QTV buffer will fill up.",
       "group-id": "38",
       "remarks": "Not allowing to slow down enough, buffer level might still drop down to zero if there were longer network lag. This causes pausing during playback. Allowing to slow down too much is noticeable.",
       "type": "float",
@@ -14832,13 +14995,13 @@
     },
     "qtv_api_url": {
       "default": "http://qtvapi.quakeworld.nu/api/v1/servers",
-      "desc": "URL used by /qtv command to resolve servers to QTV addresses and vice versa",
+      "desc": "URL used by /qtv command to resolve servers to QTV addresses and vice versa.",
       "group-id": "38",
       "type": "string"
     },
     "qtv_buffertime": {
       "default": "0.5",
-      "desc": "Defines how much the client buffers from the QTV stream",
+      "desc": "Defines how much the client buffers from the QTV stream.",
       "group-id": "38",
       "remarks": "This determines the \"delay\" you will get from what is actually happening. For example if you want to synchronize shoutcast commentary with the QTV stream, this is the variable you need to change.",
       "type": "float",
@@ -14857,19 +15020,19 @@
     },
     "qtv_event_changename": {
       "default": " &cFF0changed name to&r ",
-      "desc": "Text pattern used when an user changes his name on a QTV stream",
+      "desc": "Text pattern used when an user changes his name on a QTV stream.",
       "group-id": "38",
       "type": "string"
     },
     "qtv_event_join": {
       "default": " &c2F2joined&r",
-      "desc": "Text pattern used when an user joins a QTV stream",
+      "desc": "Text pattern used when an user joins a QTV stream.",
       "group-id": "38",
       "type": "string"
     },
     "qtv_event_leave": {
       "default": " &cF22left&r",
-      "desc": "Text pattern used when an user leaves a QTV stream",
+      "desc": "Text pattern used when an user leaves a QTV stream.",
       "group-id": "38",
       "type": "string"
     },
@@ -14899,9 +15062,9 @@
     },
     "qtv_prebuffertime": {
       "default": "0",
-      "desc": "Number of seconds to buffer before starting playback from QTV, or 0 to use /qtv_buffertime",
+      "desc": "Number of seconds to buffer before starting playback from QTV, or 0 to use /qtv_buffertime.",
       "group-id": "38",
-      "remarks": "See /qtv_buffertime",
+      "remarks": "See /qtv_buffertime.",
       "type": "float",
       "values": [
         {
@@ -14916,11 +15079,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "say_team will be blocked when sending to QTV",
+          "description": "say_team will be blocked when sending to QTV.",
           "name": "false"
         },
         {
-          "description": "say_team allowed as normal on QTV",
+          "description": "say_team allowed as normal on QTV.",
           "name": "true"
         }
       ]
@@ -14959,12 +15122,12 @@
     },
     "qwdtools_dir": {
       "default": "qwdtools",
-      "desc": "Specifies the qwdtools utility placement",
+      "desc": "Specifies the qwdtools utility placement.",
       "group-id": "7",
       "type": "string",
       "values": [
         {
-          "description": "Use path relative to you quakedir",
+          "description": "Use path relative to your quakedir",
           "name": "*"
         }
       ]
@@ -15040,25 +15203,25 @@
       "system-generated": true
     },
     "r_aliastransadj": {
-      "desc": "Not much is known about this variable except for that increasing the value will\ncause the player models to be displayed smaller.",
+      "desc": "Not much is known about this variable except for that increasing the value will cause the player models to be displayed smaller.",
       "group-id": "31",
       "type": "float"
     },
     "r_aliastransbase": {
-      "desc": "Not much is known about this variable except for that increasing the value will\ncause the player models to be displayed smaller.",
+      "desc": "Not much is known about this variable except for that increasing the value will cause the player models to be displayed smaller.",
       "group-id": "31",
       "type": "float"
     },
     "r_ambient": {
-      "desc": "This variable controls the amount of ambient lighting on the map. When this \nvariable is increased the map will become brighter and all walls and objects \nwill be rendered in a lighter color.\nIt was removed in QWCL and has been re-introduced in this client, however it \ncan only be used when the server is running with cheats enabled (for example \n\"qwsv -cheats\"), because it could be used as a cheat by making it easier to see\nplayers in dark corners when no fullbright skins are used.",
+      "desc": "This variable controls the amount of ambient lighting on the map.\nWhen this variable is increased the map will become brighter and all walls and objects will be rendered in a lighter color.\nIt was removed in QWCL and has been re-introduced in this client, however it can only be used when the server is running with cheats enabled (for example \"qwsv -cheats\"), because it could be used as a cheat by making it easier to see players in dark corners when no fullbright skins are used.",
       "group-id": "31",
       "type": "float"
     },
     "r_bloom": {
       "default": "0",
-      "desc": "Enables lights blooming",
+      "desc": "Enables lights blooming.",
       "group-id": "8",
-      "remarks": "Lights will have a \\\"diamond\\\" effect near them",
+      "remarks": "Lights will have a \"diamond\" effect near them.",
       "type": "boolean",
       "values": [
         {
@@ -15073,19 +15236,19 @@
     },
     "r_bloom_alpha": {
       "default": "0.5",
-      "desc": "Transparency level of the blooming effect",
+      "desc": "Transparency level of the blooming effect.",
       "group-id": "8",
       "type": "float"
     },
     "r_bloom_darken": {
       "default": "3",
-      "desc": "Level of \\\"darkness\\\" of the blooming effect",
+      "desc": "Level of \"darkness\" of the blooming effect.",
       "group-id": "8",
       "type": "integer"
     },
     "r_bloom_diamond_size": {
       "default": "8",
-      "desc": "Size of the diamond particle used in the blooming effect",
+      "desc": "Size of the diamond particle used in the blooming effect.",
       "group-id": "8",
       "type": "integer"
     },
@@ -15107,13 +15270,13 @@
     },
     "r_bloom_intensity": {
       "default": "1",
-      "desc": "Intensity of the blooming effect",
+      "desc": "Intensity of the blooming effect.",
       "group-id": "8",
       "type": "integer"
     },
     "r_bloom_sample_size": {
       "default": "256",
-      "desc": "Size of the particle used in the blooming effect",
+      "desc": "Size of the particle used in the blooming effect.",
       "group-id": "8",
       "type": "integer"
     },
@@ -15148,7 +15311,7 @@
     },
     "r_drawentities": {
       "default": "1",
-      "desc": "This variable can be used to disable that any object entities are drawn. This \ncommand is useful to map authors who wish to take a look at their map without \ndrawing any objects such as lifts, buttons, platforms or items.",
+      "desc": "This variable can be used to disable that any object entities are drawn.\nThis command is useful to map authors who wish to take a look at their map without drawing any objects such as lifts, buttons, platforms or items.",
       "group-id": "8",
       "type": "boolean",
       "values": [
@@ -15205,7 +15368,7 @@
     "r_drawflat_mode": {
       "default": "0",
       "desc": "Sets the method used to adjust wall & floor textures (/r_drawflat) by the corresponding color (/r_wallcolor & /r_floorcolor)",
-      "remarks": "Works in GLSL modes only (see /gl_program_world)\nMode 0 will give best performance, mode 2 is the recommended setting for different colors",
+      "remarks": "Works in GLSL modes only (see /gl_program_world).\nMode 0 will give best performance, mode 2 is the recommended setting for different colors.",
       "type": "enum",
       "values": [
         {
@@ -15229,9 +15392,9 @@
     },
     "r_drawparticles": {
       "default": "1",
-      "desc": "Toggles drawing particle effects.  Intended for helping isolate rendering performance issues.",
+      "desc": "Toggles drawing particle effects.\nIntended for helping isolate rendering performance issues.",
       "group-id": "8",
-      "remarks": "Limited by particle ruleset",
+      "remarks": "Limited by particle ruleset.",
       "type": "boolean",
       "values": [
         {
@@ -15248,7 +15411,7 @@
       "default": "1",
       "desc": "Controls transparency level of the currently-held weapon.",
       "group-id": "54",
-      "remarks": "Example: 0.5 = 50% transparency.\nr_drawviewmodel 2 will cause weapon to be hidden when fov > 90",
+      "remarks": "Example: 0.5 = 50% transparency.\nr_drawviewmodel 2 will cause weapon to be hidden when fov > 90.",
       "type": "float",
       "values": [
         {
@@ -15299,7 +15462,7 @@
     },
     "r_dynamic": {
       "default": "1",
-      "desc": "Controls dynamic lighting (muzzle-flash, quad & rocket glow, etc) on world surfaces",
+      "desc": "Controls dynamic lighting (muzzle-flash, quad & rocket glow, etc) on world surfaces.",
       "group-id": "15",
       "type": "enum",
       "values": [
@@ -15319,9 +15482,9 @@
     },
     "r_enemyskincolor": {
       "default": "",
-      "desc": "Allows you to set color for enemies you see in RGB format",
+      "desc": "Allows you to set color for enemies you see in RGB format.",
       "group-id": "44",
-      "remarks": "See r_skincolormode for more info",
+      "remarks": "See r_skincolormode for more info.",
       "type": "string"
     },
     "r_explosionLight": {
@@ -15390,15 +15553,61 @@
     },
     "r_explosionType": {
       "default": "1",
-      "desc": "0 = Fire + sparks\n1 = Fire only\n2 = Teleport\n3 = Blood\n4 = Big blood\n5 = Double gunshot\n6 = Blob effect\n7 = Big explosion\n8 = Fuel Rod Gun Explosion\n9 = Sparks\n10 = Off",
+      "desc": "Sets the type of effect used for explosions.",
       "group-id": "8",
-      "type": "float"
+      "type": "enum",
+      "values": [
+        {
+          "description": "Fire + sparks",
+          "name": "0"
+        },
+        {
+          "description": "Fire only",
+          "name": "1"
+        },
+        {
+          "description": "Teleport",
+          "name": "2"
+        },
+        {
+          "description": "Blood",
+          "name": "3"
+        },
+        {
+          "description": "Big blood",
+          "name": "4"
+        },
+        {
+          "description": "Double gunshot",
+          "name": "5"
+        },
+        {
+          "description": "Blob effect",
+          "name": "6"
+        },
+        {
+          "description": "Big explosion",
+          "name": "7"
+        },
+        {
+          "description": "Fuel Rod Gun explosion",
+          "name": "8"
+        },
+        {
+          "description": "Sparks",
+          "name": "9"
+        },
+        {
+          "description": "None",
+          "name":  "10"
+        }
+      ]
     },
     "r_farclip": {
       "default": "8192",
       "desc": "Can be used to overcome vision being limited to 4096 units in GL clients (good for xpress2 etc).",
       "group-id": "35",
-      "remarks": "See also: r_nearclip",
+      "remarks": "See also: r_nearclip.",
       "type": "float"
     },
     "r_fastsky": {
@@ -15470,9 +15679,9 @@
     },
     "r_fullbright": {
       "default": "0",
-      "desc": "This variable toggles the use of lights at full brightness on the map. This allows map authors to remove all of the lighting effects from the map, effectively removing all shadows.",
+      "desc": "This variable toggles the use of lights at full brightness on the map.\nThis allows map authors to remove all of the lighting effects from the map, effectively removing all shadows.",
       "group-id": "15",
-      "remarks": "This variable can only be used when the server is running with cheats enabled (for \nexample \"mvdsv -cheats\" or sv_cheats 1), because it could be used as a cheat by making it easier\nto see players in shadows.",
+      "remarks": "This variable can only be used when the server is running with cheats enabled (for example \"mvdsv -cheats\" or sv_cheats 1), because it could be used as a cheat by making it easier to see players in shadows.",
       "type": "boolean",
       "values": [
         {
@@ -15487,7 +15696,7 @@
     },
     "r_fullbrightSkins": {
       "default": "1",
-      "desc": "Determines the fullbright percentage of skins. Fullbright skins can always be used during demo playback. \nThe f_skins response will indicate the brightness level being used as a percentage.",
+      "desc": "Determines the fullbright percentage of skins.\nFullbright skins can always be used during demo playback.\nThe f_skins response will indicate the brightness level being used as a percentage.",
       "group-id": "44",
       "type": "float",
       "values": [
@@ -15525,7 +15734,7 @@
     },
     "r_grenadeTrail": {
       "default": "1",
-      "desc": "Customizable grenade trails.\n",
+      "desc": "Customizable grenade trails.",
       "group-id": "8",
       "type": "enum",
       "values": [
@@ -15585,7 +15794,7 @@
     },
     "r_instagibTrail": {
       "default": "1",
-      "desc": "Type of trail to use when viewing trails left in /instagib mode",
+      "desc": "Type of trail to use when viewing trails left in /instagib mode.",
       "group-id": "8",
       "type": "enum",
       "values": [
@@ -15649,7 +15858,7 @@
     },
     "r_lavacolor": {
       "default": "80 0 0",
-      "desc": "Changes color of lava when r_fastturb set to 1",
+      "desc": "Changes color of lava when r_fastturb set to 1.",
       "group-id": "51",
       "type": "string"
     },
@@ -15685,13 +15894,13 @@
     },
     "r_lgbloodColor": {
       "default": "225",
-      "desc": "Determines the color of the blood (for standard particles). The QW-default value is 225.",
+      "desc": "Determines the color of the blood (for standard particles).\nThe QW-default value is 225.",
       "group-id": "8",
       "type": "float"
     },
     "r_lightdecayrate": {
       "default": "2",
-      "desc": "Determines how fast lights decay (radius decreases).  Minimum value 1 (QWCL)",
+      "desc": "Determines how fast lights decay (radius decreases).\nMinimum value 1 (QWCL)",
       "group-id": "8",
       "type": "float"
     },
@@ -15752,12 +15961,12 @@
       "default": "2",
       "desc": "Distance of clipping nearest objects (v_models).",
       "group-id": "53",
-      "remarks": "See also: r_farclip",
+      "remarks": "See also: r_farclip.",
       "type": "float"
     },
     "r_netgraph": {
       "default": "0",
-      "desc": "Setting r_netgraph 1 is a diagnostic tool to help you tweak your rate. If you find that you suffer from short pauses in the game and you see red spikes in your netgraph, you should try setting the rate down a bit.\nThe height of the pink lines towards the bottom is your latency on received packets.\nRed lines are lost packets. (bad)\nYellow lines are from the rate command kicking in, it's data that wasn't sent to you because you didn't have the bandwidth for it. (OK)\nBlue lines are very bad, they invalid delta's, and are related to the U_REMOVE warnings.",
+      "desc": "Netgraph is a diagnostic tool to help you tweak your rate.\nIf you find that you suffer from short pauses in the game and you see red spikes in your netgraph, you should try setting the rate down a bit.\nThe height of the pink lines towards the bottom is your latency on received packets.\nRed lines are lost packets. (bad)\nYellow lines are from the rate command kicking in, it's data that wasn't sent to you because you didn't have the bandwidth for it. (OK)\nBlue lines are very bad, they invalid delta's, and are related to the U_REMOVE warnings.",
       "group-id": "40",
       "remarks": "If during your play, you frequently see a string of messages with the term \"U_REMOVE\" in them, and your play seems to freeze for serveral seconds, use the console command cl_nodelta 1. This is a slightly less efficient way for QuakeWorld to work, but if your ISP is overloaded or has some configuration problems, it may not pass packets to QuakeWorld properly and cause difficulty.",
       "type": "boolean",
@@ -15774,7 +15983,7 @@
     },
     "r_netstats": {
       "default": "0",
-      "desc": "Shows information about ping, packetloss, average packet size and incoming/outgoing traffic. Equivalent with 'net' HUD element.",
+      "desc": "Shows information about ping, packetloss, average packet size and incoming/outgoing traffic.\nEquivalent with 'net' HUD element.",
       "group-id": "40",
       "type": "boolean",
       "values": [
@@ -15790,7 +15999,7 @@
     },
     "r_novis": {
       "default": "0",
-      "desc": "This variable toggles the use of VIS information from the map data. When this \nvariable is set to \"1\" the game will calculate it's own VIS information on the \nfly instead of using the information stored in the map data, this will cause \na severe performance penalty in the game. When \"r_novis\" is set to \"1\", the \nvariable \"gl_turbalpha\" has a value lower than \"1\" and the server allows the\nclient to display liquid transparently the player will be able to see through \nliquids. This is a nice effect to see but it is not recommended to keep this \nvariable set to \"1\" because of the huge performance penalty. \nIt is possible to enable transparent liquids and still keep this variable set to\n\"0\" (and thus not experience such a severe performance drop) by using maps that\nare VISed accordingly. You can visit the official Water VIS site at \n\"http://www.sod.net/\" and download the vispatch program along with the patch \ndata files which you would use to update the VIS data for all of your game maps.\nThere are also map packs available that contain VISed versions of the original\nID maps.",
+      "desc": "This variable toggles the use of VIS information from the map data.\nWhen this variable is set to \"1\" the game will calculate it's own VIS information on the fly instead of using the information stored in the map data, this will cause a severe performance penalty in the game.\nWhen \"r_novis\" is set to \"1\", the variable \"gl_turbalpha\" has a value lower than \"1\" and the server allows the client to display liquid transparently the player will be able to see through liquids.\nThis is a nice effect to see but it is not recommended to keep this variable set to \"1\" because of the huge performance penalty.\nIt is possible to enable transparent liquids and still keep this variable set to \"0\" (and thus not experience such a severe performance drop) by using maps that are VISed accordingly.\nYou can visit the official Water VIS site at \"http://www.sod.net/\" and download the vispatch program along with the patch data files which you would use to update the VIS data for all of your game maps.\nThere are also map packs available that contain VISed versions of the original ID maps.",
       "group-id": "51",
       "type": "boolean",
       "values": [
@@ -15834,7 +16043,7 @@
     },
     "r_particles_count": {
       "default": "2048",
-      "desc": "Maximum ammount of particles displayed",
+      "desc": "Maximum ammount of particles displayed.",
       "group-id": "36",
       "remarks": "You can adjust graphics performance with this.",
       "type": "integer",
@@ -15954,13 +16163,13 @@
       ]
     },
     "r_reportsurfout": {
-      "desc": "Toggle the display of how many surfaces where not displayed. This\nshouldn't happen during normal game play, only when in noclip mode.",
+      "desc": "Toggle the display of how many surfaces where not displayed.\nThis shouldn't happen during normal game play, only when in noclip mode.",
       "group-id": "31",
       "type": "float"
     },
     "r_rocketLight": {
       "default": "1",
-      "desc": "Enables rocket lights. Values from 0-1 can be used to scale the light.",
+      "desc": "Enables rocket lights.\nValues from 0-1 can be used to scale the light.",
       "group-id": "8",
       "type": "float",
       "values": [
@@ -16016,7 +16225,7 @@
     },
     "r_rocketTrail": {
       "default": "1",
-      "desc": "Customizable rocket trails.\n",
+      "desc": "Customizable rocket trails.",
       "group-id": "8",
       "type": "enum",
       "values": [
@@ -16093,7 +16302,7 @@
       "default": "1",
       "desc": "Adds transparency to the lightning gun beam (shaft).",
       "group-id": "8",
-      "remarks": "Disabled in ruleset smackdown",
+      "remarks": "Disabled in ruleset smackdown.",
       "type": "float",
       "values": [
         {
@@ -16145,7 +16354,7 @@
       "default": "-1",
       "desc": "Sets r_skincolormode for players upon death.",
       "group-id": "44",
-      "remarks": "See r_skincolormode for valid values",
+      "remarks": "See r_skincolormode for valid values.",
       "type": "enum",
       "values": [
         {
@@ -16156,7 +16365,7 @@
     },
     "r_skycolor": {
       "default": "40 80 150",
-      "desc": "Changes color of sky when r_fastsky set to 1",
+      "desc": "Changes color of sky when r_fastsky set to 1.",
       "group-id": "51",
       "type": "string"
     },
@@ -16168,7 +16377,7 @@
     },
     "r_slimecolor": {
       "default": "10 60 10",
-      "desc": "Changes color of slime when r_fastturb set to 1",
+      "desc": "Changes color of slime when r_fastturb set to 1.",
       "group-id": "51",
       "type": "string"
     },
@@ -16194,20 +16403,20 @@
     },
     "r_speeds": {
       "default": "0",
-      "desc": "Toggles the displaying of drawing time and stats of what is\ncurrently being viewed.\nExample:\n32.7 ms 267/196/ 74 poly   3 surf\n38.6 ms 267/196/ 74 poly  20 surf\n60.4 ms 267/196/ 74 poly  18 surf\n38.2 ms 267/196/ 73 poly  18 surf",
+      "desc": "Toggles the displaying of drawing time and stats of what is currently being viewed.\nExample:\n32.7 ms 267/196/ 74 poly   3 surf\n38.6 ms 267/196/ 74 poly  20 surf\n60.4 ms 267/196/ 74 poly  18 surf\n38.2 ms 267/196/ 73 poly  18 surf",
       "group-id": "40",
       "type": "float"
     },
     "r_teamskincolor": {
       "default": "",
-      "desc": "Allows you to set color for teammates you see in RGB format",
+      "desc": "Allows you to set color for teammates you see in RGB format.",
       "group-id": "44",
-      "remarks": "See r_skincolormode for more info",
+      "remarks": "See r_skincolormode for more info.",
       "type": "string"
     },
     "r_telecolor": {
       "default": "255 60 60",
-      "desc": "Changes color of teleport when r_fastturb set to 1",
+      "desc": "Changes color of teleport when r_fastturb set to 1.",
       "group-id": "51",
       "type": "string"
     },
@@ -16264,43 +16473,43 @@
     },
     "r_tracker_color_bad": {
       "default": "900",
-      "description": "Color to use when reporting a frag by opponent's team",
+      "desc": "Color to use when reporting a frag by opponent's team.",
       "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_fragonme": {
       "default": "900",
-      "desc": "Color to use when reporting an opponent killed the current player",
+      "desc": "Color to use when reporting an opponent killed the current player.",
       "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_good": {
       "default": "090",
-      "desc": "Color to use when reporting a kill by current player's team",
+      "desc": "Color to use when reporting a kill by current player's team.",
       "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_myfrag": {
       "default": "090",
-      "desc": "Color to use when reporting a frag by current player",
+      "desc": "Color to use when reporting a frag by current player.",
       "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_suicide": {
       "default": "900",
-      "desc": "Color to use when reporting a suicide",
+      "desc": "Color to use when reporting a suicide.",
       "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_tkbad": {
       "default": "009",
-      "desc": "Color to use when reporting a teamkill by current player's team",
+      "desc": "Color to use when reporting a teamkill by current player's team.",
       "group-id": "40",
       "type": "string"
     },
     "r_tracker_color_tkgood": {
       "default": "990",
-      "desc": "Color to use when reporting an opponent's teamkill",
+      "desc": "Color to use when reporting an opponent's teamkill.",
       "group-id": "40",
       "type": "string"
     },
@@ -16329,15 +16538,15 @@
       "type": "enum",
       "values": [
         {
-          "description": "No extra frag messages shown",
+          "description": "No extra frag messages shown.",
           "name": "0"
         },
         {
-          "description": "Frag messages related to yourself will be shown in extra window",
+          "description": "Frag messages related to yourself will be shown in extra window.",
           "name": "1"
         },
         {
-          "description": "All frag messages will be shown in extra window",
+          "description": "All frag messages will be shown in extra window.",
           "name": "2"
         }
       ]
@@ -16350,26 +16559,26 @@
       "type": "string",
       "values": [
         {
-          "description": "<r g b><a> = red, green, blue and alpha values 0..255",
+          "description": "<r g b><a> = red, green, blue and alpha values 0..255.",
           "name": "*"
         }
       ]
     },
     "r_tracker_images_scale": {
       "default": "1",
-      "desc": "Controls the size of images when using the tracker.  Valid range 0.1-10",
+      "desc": "Controls the size of images when using the tracker.\nValid range 0.1-10.",
       "group-id": "40",
       "type": "float"
     },
     "r_tracker_inconsole": {
       "default": "0",
-      "desc": "Controls how tracker messages will appear in the console/notify area",
+      "desc": "Controls how tracker messages will appear in the console/notify area.",
       "group-id": "40",
-      "remarks": "To see full death messages in the console, use con_fragmessages 2",
+      "remarks": "To see full death messages in the console, use con_fragmessages 2.",
       "type": "enum",
       "values": [
         {
-          "description": "Tracker messages will not be shown in the console",
+          "description": "Tracker messages will not be shown in the console.",
           "name": "0"
         },
         {
@@ -16381,7 +16590,7 @@
           "name": "2"
         },
         {
-          "description": "Tracker messages will be shown in console and regular tracker area but not in notify area",
+          "description": "Tracker messages will be shown in console and regular tracker area but not in notify area.",
           "name": "3"
         }
       ]
@@ -16395,13 +16604,13 @@
     },
     "r_tracker_name_width": {
       "default": "0",
-      "desc": "Maximum length of player names in the tracker",
+      "desc": "Maximum length of player names in the tracker.",
       "group-id": "40",
       "type": "integer"
     },
     "r_tracker_own_frag_prefix": {
       "default": "You fragged ",
-      "desc": "Text to show before frag messages relating to the current player",
+      "desc": "Text to show before frag messages relating to the current player.",
       "group-id": "40",
       "type": "string"
     },
@@ -16431,7 +16640,7 @@
     },
     "r_tracker_streaks": {
       "default": "0",
-      "desc": "Everytime a player makes a set number of consecutive kills, it will display a message showing they are on a streak, when the player is killed, it will display the name of the person who ended that streak.",
+      "desc": "Everytime a player makes a set number of consecutive kills, it will display a message showing they are on a streak.\nWhen the player is killed, it will display the name of the person who ended that streak.",
       "group-id": "40",
       "type": "float"
     },
@@ -16439,14 +16648,14 @@
       "default": " (died)",
       "desc": "Text appearing in the tracker when a player dies (typically lava, slime, drowning etc)",
       "group-id": "40",
-      "remarks": "Relates to PLAYER_DEATH rules in fragfile.dat",
+      "remarks": "Relates to PLAYER_DEATH rules in fragfile.dat.",
       "type": "string"
     },
     "r_tracker_string_enemy": {
       "default": "enemy",
-      "desc": "Text appearing in the tracker when a player earns a frag",
+      "desc": "Text appearing in the tracker when a player earns a frag.",
       "group-id": "40",
-      "remarks": "Relates to X_FRAGS_UNKNOWN rules in fragfile.dat",
+      "remarks": "Relates to X_FRAGS_UNKNOWN rules in fragfile.dat.",
       "type": "string"
     },
     "r_tracker_string_suicides": {
@@ -16480,7 +16689,7 @@
       "type": "integer",
       "values": [
         {
-          "description": "horizontal position",
+          "description": "horizontal position.",
           "name": "*"
         }
       ]
@@ -16493,14 +16702,14 @@
       "type": "integer",
       "values": [
         {
-          "description": "vertical position",
+          "description": "vertical position.",
           "name": "*"
         }
       ]
     },
     "r_turbwarp": {
       "group-id": "31",
-      "remarks": "SW only!\nThis variable has the same effect as r_waterwarp in other quake clients. ",
+      "remarks": "SW only!\nThis variable has the same effect as r_waterwarp in other quake clients.",
       "type": "boolean",
       "values": [
         {
@@ -16515,7 +16724,7 @@
     },
     "r_viewmodelSize": {
       "default": "1",
-      "desc": "This allows you to change the size of the viewmodel (the model of your active \nweapon displayed on the center of your screen) a little, useful if you prefer\nto use \"r_drawviewmodel 1\" and higher fov values (for demos for example).\nFor \"fov 110\" you could try \"r_viewmodelSize 0.8\" or 0.85 for example.",
+      "desc": "This allows you to change the size of the viewmodel (the model of your active weapon displayed on the center of your screen) a little.\nUseful if you prefer to use \"r_drawviewmodel 1\" and higher fov values (for demos for example).\nFor \"fov 110\" you could try \"r_viewmodelSize 0.8\" or 0.85 for example.",
       "group-id": "54",
       "type": "float"
     },
@@ -16537,13 +16746,13 @@
     },
     "r_viewmodeloffset": {
       "default": "",
-      "desc": "Moves the gun model to the right (positive value) or to the left (negative value). Good for people who like to see right/left-handed looking weapons.",
+      "desc": "Moves the gun model to the right (positive value) or to the left (negative value).\nGood for people who like to see right/left-handed looking weapons.",
       "group-id": "54",
       "remarks": "You can also change Y and Z coordinates, just provide parameters in \"X Y Z\" format.\nSee also r_shiftbeam variable.",
       "type": "string",
       "values": [
         {
-          "description": "-10 to 10",
+          "description": "-10 to 10.",
           "name": "*"
         }
       ]
@@ -16556,11 +16765,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Display the weapon you really hold",
+          "description": "Display the weapon you really hold.",
           "name": "false"
         },
         {
-          "description": "Disaply the current pre-selected weapon",
+          "description": "Disaply the current pre-selected weapon.",
           "name": "true"
         }
       ]
@@ -16573,7 +16782,7 @@
     },
     "r_watercolor": {
       "default": "10 50 80",
-      "desc": "Changes color of water when r_fastturb set to 1",
+      "desc": "Changes color of water when r_fastturb set to 1.",
       "group-id": "51",
       "type": "string"
     },
@@ -16593,45 +16802,45 @@
     },
     "railcolor": {
       "default": "",
-      "desc": "Player's rail color",
+      "desc": "Player's rail color.",
       "group-id": "37",
-      "remarks": "Possible values are: 1 - 7.  Sent to server, requires mod support",
+      "remarks": "Sent to server, requires mod support.",
       "type": "enum",
       "values": [
         {
-          "description": "Server decides color",
+          "description": "Server decides color.",
           "name": ""
         },
         {
-          "description": "White",
+          "description": "White.",
           "name": "0"
         },
         {
-          "description": "Blue",
+          "description": "Blue.",
           "name": "1"
         },
         {
-          "description": "Green",
+          "description": "Green.",
           "name": "2"
         },
         {
-          "description": "Light Blue",
+          "description": "Light Blue.",
           "name": "3"
         },
         {
-          "description": "Red",
+          "description": "Red.",
           "name": "4"
         },
         {
-          "description": "Magenta",
+          "description": "Magenta.",
           "name": "5"
         },
         {
-          "description": "Yellow",
+          "description": "Yellow.",
           "name": "6"
         },
         {
-          "description": "White",
+          "description": "White.",
           "name": "7"
         }
       ]
@@ -16644,13 +16853,13 @@
     },
     "rcon_address": {
       "default": "",
-      "desc": "Address of the server to query with remote console commands",
+      "desc": "Address of the server to query with remote console commands.",
       "group-id": "2",
       "type": "string"
     },
     "rcon_password": {
       "default": "",
-      "desc": "Password used for remote console communication",
+      "desc": "Password used for remote console communication.",
       "group-id": "2",
       "type": "string"
     },
@@ -16713,18 +16922,18 @@
     },
     "ruleset": {
       "default": "default",
-      "desc": "Enforces a set of restrictions on the client features",
+      "desc": "Enforces a set of restrictions on the client features.",
       "group-id": "37",
-      "remarks": "Most commonly used is \\\"smackdown\\\"",
+      "remarks": "Most commonly used is \"smackdown\"",
       "type": "string"
     },
     "s_alsa_device": {
-      "desc": "Sets which device ALSA will be trying to open (when s_driver is set to alsa). Default is: \"default\", if that fails it will try \"hw\" and if that fails too, \"plug:hw\" will be tried.",
+      "desc": "Sets which device ALSA will be trying to open (when s_driver is set to alsa).\nDefault is: \"default\", if that fails it will try \"hw\" and if that fails too, \"plug:hw\" will be tried.",
       "group-id": "26",
       "type": "string"
     },
     "s_alsa_latency": {
-      "desc": "Specifies latency for ALSA. If you got distortion in sound, upper the value a bit. If you experience delays, try lowering this value.",
+      "desc": "Specifies latency for ALSA.\nIf you got distortion in sound, upper the value a bit.\nIf you experience delays, try lowering this value.",
       "group-id": "26",
       "type": "float"
     },
@@ -16769,65 +16978,65 @@
       "type": "enum",
       "values": [
         {
-          "description": "16 bit sound",
+          "description": "16 bit sound.",
           "name": "16"
         },
         {
-          "description": "8 bit sound",
+          "description": "8 bit sound.",
           "name": "8"
         }
       ]
     },
     "s_chat_custom": {
       "default": "1",
-      "desc": "Controls usage of s_mm*, s_chat_*, s_otherchat_* and s_spec_* variables. ",
+      "desc": "Controls usage of s_mm*, s_chat_*, s_otherchat_* and s_spec_* variables.",
       "group-id": "3",
       "type": "enum",
       "values": [
         {
-          "description": "No chat sounds played",
+          "description": "No chat sounds played.",
           "name": "0"
         },
         {
-          "description": "Chat sounds played for mm1 & mm2",
+          "description": "Chat sounds played for mm1 & mm2.",
           "name": "1"
         },
         {
-          "description": "Chat sounds played for mm2 only ",
+          "description": "Chat sounds played for mm2 only.",
           "name": "2"
         }
       ]
     },
     "s_desiredsamples": {
       "default": "0",
-      "desc": "Indicates how large the audio buffer should be, in samples.  If 0, ezQuake will choose a sensible default, based on value of s_khz",
+      "desc": "Indicates how large the audio buffer should be, in samples.\nIf 0, ezQuake will choose a sensible default, based on value of s_khz.",
       "group-id": "45",
-      "remarks": "This is a suggestion only, the driver is free to choose a different value.  Smaller buffer sizes generally result in lower latency, but higher CPU usage.",
+      "remarks": "This is a suggestion only, the driver is free to choose a different value.\nSmaller buffer sizes generally result in lower latency, but higher CPU usage.",
       "type": "integer"
     },
     "s_device": {
-      "desc": "Allows you to choose from multiple sound devices.\n",
+      "desc": "Allows you to choose from multiple sound devices.",
       "group-id": "26",
-      "remarks": "Linux only.\nUse s_restart after you change it.\n\nFor OSS you should use \"/dev/dsp\", \"/dev/dsp0\", \"/dev/dsp1\", etc\nFor ALSA use \"default\", \"dmix\", etc",
+      "remarks": "Linux only.\nUse s_restart after you change it.\n\nFor OSS you should use \"/dev/dsp\", \"/dev/dsp0\", \"/dev/dsp1\", etc.\nFor ALSA use \"default\", \"dmix\", etc.",
       "type": "string",
       "values": [
         {
-          "description": "device name",
+          "description": "device name.",
           "name": "*"
         }
       ]
     },
     "s_driver": {
-      "desc": "Specifices which sounddriver to use: ALSA/OSS or experimental Pulseaudio.\n",
+      "desc": "Specifices which sounddriver to use: ALSA/OSS or experimental Pulseaudio.",
       "group-id": "26",
       "type": "enum",
       "values": [
         {
-          "description": "Will use ALSA drivers",
+          "description": "Will use ALSA drivers.",
           "name": "alsa"
         },
         {
-          "description": "Will use OSS drivers",
+          "description": "Will use OSS drivers.",
           "name": "oss"
         },
         {
@@ -16838,9 +17047,9 @@
     },
     "s_khz": {
       "default": "11",
-      "desc": "The client includes \"sound interpolation\" which allows it to play sounds at higher frequencies, than the default 11025 Hz with perfect quality. In addition to \"s_khz\" also \"s_bits\" (linux only) will have an influence on interpolation quality. This variable allows you to choose the frequency you want to interpolate the sounds to. You will quickly discover, that the shaft sound is different at increased sampling rate. That's because shaft sounds were recorded at 22050 kHz, so probably that's how they should sound from the beginning. If you don't like it, you can always convert them to 11025.",
+      "desc": "The client includes \"sound interpolation\" which allows it to play sounds at higher frequencies, than the default 11025 Hz with perfect quality.\nIn addition to \"s_khz\" also \"s_bits\" (linux only) will have an influence on interpolation quality. This variable allows you to choose the frequency you want to interpolate the sounds to.\nYou will quickly discover, that the shaft sound is different at increased sampling rate. That's because shaft sounds were recorded at 22050 kHz, so probably that's how they should sound from the beginning. If you don't like it, you can always convert them to 11025.",
       "group-id": "45",
-      "remarks": "Also you can change it 'on fly' - just do s_restart after you change s_khz",
+      "remarks": "Also you can change it 'on fly' - just do s_restart after you change s_khz.",
       "type": "enum",
       "values": [
         {
@@ -16848,35 +17057,35 @@
           "name": "11"
         },
         {
-          "description": "22khz sound",
+          "description": "22khz sound.",
           "name": "22"
         },
         {
-          "description": "44khz sound",
+          "description": "44khz sound.",
           "name": "44"
         },
         {
-          "description": "48khz sound",
+          "description": "48khz sound.",
           "name": "48"
         }
       ]
     },
     "s_linearresample": {
       "default": "0",
-      "desc": "Controls whether or not to resample sounds as they are loaded",
+      "desc": "Controls whether or not to resample sounds as they are loaded.",
       "group-id": "45",
       "type": "enum",
       "values": [
         {
-          "description": "Do not perform resampling",
+          "description": "Do not perform resampling.",
           "name": "0"
         },
         {
-          "description": "Upscale sounds as they are loaded",
+          "description": "Upscale sounds as they are loaded.",
           "name": "1"
         },
         {
-          "description": "Upscale & downscale sounds as they loaded, as appropriate",
+          "description": "Upscale & downscale sounds as they loaded, as appropriate.",
           "name": "2"
         }
       ]
@@ -16890,7 +17099,7 @@
     "s_loadas8bit": {
       "default": "0",
       "group-id": "45",
-      "remarks": "This will give a little performance boost when playing the game at the cost of \nquality for the sound samples.)",
+      "remarks": "This will give a little performance boost when playing the game at the cost of quality for the sound samples.)",
       "type": "boolean",
       "values": [
         {
@@ -16904,7 +17113,7 @@
       ]
     },
     "s_mixahead": {
-      "desc": "Only affects OSS and legacy ALSA:\n\nThis variable defines the delay time for sounds. How low you can set your sound\nmixahead depends on your FPS, when you set it too low, your sound will start \ncrackling. Generally, with 72 FPS you should be able to use a delay of 0.06 seconds.",
+      "desc": "Only affects OSS and legacy ALSA:\n\nThis variable defines the delay time for sounds. How low you can set your sound mixahead depends on your FPS, when you set it too low, your sound will start  crackling.\nGenerally, with 72 FPS you should be able to use a delay of 0.06 seconds.",
       "group-id": "45",
       "type": "float"
     },
@@ -16939,11 +17148,11 @@
       "type": "enum",
       "values": [
         {
-          "description": "Use ALSA sound output",
+          "description": "Use ALSA sound output.",
           "name": "0"
         },
         {
-          "description": "Use OSS sound output",
+          "description": "Use OSS sound output.",
           "name": "1"
         }
       ]
@@ -16957,7 +17166,7 @@
           "name": "false"
         },
         {
-          "description": "Don't use extra sound updates.  Gives a slight fps boost, but may lead to choppy sound on low-end machines",
+          "description": "Don't use extra sound updates.\nGives a slight fps boost, but may lead to choppy sound on low-end machines.",
           "name": "true"
         }
       ]
@@ -16972,13 +17181,13 @@
           "name": "false"
         },
         {
-          "description": "Disable the playback of sounds.  Note that it effectively just resets sound volume to zero, but the sound engine still runs.  If you want disable sound in order to get more fps, use the -nosound command line option instead.",
+          "description": "Disable the playback of sounds.\nNote that it effectively just resets sound volume to zero, but the sound engine still runs.\nIf you want disable sound in order to get more fps, use the -nosound command line option instead.",
           "name": "true"
         }
       ]
     },
     "s_oss_device": {
-      "desc": "Specifies which device OSS will try to open. Default is \"/dev/dsp\"",
+      "desc": "Specifies which device OSS will try to open.\nDefault is \"/dev/dsp\"",
       "group-id": "26",
       "type": "string"
     },
@@ -17010,7 +17219,7 @@
       ]
     },
     "s_pulseaudio_latency": {
-      "desc": "Specifies latency for Pulseaudio. If you got distortion in sound, upper the value a bit. If you experience delays, try lowering this value.",
+      "desc": "Specifies latency for Pulseaudio.\nIf you got distortion in sound, upper the value a bit.\nIf you experience delays, try lowering this value.",
       "group-id": "26",
       "type": "float"
     },
@@ -17060,17 +17269,17 @@
       "type": "float"
     },
     "s_stereo": {
-      "desc": "Use stereo or mono sound",
+      "desc": "Use stereo or mono sound.",
       "group-id": "26",
       "remarks": "Linux only.\nUse s_restart after you change it.",
       "type": "boolean",
       "values": [
         {
-          "description": "mono",
+          "description": "Mono.",
           "name": "false"
         },
         {
-          "description": "stereo",
+          "description": "Stereo.",
           "name": "true"
         }
       ]
@@ -17081,7 +17290,7 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Off",
+          "description": "Off.",
           "name": "false"
         },
         {
@@ -17097,7 +17306,7 @@
       "type": "enum",
       "values": [
         {
-          "description": "Will use new sound drivers for ALSA/OSS",
+          "description": "Will use new sound drivers for ALSA/OSS.",
           "name": "0"
         },
         {
@@ -17108,36 +17317,36 @@
     },
     "samelevel": {
       "default": "1",
-      "desc": "When enabled, the same level will be played once the match is over\nOther mods use this value to store options",
+      "desc": "When enabled, the same level will be played once the match is over.\nOther mods use this value to store options.",
       "group-id": "43",
       "type": "float",
       "values": [
         {
-          "description": "Advance to next map after intermission",
+          "description": "Advance to next map after intermission.",
           "name": "0"
         },
         {
-          "description": "Play same map again",
+          "description": "Play same map again.",
           "name": "1"
         }
       ]
     },
     "sb_autohide": {
       "default": "1",
-      "desc": "This toggles in which cases the server browser should automatically hide itself \nwhen connecting to a server.",
+      "desc": "This toggles in which cases the server browser should automatically hide itself when connecting to a server.",
       "group-id": "42",
       "type": "enum",
       "values": [
         {
-          "description": "Never hide server browser",
+          "description": "Never hide server browser.",
           "name": "0"
         },
         {
-          "description": "This will cause the server browser to always hide after connecting",
+          "description": "This will cause the server browser to always hide after connecting.",
           "name": "1"
         },
         {
-          "description": "This will cause the server browser to hide after connecting only, if the     connected server is not a qizmo proxy, useful if you often connect to Qizmos\n    only for rerouting features (with \"useproxy 1\")",
+          "description": "This will cause the server browser to hide after connecting only if the connected server is not a qizmo proxy.\nUseful if you often connect to Qizmos only for rerouting features (with \"useproxy 1\")",
           "name": "2"
         }
       ]
@@ -17150,11 +17359,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "do not refresh server list automatically",
+          "description": "do not refresh server list automatically.",
           "name": "false"
         },
         {
-          "description": "auto-refresh server list when first entering Server Browser menu",
+          "description": "auto-refresh server list when first entering Server Browser menu.",
           "name": "true"
         }
       ]
@@ -17167,7 +17376,7 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Lookup disabled",
+          "description": "Lookup disabled.",
           "name": "false"
         },
         {
@@ -17183,11 +17392,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "don't hide dead servers",
+          "description": "don't hide dead servers.",
           "name": "false"
         },
         {
-          "description": "hide dead servers",
+          "description": "hide dead servers.",
           "name": "true"
         }
       ]
@@ -17199,11 +17408,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "don't hide empty servers",
+          "description": "don't hide empty servers.",
           "name": "false"
         },
         {
-          "description": "hide empty servers",
+          "description": "hide empty servers.",
           "name": "true"
         }
       ]
@@ -17215,11 +17424,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "don't hide full servers",
+          "description": "don't hide full servers.",
           "name": "false"
         },
         {
-          "description": "hide full servers",
+          "description": "hide full servers.",
           "name": "true"
         }
       ]
@@ -17247,11 +17456,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "don't hide empty servers",
+          "description": "don't hide empty servers.",
           "name": "false"
         },
         {
-          "description": "hide empty servers",
+          "description": "hide empty servers.",
           "name": "true"
         }
       ]
@@ -17263,19 +17472,19 @@
     },
     "sb_inforetries": {
       "default": "3",
-      "desc": "This determines how often ezQuake should try to retrieve information from a server \nuntil it is considered to be not responding.",
+      "desc": "This determines how often ezQuake should try to retrieve information from a server until it is considered to be not responding.",
       "group-id": "42",
       "type": "float"
     },
     "sb_infospersec": {
       "default": "100",
-      "desc": "This determines how many serverinfos per second ezQuake should retrieve when \nscanning servers. When setting this value too high you will flood your line,\ncausing you to not receive information from servers or lagging your connect\nto the server you are currently connected to.",
+      "desc": "This determines how many serverinfos per second ezQuake should retrieve when scanning servers.\nWhen setting this value too high you will flood your line, causing you to not receive information from servers or lagging your connection to the server you are currently connected to.",
       "group-id": "42",
       "type": "float"
     },
     "sb_infotimeout": {
       "default": "1000",
-      "desc": "This determines how long ezQuake will wait for a reply when trying to retrieve\ninformation from a server until the attempt times out.",
+      "desc": "This determines how long ezQuake will wait for a reply when trying to retrieve information from a server until the attempt times out.",
       "group-id": "42",
       "type": "float"
     },
@@ -17297,35 +17506,35 @@
     },
     "sb_liveupdate": {
       "default": "2",
-      "desc": "This will determine how often ezQuake should refresh the serverinfo window, the\nspecified value sets the delay in seconds. Setting it to \"0\" will disable\nautomatic refreshing.",
+      "desc": "This will determine how often ezQuake should refresh the serverinfo window, the specified value sets the delay in seconds.\nSetting it to \"0\" will disable automatic refreshing.",
       "group-id": "42",
       "type": "float"
     },
     "sb_mastercache": {
       "default": "1",
-      "desc": "This toggles whether ezQuake should cache the results of queries to master server \n(in directory qw/sb/cache). If you restart ezQuake and don't update sources or if \na master server is down, ezQuake will use the cache.",
+      "desc": "This toggles whether ezQuake should cache the results of queries to master server (in directory qw/sb/cache).\nIf you restart ezQuake and don't update sources or if a master server is down, ezQuake will use the cache.",
       "group-id": "42",
       "type": "boolean",
       "values": [
         {
-          "description": "don't use cache for master servers",
+          "description": "don't use cache for master servers.",
           "name": "false"
         },
         {
-          "description": "use the cache for master servers when they are down or haven't been refreshed",
+          "description": "use the cache for master servers when they are down or haven't been refreshed.",
           "name": "true"
         }
       ]
     },
     "sb_masterretries": {
       "default": "3",
-      "desc": "This determines how often ezQuake should try to retrieve information from a master \nserver until it is considered to be not responding.",
+      "desc": "This determines how often ezQuake should try to retrieve information from a master server until it is considered to be not responding.",
       "group-id": "42",
       "type": "float"
     },
     "sb_mastertimeout": {
       "default": "1000",
-      "desc": "This determines how long ezQuake will wait for a reply when trying to retrieve\ninformation from a master server until the attempt times out.",
+      "desc": "This determines how long ezQuake will wait for a reply when trying to retrieve information from a master server until the attempt times out.",
       "group-id": "42",
       "type": "float"
     },
@@ -17353,31 +17562,31 @@
     },
     "sb_pings": {
       "default": "3",
-      "desc": "This determines how many pings ezQuake will send to a server when trying to\ndetermine your ping to it. A higher value will cause scanning servers to take\nlonger, but the result may be more exact. A lower value obviously makes scanning\nfaster, but pings may be inaccurate.",
+      "desc": "This determines how many pings ezQuake will send to a server when trying to determine your ping to it.\nA higher value will cause scanning servers to take longer, but the result may be more exact.\nA lower value obviously makes scanning faster, but pings may be inaccurate.",
       "group-id": "42",
       "type": "float"
     },
     "sb_pingspersec": {
       "default": "150",
-      "desc": "This determines how many pings per second ezQuake should sent out when scanning\nservers. If you set this value too high the result will be that the pings will \nnot be accurate because you overloaded your line. If you set it too low scanning \nservers will take very long especially when you have a large server list.",
+      "desc": "This determines how many pings per second ezQuake should sent out when scanning servers.\nIf you set this value too high the result will be that the pings will not be accurate because you overloaded your line.\nIf you set it too low scanning servers will take very long especially when you have a large server list.",
       "group-id": "42",
       "type": "float"
     },
     "sb_pingtimeout": {
       "default": "1000",
-      "desc": "This determines how long ezQuake will wait for a reply when trying to ping a \nserver until the attempt times out.",
+      "desc": "This determines how long ezQuake will wait for a reply when trying to ping a server until the attempt times out.",
       "group-id": "42",
       "type": "float"
     },
     "sb_proxinfopersec": {
       "default": "10",
-      "desc": "Number of proxies to contact per second\nUsed when finding fastest path to a server.",
+      "desc": "Number of proxies to contact per second.\nUsed when finding fastest path to a server.",
       "group-id": "42",
       "type": "float"
     },
     "sb_proxretries": {
       "default": "3",
-      "desc": "Number of times to attempt contact with a proxy before ",
+      "desc": "Number of times to attempt contact with a proxy before giving up.",
       "group-id": "42",
       "type": "integer"
     },
@@ -17389,63 +17598,63 @@
     },
     "sb_showaddress": {
       "default": "0",
-      "desc": "This toggles whether ezQuake should display the server IP column in the server\nlist.",
+      "desc": "This toggles whether ezQuake should display the server IP column in the server list.",
       "group-id": "42",
       "type": "boolean",
       "values": [
         {
-          "description": "do not show the server IP column",
+          "description": "do not show the server IP column.",
           "name": "false"
         },
         {
-          "description": "show the server IP column",
+          "description": "show the server IP column.",
           "name": "true"
         }
       ]
     },
     "sb_showcounters": {
-      "desc": "This toggles whether ezQuake should display the number of servers or players in\nthe status line.",
+      "desc": "This toggles whether ezQuake should display the number of servers or players in the status line.",
       "group-id": "31",
       "type": "boolean",
       "values": [
         {
-          "description": "do not show the server/player counter in the status line",
+          "description": "do not show the server/player counter in the status line.",
           "name": "false"
         },
         {
-          "description": "show the server/player counter in the status line",
+          "description": "show the server/player counter in the status line.",
           "name": "true"
         }
       ]
     },
     "sb_showfraglimit": {
       "default": "0",
-      "desc": "This toggles whether ezQuake should display the fraglimit column in the server\nlist.",
+      "desc": "This toggles whether ezQuake should display the fraglimit column in the server list.",
       "group-id": "42",
       "type": "boolean",
       "values": [
         {
-          "description": "do not show the fraglimit column",
+          "description": "do not show the fraglimit column.",
           "name": "false"
         },
         {
-          "description": "show the fraglimit column",
+          "description": "show the fraglimit column.",
           "name": "true"
         }
       ]
     },
     "sb_showgamedir": {
       "default": "0",
-      "desc": "This toggles whether ezQuake should display the gamedir column in the server list,\nfor example to see which mod is being played.",
+      "desc": "This toggles whether ezQuake should display the gamedir column in the server list, for example to see which mod is being played.",
       "group-id": "42",
       "type": "boolean",
       "values": [
         {
-          "description": "do not show the gamedir column",
+          "description": "do not show the gamedir column.",
           "name": "false"
         },
         {
-          "description": "show the gamedir column",
+          "description": "show the gamedir column.",
           "name": "true"
         }
       ]
@@ -17457,11 +17666,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "do not show the map column",
+          "description": "do not show the map column.",
           "name": "false"
         },
         {
-          "description": "show the map column",
+          "description": "show the map column.",
           "name": "true"
         }
       ]
@@ -17473,27 +17682,27 @@
       "type": "boolean",
       "values": [
         {
-          "description": "do not show the ping column",
+          "description": "do not show the ping column.",
           "name": "false"
         },
         {
-          "description": "show the ping column",
+          "description": "show the ping column.",
           "name": "true"
         }
       ]
     },
     "sb_showplayers": {
       "default": "1",
-      "desc": "This toggles whether ezQuake should display the players column in the server list\nthat shows how many players are on the server as well as how many players are \nallowed.",
+      "desc": "This toggles whether ezQuake should display the players column in the server list that shows how many players are on the server as well as how many players are allowed.",
       "group-id": "42",
       "type": "boolean",
       "values": [
         {
-          "description": "do not show the players column",
+          "description": "do not show the players column.",
           "name": "false"
         },
         {
-          "description": "show the players column",
+          "description": "show the players column.",
           "name": "true"
         }
       ]
@@ -17505,50 +17714,50 @@
       "type": "enum",
       "values": [
         {
-          "description": "Hide proxies in the server browser",
+          "description": "Hide proxies in the server browser.",
           "name": "0"
         },
         {
-          "description": "Show proxies in the server browser",
+          "description": "Show proxies in the server browser.",
           "name": "1"
         },
         {
-          "description": "Only show proxies in the server browser",
+          "description": "Only show proxies in the server browser.",
           "name": "2"
         }
       ]
     },
     "sb_showtimelimit": {
       "default": "0",
-      "desc": "This toggles whether ezQuake should display the timelimit column in the server \nlist.",
+      "desc": "This toggles whether ezQuake should display the timelimit column in the server list.",
       "group-id": "42",
       "type": "boolean",
       "values": [
         {
-          "description": "do not show the timelimit column",
+          "description": "do not show the timelimit column.",
           "name": "false"
         },
         {
-          "description": "show the timelimit column",
+          "description": "show the timelimit column.",
           "name": "true"
         }
       ]
     },
     "sb_sortplayers": {
       "default": "92",
-      "desc": "This determines sort order in the players list. This uses the numbers from the\ndescription of the columns. Check \"Columns available in servers/players list\"\nabove for an explanation of each number. A \"-\" in front of the value reverses \nthe sort order for that value from ascending to descending.\naddress (ip:port).",
+      "desc": "This determines sort order in the players list. This uses the numbers from the description of the columns.\nCheck \"Columns available in servers/players list\" above for an explanation of each number.\nA \"-\" in front of the value reverses the sort order for that value from ascending to descending.\n\naddress (ip:port).",
       "group-id": "42",
       "type": "float"
     },
     "sb_sortservers": {
       "default": "32",
-      "desc": "This determines sort order in the servers list. This uses the numbers from the\ndescription of the columns. Check \"Columns available in servers/players list\" \nabove for an explanation of each number. A \"-\" in front of the value reverses \nthe sort order for that value from ascending to descending.\nserver address (ip:port).",
+      "desc": "This determines sort order in the servers list. This uses the numbers from the description of the columns.\nCheck \"Columns available in servers/players list\"  above for an explanation of each number.\nA \"-\" in front of the value reverses the sort order for that value from ascending to descending.\n\nserver address (ip:port).",
       "group-id": "42",
       "type": "float"
     },
     "sb_sortsources": {
       "default": "3",
-      "desc": "Ordering instructions for server browser sources list are stored in this variable. You can order source server in Server browser by pressing Ctrl+1, Ctrl+2 and Ctrl+3. Sequence of your desired combination will be stored in this variable, newest keys first.",
+      "desc": "Ordering instructions for server browser sources list are stored in this variable.\nYou can order source server in Server browser by pressing Ctrl+1, Ctrl+2 and Ctrl+3.\nSequence of your desired combination will be stored in this variable, newest keys first.",
       "group-id": "42",
       "type": "string",
       "values": [
@@ -17560,22 +17769,22 @@
     },
     "sb_sourcevalidity": {
       "default": "30",
-      "desc": "This sets the time of master servers validity in minutes. Master servers that\nwere updated within the specified time will not be refreshed when updating \nsources with [SPACE].",
+      "desc": "This sets the time of master servers validity in minutes.\nMaster servers that were updated within the specified time will not be refreshed when updating  sources with [SPACE].",
       "group-id": "42",
       "type": "float"
     },
     "sb_status": {
       "default": "1",
-      "desc": "This toggles whether the server status should be displayed in the two bottom \nlines of the server browser.",
+      "desc": "This toggles whether the server status should be displayed in the two bottom lines of the server browser.",
       "group-id": "42",
       "type": "boolean",
       "values": [
         {
-          "description": "do not display the status",
+          "description": "do not display the status.",
           "name": "false"
         },
         {
-          "description": "display the status",
+          "description": "display the status.",
           "name": "true"
         }
       ]
@@ -17586,7 +17795,7 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Disable",
+          "description": "Disable.",
           "name": "false"
         },
         {
@@ -17598,7 +17807,7 @@
     "scr_autoid": {
       "default": "5",
       "group-id": "40",
-      "remarks": "Only works when spectating. You can remove the drawing of the playername by using scr_autoid_drawname 0.",
+      "remarks": "Only works when spectating.\nYou can remove the drawing of the playername by using scr_autoid_drawname 0.",
       "type": "enum",
       "values": [
         {
@@ -17646,7 +17855,7 @@
       "default": "16",
       "desc": "Sets a fixed length of the bar for autoid functionality.",
       "group-id": "40",
-      "remarks": "If 0, length will be based on scr_autoid_namelength and/or length of individual player's name",
+      "remarks": "If 0, length will be based on scr_autoid_namelength and/or length of individual player's name.",
       "type": "integer"
     },
     "scr_autoid_drawname": {
@@ -17655,11 +17864,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Player name is not drawn above player when scr_autoid >0",
+          "description": "Player name is not drawn above player when scr_autoid >0.",
           "name": "false"
         },
         {
-          "description": "Player name is drawn above player when scr_autoid >0",
+          "description": "Player name is drawn above player when scr_autoid >0.",
           "name": "true"
         }
       ]
@@ -17691,7 +17900,7 @@
     },
     "scr_autoid_namelength": {
       "default": "0",
-      "desc": "Maximum number of characters in a player name above player's head with autoid",
+      "desc": "Maximum number of characters in a player name above player's head with autoid.",
       "group-id": "40",
       "type": "integer"
     },
@@ -17703,7 +17912,7 @@
     },
     "scr_autoid_scale": {
       "default": "1",
-      "desc": "Sets relative size of scr_autoid display",
+      "desc": "Sets relative size of scr_autoid display.",
       "group-id": "40",
       "type": "float"
     },
@@ -17717,44 +17926,44 @@
           "name": "false"
         },
         {
-          "description": "Player's weapon is indicated by an icon",
+          "description": "Player's weapon is indicated by an icon.",
           "name": "true"
         }
       ]
     },
     "scr_autoid_weapons": {
       "default": "2",
-      "desc": "When scr_autoid is > 4, this determines when the player's best weapon will appear",
+      "desc": "When scr_autoid is > 4, this determines when the player's best weapon will appear.",
       "group-id": "40",
-      "remarks": "The order of 'best' weapon can be controlled via the 'tp_weapon_order' variable",
+      "remarks": "The order of 'best' weapon can be controlled via the 'tp_weapon_order' variable.",
       "type": "enum",
       "values": [
         {
-          "description": "Shotgun or better",
+          "description": "Shotgun or better.",
           "name": "1"
         },
         {
-          "description": "Super-shotgun or better",
+          "description": "Super-shotgun or better.",
           "name": "2"
         },
         {
-          "description": "Nailgun or better",
+          "description": "Nailgun or better.",
           "name": "4"
         },
         {
-          "description": "Super nailgun or better",
+          "description": "Super nailgun or better.",
           "name": "8"
         },
         {
-          "description": "Grenade launcher or better",
+          "description": "Grenade launcher or better.",
           "name": "16"
         },
         {
-          "description": "Rocket launcher or better",
+          "description": "Rocket launcher or better.",
           "name": "32"
         },
         {
-          "description": "Lightning gun or better",
+          "description": "Lightning gun or better.",
           "name": "64"
         }
       ]
@@ -17791,7 +18000,7 @@
     },
     "scr_centershift": {
       "default": "0",
-      "desc": "Shifts all centerprints. If you are playing in 1280x1024 and want to watch some demo recorded in 320x200 with +wp_stats (ktpro) or sbar_on (teamfortress) you can shift that text down.",
+      "desc": "Shifts all centerprints.\nIf you are playing in 1280x1024 and want to watch some demo recorded in 320x200 with +wp_stats (ktpro) or sbar_on (teamfortress) you can shift that text down.",
       "group-id": "40",
       "type": "integer",
       "values": [
@@ -17808,7 +18017,7 @@
     },
     "scr_centertime": {
       "default": "2",
-      "desc": "This variable sets the amount of time in seconds that centerprinted messages \nstay on the screen.",
+      "desc": "This variable sets the amount of time in seconds that centerprinted messages stay on the screen.",
       "group-id": "40",
       "type": "enum",
       "values": [
@@ -17828,7 +18037,7 @@
     },
     "scr_coloredText": {
       "default": "1",
-      "desc": "Allows colored text in scoreboard, console and notify area.\nscr_coloredText",
+      "desc": "Allows colored text in scoreboard, console and notify area.",
       "group-id": "40",
       "remarks": "See Colored text manual page for more details.",
       "type": "enum",
@@ -17855,11 +18064,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Coloring off",
+          "description": "Coloring off.",
           "name": "false"
         },
         {
-          "description": "Coloring on",
+          "description": "Coloring on.",
           "name": "true"
         }
       ]
@@ -17924,7 +18133,7 @@
     },
     "scr_conback": {
       "default": "1",
-      "desc": "Allows display of map preview as a console background",
+      "desc": "Allows display of map preview as a console background.",
       "group-id": "5",
       "type": "enum",
       "values": [
@@ -17946,7 +18155,7 @@
       "default": "conback",
       "desc": "Console background image filename.",
       "group-id": "5",
-      "remarks": "Put console images into id1/gfx or qw/gfx or ezquake/gfx",
+      "remarks": "Put console images into id1/gfx or qw/gfx or ezquake/gfx.",
       "type": "string"
     },
     "scr_consize": {
@@ -18026,7 +18235,7 @@
       "default": "1",
       "desc": "Displays horizontal bar with frag stats (4 cells) in the old hud.",
       "group-id": "47",
-      "remarks": "Required settings for this to work: scr_newhud 0 or 2, viewsize below 110, cl_sbar 1 or cl_sbar 0 but vid_conwidth below 512; if you migrated from FuhQuake and can't get this to work, check these settings, the feature should work the same as in FuhQuake",
+      "remarks": "Required settings for this to work:\nscr_newhud 0 or 2, viewsize below 110, cl_sbar 1 or cl_sbar 0 but vid_conwidth below 512.\nif you migrated from FuhQuake and can't get this to work, check these settings, the feature should work the same as in FuhQuake.",
       "type": "enum",
       "values": [
         {
@@ -18045,9 +18254,9 @@
     },
     "scr_drawVFrags": {
       "default": "1",
-      "desc": "Shows vertical row with frag stats on the right side of the old hud. When teamplay mode is on, will display also frags per team.",
+      "desc": "Shows vertical row with frag stats on the right side of the old hud.\nWhen teamplay mode is on, will display also frags per team.",
       "group-id": "47",
-      "remarks": "Note: vid_conwidth must be at least 512, scr_centerSbar must be disabled; works only in deathmatch, not in cooperative",
+      "remarks": "Note: vid_conwidth must be at least 512, scr_centerSbar must be disabled.\nWorks only in deathmatch, not in cooperative.",
       "type": "enum",
       "values": [
         {
@@ -18071,11 +18280,11 @@
       "type": "enum",
       "values": [
         {
-          "description": "Standard QWCL behaviour - reduce vertical fov, cropping image",
+          "description": "Standard QWCL behaviour: reduce vertical fov, cropping image.",
           "name": "0"
         },
         {
-          "description": "Reduce horizontal size, keeping aspect ratio correct",
+          "description": "Reduce horizontal size, keeping aspect ratio correct.",
           "name": "1"
         }
       ]
@@ -18098,7 +18307,7 @@
     },
     "scr_menudrawhud": {
       "default": "0",
-      "desc": "Draw HUD elements/crosshair/etc in background of main menu. Useful when HUD distracting you in server browser.",
+      "desc": "Draw HUD elements/crosshair/etc in background of main menu.\nUseful when HUD distracting you in server browser.",
       "group-id": "40",
       "type": "boolean",
       "values": [
@@ -18118,11 +18327,11 @@
       "type": "enum",
       "values": [
         {
-          "description": "Old standard status bar",
+          "description": "Old standard status bar.",
           "name": "0"
         },
         {
-          "description": "New customizable status bar",
+          "description": "New customizable status bar.",
           "name": "1"
         },
         {
@@ -18141,22 +18350,22 @@
           "name": "false"
         },
         {
-          "description": "The notify area is always shown",
+          "description": "The notify area is always shown.",
           "name": "true"
         }
       ]
     },
     "scr_printspeed": {
       "default": "8",
-      "desc": "This variable controls how fast the text is displayed at the end of the single \nplayer episodes.",
+      "desc": "This variable controls how fast the text is displayed at the end of the single player episodes.",
       "group-id": "5",
       "type": "float"
     },
     "scr_qtvbuffer": {
       "default": "0",
-      "desc": "Enables display of the QTV buffer status",
+      "desc": "Enables display of the QTV buffer status.",
       "group-id": "40",
-      "remarks": "Makes it able to check how much of the stream is buffered on the client side",
+      "remarks": "Makes it able to check how much of the stream is buffered on the client side.",
       "type": "boolean",
       "values": [
         {
@@ -18171,13 +18380,13 @@
     },
     "scr_qtvbuffer_x": {
       "default": "0",
-      "desc": "Horizontal position of the qtvbuffer counter",
+      "desc": "Horizontal position of the qtvbuffer counter.",
       "group-id": "40",
       "type": "integer"
     },
     "scr_qtvbuffer_y": {
       "default": "-10",
-      "desc": "Vertical position of the qtvbuffer counter",
+      "desc": "Vertical position of the qtvbuffer counter.",
       "group-id": "40",
       "type": "integer"
     },
@@ -18400,43 +18609,43 @@
       "type": "enum",
       "values": [
         {
-          "description": "If user is AFK, time replaced with AFK",
+          "description": "If user is AFK, time replaced with AFK.",
           "name": "1"
         },
         {
-          "description": "If user is AFK, time value shown in red",
+          "description": "If user is AFK, time value shown in red.",
           "name": "2"
         }
       ]
     },
     "scr_scoreboard_borderless": {
       "default": "1",
-      "desc": "Controls scoreboard border behavior",
+      "desc": "Controls scoreboard border behavior.",
       "group-id": "47",
       "type": "boolean",
       "values": [
         {
-          "description": "no scoreboard border will be displayed",
+          "description": "no scoreboard border will be displayed.",
           "name": "false"
         },
         {
-          "description": "scoreboard border will be displayed",
+          "description": "scoreboard border will be displayed.",
           "name": "true"
         }
       ]
     },
     "scr_scoreboard_centered": {
       "default": "1",
-      "desc": "Controls X-position of scoreboard",
+      "desc": "Controls X-position of scoreboard.",
       "group-id": "47",
       "type": "boolean",
       "values": [
         {
-          "description": "Scoreboard will not be centered",
+          "description": "Scoreboard will not be centered.",
           "name": "false"
         },
         {
-          "description": "Scoreboard will be centered",
+          "description": "Scoreboard will be centered.",
           "name": "true"
         }
       ]
@@ -18463,7 +18672,7 @@
       "type": "float",
       "values": [
         {
-          "description": "[0...1] 0=transparent scoreboard 1=black scoreboard",
+          "description": "[0...1] 0=transparent scoreboard 1=black scoreboard.",
           "name": "*"
         }
       ]
@@ -18486,11 +18695,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "When you overwrite team/enemy color it will use only those colors for skins",
+          "description": "When you overwrite team/enemy color it will use only those colors for skins.",
           "name": "false"
         },
         {
-          "description": "When you overwrite team/enemy color it will use only those colors for skins and scoreboard",
+          "description": "When you overwrite team/enemy color it will use only those colors for skins and scoreboard.",
           "name": "true"
         }
       ]
@@ -18522,7 +18731,7 @@
       "type": "integer",
       "values": [
         {
-          "description": "If 0, scoreboard will be shown at the left of the screen (scr_scoreboard_centered 0) or middle (scr_scoreboard_centered 1). If nonzero, the scoreboard will be shifted left (negative values) or right (positive values).",
+          "description": "If 0, scoreboard will be shown at the left of the screen (scr_scoreboard_centered 0) or middle (scr_scoreboard_centered 1).\nIf nonzero, the scoreboard will be shifted left (negative values) or right (positive values).",
           "name": "*"
         }
       ]
@@ -18534,7 +18743,7 @@
       "type": "integer",
       "values": [
         {
-          "description": "If 0, scoreboard will be shown at the top of the screen. If nonzero, the scoreboard will be shifted down.",
+          "description": "If 0, scoreboard will be shown at the top of the screen.\nIf nonzero, the scoreboard will be shifted down.",
           "name": "*"
         }
       ]
@@ -18561,7 +18770,7 @@
       ]
     },
     "scr_scoreboard_spectator_name": {
-      "desc": "This variable will change what spectators are called in the scoreboard. When teamplay is not on, this variable is cut to 4 characters. &cRGB values are not accepted.",
+      "desc": "This variable will change what spectators are called in the scoreboard.\nWhen teamplay is not on, this variable is cut to 4 characters.\n&cRGB values are not accepted.",
       "group-id": "47",
       "type": "string"
     },
@@ -18582,7 +18791,7 @@
     },
     "scr_showcrosshair": {
       "default": "1",
-      "desc": "Allows you to force the display of the crosshair when in menus or in scoreboard",
+      "desc": "Allows you to force the display of the crosshair when in menus or in scoreboard.",
       "group-id": "40",
       "type": "boolean",
       "values": [
@@ -18598,19 +18807,19 @@
     },
     "scr_shownick_frame_color": {
       "default": "10 0 0 120",
-      "desc": "If using '/shownick 1' in KTX, this determines the color of the frame around the on-screen information",
+      "desc": "If using '/shownick 1' in KTX, this determines the color of the frame around the on-screen information.",
       "group-id": "40",
       "type": "string"
     },
     "scr_shownick_name_width": {
       "default": "6",
-      "desc": "Maximum length of player's name when using '/shownick 1' in KTX",
+      "desc": "Maximum length of player's name when using '/shownick 1' in KTX.",
       "group-id": "40",
       "type": "integer"
     },
     "scr_shownick_order": {
       "default": "%p%n %a/%H %w",
-      "desc": "Format string for results of '/shownick 1' in KTX",
+      "desc": "Format string for results of '/shownick 1' in KTX.",
       "group-id": "40",
       "type": "string"
     },
@@ -18622,40 +18831,40 @@
     },
     "scr_shownick_scale": {
       "default": "1",
-      "desc": "Adjusts relative size of text when showing results of '/shownick 1' in KTX",
+      "desc": "Adjusts relative size of text when showing results of '/shownick 1' in KTX.",
       "group-id": "40",
       "type": "float"
     },
     "scr_shownick_time": {
       "default": "0.8",
-      "desc": "Number of seconds to show results of '/shownick 1' command in KTX",
+      "desc": "Number of seconds to show results of '/shownick 1' command in KTX.",
       "group-id": "40",
       "type": "float"
     },
     "scr_shownick_x": {
       "default": "0",
-      "desc": "Horizontal position of the shownick label",
+      "desc": "Horizontal position of the shownick label.",
       "group-id": "40",
       "type": "integer"
     },
     "scr_shownick_y": {
       "default": "0",
-      "desc": "Vertical position of the shownick label",
+      "desc": "Vertical position of the shownick label.",
       "group-id": "40",
       "type": "integer"
     },
     "scr_spectatorMessage": {
       "default": "1",
-      "desc": "Switch on/off the text at the bottom of the screen when spectating in free mode: \"SPECTATOR MODE | PRESS [ATTACK] for AutoCamera\"",
+      "desc": "Switch on/off the text at the bottom of the screen when spectating in free mode:\n\"SPECTATOR MODE | PRESS [ATTACK] for AutoCamera\"",
       "group-id": "40",
       "type": "boolean",
       "values": [
         {
-          "description": "Off",
+          "description": "Off.",
           "name": "false"
         },
         {
-          "description": "On",
+          "description": "On.",
           "name": "true"
         }
       ]
@@ -18679,7 +18888,7 @@
     },
     "scr_teaminfo_align_right": {
       "default": "1",
-      "desc": "Aligns scr_teaminfo left or right",
+      "desc": "Aligns scr_teaminfo left or right.",
       "group-id": "40",
       "type": "boolean",
       "values": [
@@ -18700,7 +18909,7 @@
       "type": "enum",
       "values": [
         {
-          "description": "Does not display teammates' armor",
+          "description": "Does not display teammates' armor.",
           "name": "0"
         },
         {
@@ -18724,14 +18933,14 @@
       "type": "string",
       "values": [
         {
-          "description": "R G B alpha, each 0-255",
+          "description": "R G B alpha, each 0-255.",
           "name": "*"
         }
       ]
     },
     "scr_teaminfo_loc_width": {
       "default": "5",
-      "desc": "Sets the width for %l",
+      "desc": "Sets the width for %l.",
       "group-id": "40",
       "type": "integer",
       "values": [
@@ -18743,31 +18952,31 @@
     },
     "scr_teaminfo_low_health": {
       "default": "25",
-      "desc": "Sets a minimum health value to display red. E.g. if scr_teaminfo_low_health is 20, and a teammate has 20 health or less, then their health will be displayed red.",
+      "desc": "Sets a minimum health value to display red.\nE.g. if scr_teaminfo_low_health is 20, and a teammate has 20 health or less, then their health will be displayed red.",
       "group-id": "40",
       "type": "float",
       "values": [
         {
-          "description": "From 1-99",
+          "description": "From 1-99.",
           "name": "*"
         }
       ]
     },
     "scr_teaminfo_name_width": {
       "default": "6",
-      "desc": "Sets name width in scr_teaminfo",
+      "desc": "Sets name width in scr_teaminfo.",
       "group-id": "40",
       "type": "integer",
       "values": [
         {
-          "description": "From 0 (don't display name) to 20",
+          "description": "From 0 (don't display name) to 20.",
           "name": "*"
         }
       ]
     },
     "scr_teaminfo_order": {
       "default": "%p%n $x10%l$x11 %a/%H %w",
-      "desc": "Changes the order of displayed items in scr_teaminfo",
+      "desc": "Changes the order of displayed items in scr_teaminfo.",
       "group-id": "40",
       "remarks": "default: \"%p%n [%l] %h/%a %w\"",
       "type": "string",
@@ -18780,20 +18989,20 @@
     },
     "scr_teaminfo_powerup_style": {
       "default": "1",
-      "desc": "Controls how powerup indicators are displayed in scr_teaminfo",
+      "desc": "Controls how powerup indicators are displayed in scr_teaminfo.",
       "group-id": "40",
       "type": "enum",
       "values": [
         {
-          "description": "Powerup icons",
+          "description": "Powerup icons.",
           "name": "1"
         },
         {
-          "description": "Player face",
+          "description": "Player face.",
           "name": "2"
         },
         {
-          "description": "Colored text",
+          "description": "Colored text.",
           "name": "3"
         }
       ]
@@ -18824,11 +19033,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Do not show enemy players status",
+          "description": "Do not show enemy players status.",
           "name": "false"
         },
         {
-          "description": "Show enemy players status in teaminfo table",
+          "description": "Show enemy players status in teaminfo table.",
           "name": "true"
         }
       ]
@@ -18840,15 +19049,15 @@
       "type": "enum",
       "values": [
         {
-          "description": "Do not show tracked player status in the teaminfo table",
+          "description": "Do not show tracked player status in the teaminfo table.",
           "name": "0"
         },
         {
-          "description": "Show tracked player in the teaminfo table",
+          "description": "Show tracked player in the teaminfo table.",
           "name": "1"
         },
         {
-          "description": "Show tracked player when watching demos/QTV only",
+          "description": "Show tracked player when watching demos/QTV only.",
           "name": "2"
         }
       ]
@@ -18860,7 +19069,7 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Displays teammates' weapon as an icon",
+          "description": "Displays teammates' weapon as an icon.",
           "name": "false"
         },
         {
@@ -18871,24 +19080,24 @@
     },
     "scr_teaminfo_x": {
       "default": "0",
-      "desc": "Moves scr_teaminfo in the x-direction",
+      "desc": "Moves scr_teaminfo in the x-direction.",
       "group-id": "40",
       "type": "integer",
       "values": [
         {
-          "description": "from -255 to 255",
+          "description": "from -255 to 255.",
           "name": "*"
         }
       ]
     },
     "scr_teaminfo_y": {
       "default": "0",
-      "desc": "Moves scr_teaminfo in the y-direction",
+      "desc": "Moves scr_teaminfo in the y-direction.",
       "group-id": "40",
       "type": "integer",
       "values": [
         {
-          "description": "from -255 to 255",
+          "description": "from -255 to 255.",
           "name": "*"
         }
       ]
@@ -18906,7 +19115,7 @@
       ]
     },
     "scr_weaponstats": {
-      "desc": "Displays weapons stats on server that support it",
+      "desc": "Displays weapons stats on server that support it.",
       "group-id": "40",
       "type": "boolean",
       "values": [
@@ -18925,17 +19134,17 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Displays weapon stats on the left hand side of the screen",
+          "description": "Displays weapon stats on the left hand side of the screen.",
           "name": "false"
         },
         {
-          "description": "Displays weapon stats on the right hand side of the screen",
+          "description": "Displays weapon stats on the right hand side of the screen.",
           "name": "true"
         }
       ]
     },
     "scr_weaponstats_frame_color": {
-      "desc": "Sets the color of the frame around scr_weaponstats display",
+      "desc": "Sets the color of the frame around scr_weaponstats display.",
       "group-id": "40",
       "type": "string"
     },
@@ -18945,23 +19154,23 @@
       "type": "string"
     },
     "scr_weaponstats_scale": {
-      "desc": "Controls size of scr_weaponstats display.  1 = Normal text size",
+      "desc": "Controls size of scr_weaponstats display.\n1 - Normal text size.",
       "group-id": "40",
       "type": "float"
     },
     "scr_weaponstats_x": {
-      "desc": "Horizontal placement of the weapon stats table",
+      "desc": "Horizontal placement of the weapon stats table.",
       "group-id": "40",
       "type": "integer"
     },
     "scr_weaponstats_y": {
-      "desc": "Vertical placement of the weapon stats table",
+      "desc": "Vertical placement of the weapon stats table.",
       "group-id": "40",
       "type": "integer"
     },
     "sensitivity": {
       "default": "12",
-      "desc": "This variable sets the sensitivity of the mouse, it is one of the most important \nvariables in the whole game.",
+      "desc": "This variable sets the sensitivity of the mouse, it is one of the most important variables in the whole game.",
       "group-id": "10",
       "type": "float"
     },
@@ -18999,7 +19208,7 @@
     },
     "show_speed": {
       "default": "0",
-      "desc": "Displays a speed counter in the top right corner in the client's units (Horizontal velocity). (320 - Normal walking speed, 440 - Accel jump, 450 - Bunnyhopping)",
+      "desc": "Displays a speed counter in the top right corner in the client's units (Horizontal velocity).\n\n320 - Normal walking speed.\n440 - Accel jump.\n450 - Bunnyhopping.",
       "group-id": "40",
       "type": "enum",
       "values": [
@@ -19031,7 +19240,7 @@
     },
     "show_velocity_3d": {
       "default": "0",
-      "desc": "Shows your velocity as 3d vector and its projections (*GL ONLY*).\n",
+      "desc": "Shows your velocity as 3d vector and its projections (*GL ONLY*).",
       "group-id": "40",
       "remarks": "See also show_velocity_3d_offset_forward, show_velocity_3d_offset_down.",
       "type": "enum",
@@ -19041,11 +19250,11 @@
           "name": "0"
         },
         {
-          "description": "velocity and projections",
+          "description": "velocity and projections.",
           "name": "1"
         },
         {
-          "description": "only horizontal velocity and projections",
+          "description": "only horizontal velocity and projections.",
           "name": "2"
         }
       ]
@@ -19066,11 +19275,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Disable text dump printing dropped packets",
+          "description": "Disable text dump printing dropped packets.",
           "name": "false"
         },
         {
-          "description": "Enable text dump printing dropped packets",
+          "description": "Enable text dump printing dropped packets.",
           "name": "true"
         }
       ]
@@ -19119,11 +19328,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Never display the ram icon",
+          "description": "Never display the ram icon.",
           "name": "false"
         },
         {
-          "description": "Display the ram icon when running out of memory",
+          "description": "Display the ram icon when running out of memory.",
           "name": "true"
         }
       ]
@@ -19173,22 +19382,22 @@
       "type": "string"
     },
     "skin_browser_democolor": {
-      "desc": "Color of the demo entries in the skin browser",
+      "desc": "Color of the demo entries in the skin browser.",
       "group-id": "25",
       "type": "string"
     },
     "skin_browser_dircolor": {
-      "desc": "Color of the dir entries in the skin browser",
+      "desc": "Color of the dir entries in the skin browser.",
       "group-id": "25",
       "type": "string"
     },
     "skin_browser_interline": {
-      "desc": "Size of the space between entries in the skin browser",
+      "desc": "Size of the space between entries in the skin browser.",
       "group-id": "25",
       "type": "integer"
     },
     "skin_browser_scrollnames": {
-      "desc": "Toggle scrolling of the filenames in the skin browser",
+      "desc": "Toggle scrolling of the filenames in the skin browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -19203,12 +19412,12 @@
       ]
     },
     "skin_browser_selectedcolor": {
-      "desc": "Color of the selected entries in the skin browser",
+      "desc": "Color of the selected entries in the skin browser.",
       "group-id": "25",
       "type": "string"
     },
     "skin_browser_showdate": {
-      "desc": "Toggle the date column in the skin browser",
+      "desc": "Toggle the date column in the skin browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -19223,7 +19432,7 @@
       ]
     },
     "skin_browser_showsize": {
-      "desc": "Toggle the file size column in the skin browser",
+      "desc": "Toggle the file size column in the skin browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -19238,7 +19447,7 @@
       ]
     },
     "skin_browser_showstatus": {
-      "desc": "Toggle the display of the status bar in the skin browser",
+      "desc": "Toggle the display of the status bar in the skin browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -19253,7 +19462,7 @@
       ]
     },
     "skin_browser_showtime": {
-      "desc": "Toggle the time column in the skin browser",
+      "desc": "Toggle the time column in the skin browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -19268,12 +19477,12 @@
       ]
     },
     "skin_browser_sortmode": {
-      "desc": "Sorting mode in the skin browser. Each number represents one column. Their order represents the priority of the sorting.",
+      "desc": "Sorting mode in the skin browser.\nEach number represents one column. Their order represents the priority of the sorting.",
       "group-id": "25",
       "type": "string"
     },
     "skin_browser_stripnames": {
-      "desc": "Toggle stripping of the filenames in the skin browser",
+      "desc": "Toggle stripping of the filenames in the skin browser.",
       "group-id": "25",
       "type": "boolean",
       "values": [
@@ -19288,7 +19497,7 @@
       ]
     },
     "skin_browser_zipcolor": {
-      "desc": "Color of the zip entries in the skin browser",
+      "desc": "Color of the zip entries in the skin browser.",
       "group-id": "25",
       "type": "string"
     },
@@ -19309,7 +19518,7 @@
     },
     "spectator_password": {
       "default": "",
-      "desc": "A password spectators must use to connect to local server",
+      "desc": "A password spectators must use to connect to local server.",
       "group-id": "43",
       "type": "string"
     },
@@ -19337,9 +19546,27 @@
     },
     "sshot_format": {
       "default": "png",
-      "desc": "tga = Tga screenshots (gl only)\npng = Png screenshots\njpg = Jpg screenshots (gl only)\npcx = Pcx screenshots (software only)",
+      "desc": "File format used when saving screenshots.",
       "group-id": "41",
-      "type": "string"
+      "type": "string",
+      "values": [
+        {
+          "description": "TGA screenshots (gl only)",
+          "name": "tga"
+        },
+        {
+          "description": "PNG screenshots",
+          "name": "png"
+        },
+        {
+          "description": "JPEG screenshots (gl only)",
+          "name": "jpg"
+        },
+        {
+          "description": "Pcx screenshots (software only)",
+          "name": "pcx"
+        }
+      ]
     },
     "sv_accelerate": {
       "desc": "Sets the acceleration value for the player.",
@@ -19455,9 +19682,9 @@
       "type": ""
     },
     "sv_downloadchunksperframe": {
-      "desc": "Limits the speed of the chunked downloads",
+      "desc": "Limits the speed of the chunked downloads.",
       "group-id": "43",
-      "remarks": "Server-side. Clients can set high amount of chunks per frame allowed and make your data eat connection traffic rapidly. Use this variable to prevent this.",
+      "remarks": "Server-side.\nClients can set high amount of chunks per frame allowed and make your data eat connection traffic rapidly. Use this variable to prevent this.",
       "type": ""
     },
     "sv_enable_cmd_minping": {
@@ -19568,7 +19795,7 @@
     },
     "sv_mapcheck": {
       "group-id": "43",
-      "remarks": "Note: A player who has edited his map files to cheat by removing textures \nfrom walls will not be able to join the server and play.",
+      "remarks": "Note: A player who has edited his map files to cheat by removing textures from walls will not be able to join the server and play.",
       "type": "boolean",
       "values": [
         {
@@ -19590,13 +19817,13 @@
       "type": ""
     },
     "sv_maxpitch": {
-      "desc": "server-side variable for setting maximum of view angles",
+      "desc": "server-side variable for setting maximum of view angles.",
       "group-id": "43",
-      "remarks": "EZQuake and ZQuake (may be some other) clients understand this physics change, old clients will be clamped at [-70~80] (quakeworld default) view angles.",
+      "remarks": "EZQuake and ZQuake (may be some other) clients understand this physics change.\nOld clients will be clamped at [-70~80] (quakeworld default) view angles.",
       "type": "integer",
       "values": [
         {
-          "description": "By default, in quakeworld maximum viewangle is '80'. You can set for example '90' then you will be able look directly to sky. q3 players should like it",
+          "description": "By default, in quakeworld maximum viewangle is '80'. You can set for example '90' then you will be able look directly to sky. q3 players should like it.",
           "name": "*"
         }
       ]
@@ -19612,7 +19839,7 @@
       "type": "float"
     },
     "sv_maxtic": {
-      "desc": "The maximum amount of time in seconds before a client a receives an update \nfrom the server.",
+      "desc": "The maximum amount of time in seconds before a client a receives an update from the server.",
       "group-id": "43",
       "type": "float"
     },
@@ -19630,9 +19857,9 @@
       "type": ""
     },
     "sv_minpitch": {
-      "desc": "server-side variable for setting minimum of view angles",
+      "desc": "server-side variable for setting minimum of view angles.",
       "group-id": "43",
-      "remarks": "EZQuake and ZQuake (may be some other) clients understand this physics change, old clients will be clamped at [-70~80] (quakeworld default) view angles.",
+      "remarks": "EZQuake and ZQuake (may be some other) clients understand this physics change.\nOld clients will be clamped at [-70~80] (quakeworld default) view angles.",
       "type": "integer",
       "values": [
         {
@@ -19642,7 +19869,7 @@
       ]
     },
     "sv_mintic": {
-      "desc": "The minimum amount of time the server will wait before sending packets to \na client.",
+      "desc": "The minimum amount of time the server will wait before sending packets to a client.",
       "group-id": "43",
       "type": "float"
     },
@@ -19660,7 +19887,7 @@
           "name": "false"
         },
         {
-          "description": "Allows nails in most cases to uses less bandwidth and to fly around",
+          "description": "Allows nails in most cases to uses less bandwidth and to fly around.",
           "name": "true"
         }
       ]
@@ -19679,15 +19906,15 @@
       "type": "enum",
       "values": [
         {
-          "description": "pause is off",
+          "description": "pause is off.",
           "name": "0"
         },
         {
-          "description": "normal pause that can be set by 'pause' command",
+          "description": "normal pause that can be set by 'pause' command.",
           "name": "1"
         },
         {
-          "description": "auto pause (single player only) when going into menus",
+          "description": "auto pause (single player only) when going into menus.",
           "name": "2"
         },
         {
@@ -19706,7 +19933,7 @@
           "name": "false"
         },
         {
-          "description": "Has something to do with the table which is build at the loading time",
+          "description": "Has something to do with the table which is build at the loading time.",
           "name": "true"
         }
       ]
@@ -19799,7 +20026,7 @@
       "type": "float"
     },
     "sv_timeout": {
-      "desc": "Sets the amount of time in seconds before a client is considered disconnected \nif the server does not receive a packet.",
+      "desc": "Sets the amount of time in seconds before a client is considered disconnected if the server does not receive a packet.",
       "group-id": "43",
       "type": "float"
     },
@@ -19847,11 +20074,11 @@
     "sys_disableWinKeys": {
       "default": "0",
       "group-id": "48",
-      "remarks": "Note: Windows keys are now bindable (LWINKEY, RWINKEY, WINKEY, POPUPMENU). Obviously only useful on NT/2K/XP with sys_disableWinKeys 1 (and possibly useful in Linux too!).",
+      "remarks": "Note: Windows keys are now bindable (LWINKEY, RWINKEY, WINKEY, POPUPMENU).\nObviously only useful on NT/2K/XP with sys_disableWinKeys 1 (and possibly useful in Linux too!).",
       "type": "integer",
       "values": [
         {
-          "description": "Winkeys are processed by operating system",
+          "description": "Winkeys are processed by operating system.",
           "name": "0"
         },
         {
@@ -19870,11 +20097,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "alt-enter will toggle full-screen mode",
+          "description": "alt-enter will toggle full-screen mode.",
           "name": "false"
         },
         {
-          "description": "alt-enter ignored by ezquake",
+          "description": "alt-enter ignored by ezquake.",
           "name": "true"
         }
       ]
@@ -19915,7 +20142,7 @@
     },
     "sys_inactivesound": {
       "default": "0",
-      "desc": "Enables sounds when the application is not focused",
+      "desc": "Enables sounds when the application is not focused.",
       "group-id": "48",
       "type": "boolean",
       "values": [
@@ -19941,7 +20168,7 @@
     },
     "sys_yieldcpu": {
       "default": "0",
-      "desc": "Controls CPU sharing when client is waiting to draw a frame. When disabled, client will run a loop, actively waiting for the time to draw a new frame. When enabled, client will call system sleep function during the waiting, which will cause the thread to be deactivated for a while - leading to significantly lower CPU usage in most cases.",
+      "desc": "Controls CPU sharing when client is waiting to draw a frame.\nWhen disabled, client will run a loop, actively waiting for the time to draw a new frame.\nWhen enabled, client will call system sleep function during the waiting, which will cause the thread to be deactivated for a while - leading to significantly lower CPU usage in most cases.",
       "group-id": "48",
       "type": "boolean",
       "values": [
@@ -19969,7 +20196,7 @@
     },
     "teambottomcolor": {
       "default": "-1",
-      "desc": "Determines the color of the pants of the teammates you see. Overrides player's skin settings.",
+      "desc": "Determines the color of the pants of the teammates you see.\nOverrides player's skin settings.",
       "group-id": "44",
       "remarks": "To be able to use RGB 24bit colors, look for r_teamskincolor variable.",
       "type": "enum",
@@ -19999,7 +20226,7 @@
           "name": "4"
         },
         {
-          "description": "Lt Brown",
+          "description": "Light Brown",
           "name": "5"
         },
         {
@@ -20007,7 +20234,7 @@
           "name": "6"
         },
         {
-          "description": "Lt Peach",
+          "description": "Light Peach",
           "name": "7"
         },
         {
@@ -20015,7 +20242,7 @@
           "name": "8"
         },
         {
-          "description": "Dk Purple",
+          "description": "Dark Purple",
           "name": "9"
         },
         {
@@ -20038,17 +20265,17 @@
     },
     "teamforceskins": {
       "default": "0",
-      "desc": "Allows you to set different skin for every team player even if they all have same skin names set or use names of skins that you do not have in your Quake dir",
+      "desc": "Allows you to set different skin for every team player even if they all have same skin names set or use names of skins that you do not have in your Quake dir.",
       "group-id": "44",
       "remarks": "Read \"Player skins\" manual page for more info on skin rules.",
       "type": "enum",
       "values": [
         {
-          "description": "Disabled",
+          "description": "Disabled.",
           "name": "0"
         },
         {
-          "description": "Use player's name as the name of the skin to be used",
+          "description": "Use player's name as the name of the skin to be used.",
           "name": "1"
         },
         {
@@ -20063,12 +20290,20 @@
     },
     "teamlock": {
       "default": "0",
-      "desc": "Observing feature. Do not toggle enemy recognition when you switch players. One team will always remain marked as enemy even if you spec their players.",
+      "desc": "Observing feature. Do not toggle enemy recognition when you switch players.\nOne team will always remain marked as enemy even if you spec their players.",
       "group-id": "44",
       "type": "string",
       "values": [
         {
-          "description": "Either 0 or 1 to turn this feature on / off, or put in the name of the team that will always be recognized as not-enemy.",
+          "description": "Do not lock team/enemy",
+          "name": "0"
+        },
+        {
+          "description": "Lock team/enemy",
+          "name": "1"
+        },
+        {
+          "description": "Lock the specified team name as \"team\"",
           "name": "*"
         }
       ]
@@ -20081,10 +20316,25 @@
     },
     "teamplay": {
       "default": "0",
-      "desc": "Teamplay mode",
+      "desc": "Teamplay mode.",
       "group-id": "43",
-      "remarks": "Nowadays only value 2 is used; value 1 prevents you from killing your teammates including yourself",
-      "type": "integer"
+      "remarks": "Nowadays only value 2 is used.",
+      "type": "integer",
+      "values": [
+        {
+          "description": "No teamplay",
+          "name": "0"
+        },
+        {
+          "description": "Teamplay with no suicides or teamkills",
+          "name": "1"
+        },
+        {
+          "description": "Teamplay with teamkills",
+          "name": "2"
+        }
+      ]
+
     },
     "teamquadskin": {
       "default": "",
@@ -20100,7 +20350,7 @@
     },
     "teamtopcolor": {
       "default": "-1",
-      "desc": "Determines the color of the shirt of the teammates you see. Overrides player's skin settings.",
+      "desc": "Determines the color of the shirt of the teammates you see.\nOverrides player's skin settings.",
       "group-id": "44",
       "remarks": "To be able to use RGB 24bit colors, look for r_teamskincolor variable.",
       "type": "enum",
@@ -20130,7 +20380,7 @@
           "name": "4"
         },
         {
-          "description": "Lt Brown",
+          "description": "Light Brown",
           "name": "5"
         },
         {
@@ -20138,7 +20388,7 @@
           "name": "6"
         },
         {
-          "description": "Lt Peach",
+          "description": "Light Peach",
           "name": "7"
         },
         {
@@ -20146,7 +20396,7 @@
           "name": "8"
         },
         {
-          "description": "Dk Purple",
+          "description": "Dark Purple",
           "name": "9"
         },
         {
@@ -20173,13 +20423,13 @@
       "type": ""
     },
     "telnet_password": {
-      "desc": "Password for login via telnet.  Not currently used.",
+      "desc": "Password for login via telnet.\nNot currently used.",
       "group-id": "43",
       "type": "string"
     },
     "timelimit": {
       "default": "0",
-      "desc": "Number of minutes the match will take",
+      "desc": "Number of minutes the match will take.",
       "group-id": "43",
       "type": "integer"
     },
@@ -20195,59 +20445,59 @@
       "type": "enum",
       "values": [
         {
-          "description": "White",
+          "description": "White.",
           "name": "0"
         },
         {
-          "description": "Brown",
+          "description": "Brown.",
           "name": "1"
         },
         {
-          "description": "Lavender",
+          "description": "Lavender.",
           "name": "2"
         },
         {
-          "description": "Khaki",
+          "description": "Khaki.",
           "name": "3"
         },
         {
-          "description": "Red",
+          "description": "Red.",
           "name": "4"
         },
         {
-          "description": "Lt Brown",
+          "description": "Lt Brown.",
           "name": "5"
         },
         {
-          "description": "Peach",
+          "description": "Peach.",
           "name": "6"
         },
         {
-          "description": "Lt Peach",
+          "description": "Lt Peach.",
           "name": "7"
         },
         {
-          "description": "Purple",
+          "description": "Purple.",
           "name": "8"
         },
         {
-          "description": "Dk Purple",
+          "description": "Dk Purple.",
           "name": "9"
         },
         {
-          "description": "Tan",
+          "description": "Tan.",
           "name": "10"
         },
         {
-          "description": "Green",
+          "description": "Green.",
           "name": "11"
         },
         {
-          "description": "Yellow",
+          "description": "Yellow.",
           "name": "12"
         },
         {
-          "description": "Blue",
+          "description": "Blue.",
           "name": "13"
         }
       ]
@@ -20286,24 +20536,24 @@
     },
     "tp_msgtriggers": {
       "default": "1",
-      "desc": "Switches on/off message triggers",
+      "desc": "Switches on/off message triggers.",
       "group-id": "49",
       "remarks": "For ruleset 'Smackdown' message triggers always are off.",
       "type": "boolean",
       "values": [
         {
-          "description": "Message triggers are off",
+          "description": "Message triggers are off.",
           "name": "false"
         },
         {
-          "description": "Message triggers are on",
+          "description": "Message triggers are on.",
           "name": "true"
         }
       ]
     },
     "tp_name_armor": {
       "default": "armor",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
@@ -20327,37 +20577,37 @@
     },
     "tp_name_at": {
       "default": "at",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_axe": {
       "default": "axe",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_backpack": {
       "default": "{&cf2apack&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_cells": {
       "default": "cells",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_disp": {
       "default": "dispenser",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_enemy": {
       "default": "{&cf00enemy&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
@@ -20375,121 +20625,121 @@
     },
     "tp_name_filter": {
       "default": "",
-      "desc": "TF only - added to end of tp_msgtfconced message",
+      "desc": "TF only - added to end of tp_msgtfconced message/",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_flag": {
       "default": "flag",
-      "desc": "Customizes item",
+      "desc": "Customizes item/",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_ga": {
       "default": "{&c0b0ga&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item/",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_gl": {
       "default": "gl",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_health": {
       "default": "health",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_lg": {
       "default": "{&c2aalg&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_mh": {
       "default": "{&c0a0mega&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_nails": {
       "default": "nails",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_ng": {
       "default": "ng",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_none": {
       "default": "",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_nothing": {
       "default": "nothing",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_pent": {
       "default": "{&cf00pent&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_pented": {
       "default": "{&cf00pented&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_quad": {
       "default": "{&c05fquad&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_quaded": {
       "default": "{&c05fquaded&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_ra": {
       "default": "{&cf00ra&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_ring": {
       "default": "{&cff0ring&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_rl": {
       "default": "{&cf13rl&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_rlg": {
       "default": "{&cf13rl&cfff}{&c2aag&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_rockets": {
       "default": "rox",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
@@ -20531,152 +20781,152 @@
     },
     "tp_name_separator": {
       "default": "/",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_sg": {
       "default": "sg",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_shells": {
       "default": "shells",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_sng": {
       "default": "sng",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_someplace": {
       "default": "someplace",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_ssg": {
       "default": "ssg",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_status_blue": {
       "default": "$B",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_status_green": {
       "default": "$G",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_status_red": {
       "default": "$R",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_status_white": {
       "default": "$W",
-      "desc": "Currently unused",
+      "desc": "Currently unused.",
       "group-id": "13",
-      "remarks": "tp_name_status_ cvars are used by the client when generating teamplay messages",
+      "remarks": "tp_name_status_ cvars are used by the client when generating teamplay messages.",
       "type": "string"
     },
     "tp_name_status_yellow": {
       "default": "$Y",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_suit": {
       "default": "suit",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_teammate": {
       "default": "",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_weapon": {
       "default": "weapon",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_name_ya": {
       "default": "{&cff0ya&cfff}",
-      "desc": "Customizes item",
+      "desc": "Customizes item.",
       "group-id": "13",
       "type": "string"
     },
     "tp_need_cells": {
       "default": "13",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_ga": {
       "default": "60",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_health": {
       "default": "50",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_nails": {
       "default": "0",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_ra": {
       "default": "120",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_rl": {
       "default": "1",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_rockets": {
       "default": "5",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_shells": {
       "default": "0",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_weapon": {
       "default": "87",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
     "tp_need_ya": {
       "default": "80",
-      "desc": "Customizes the %u macro",
+      "desc": "Customizes the %u macro.",
       "group-id": "14",
       "type": "float"
     },
@@ -20684,7 +20934,7 @@
       "default": "0",
       "desc": "You can choose the way the client decides what object you want to point with $point macro.",
       "group-id": "49",
-      "remarks": "Priorities of object are given in tp_point command. You have to type all objects manually in tp_point command. Example: tp_point quad ra mh health. In this example, quad has the highest priority and $point will always return quad if quad ra mh are all in your view. Example: tp_point all. You never know what object will be pointed because all objects get the same priority.",
+      "remarks": "Priorities of object are given in tp_point command. You have to type all objects manually in tp_point command.\n\nExample: tp_point quad ra mh health\nIn this example, quad has the highest priority and $point will always return quad if quad ra mh are all in your view.\n\nExample: tp_point all\nYou never know what object will be pointed because all objects get the same priority.",
       "type": "boolean",
       "values": [
         {
@@ -20705,7 +20955,7 @@
     },
     "tp_poweruptextstyle": {
       "default": "0",
-      "desc": "Controls whether $tp_powerups (used in built-in binds) uses long or short-form powerup names",
+      "desc": "Controls whether $tp_powerups (used in built-in binds) uses long or short-form powerup names.",
       "group-id": "14",
       "type": "boolean",
       "values": [
@@ -20721,7 +20971,7 @@
     },
     "tp_soundtrigger": {
       "default": "~",
-      "desc": "SoundTrigger like proxys.\nA SoundTrigger must be terminated by either a CR, LF or filter. The .wav extension is not required at the end. Trigger is a character before the sound file.\nExample:\nfilter #a\nsay_team I'm at %l ~location.wav\"\nsay_team ~location.wav$\\me: I'm at %l #a\"\nsay_team ~location$\\me: I'm at %l #a\"\nsay_team I'm at %l ~location #a\"",
+      "desc": "SoundTrigger like proxys.\nA SoundTrigger must be terminated by either a CR, LF or filter. The .wav extension is not required at the end.\nTrigger is a character before the sound file.\n\nExample:\nfilter #a\nsay_team I'm at %l ~location.wav\"\nsay_team ~location.wav$\\me: I'm at %l #a\"\nsay_team ~location$\\me: I'm at %l #a\"\nsay_team I'm at %l ~location #a\"",
       "group-id": "49",
       "type": "string"
     },
@@ -20748,12 +20998,12 @@
     },
     "tp_weapon_order": {
       "default": "78654321",
-      "desc": "This allows you to define the order from best to worst weapon. The default value\nis \"78564321\", which means that the Rocket Launcher is the best weapon (impulse 7)\nthen Lightning Gun (impulse 8), Super Nailgun (impulse 5), Grenade Launcher\n(impulse 6), Nailgun (impulse 4), Super Shotgun (impulse 3), Shotgun (impulse 2),\nAxe (impulse 1).",
+      "desc": "This allows you to define the order from best to worst weapon.\nThe default value is \"78564321\", which means that the Rocket Launcher is the best weapon (impulse 7), then Lightning Gun (impulse 8), Super Nailgun (impulse 5), Grenade Launcher (impulse 6), Nailgun (impulse 4), Super Shotgun (impulse 3), Shotgun (impulse 2), Axe (impulse 1).",
       "group-id": "49",
       "type": "string"
     },
     "userdir": {
-      "desc": "userdir [dir [type]]\nAddition of the given directory to the list searched files",
+      "desc": "userdir [dir [type]]\nAddition of the given directory to the list searched files.",
       "group-id": "33",
       "type": "enum",
       "values": [
@@ -20785,13 +21035,13 @@
     },
     "v_centermove": {
       "default": "0.15",
-      "desc": "This variable sets the distance that the player must move before the screen \nautomatically centers itself when \"lookspring\" is set to \"1\". This variable is \nonly useful to people who only play with the keyboard, have \"lookspring\" set to\n\"1\" and do not have \"+klook\" or \"+mlook\" enabled at that time. When the player \nmoves the distance specified in this variable the screen will pop back to the \ncenter position.",
+      "desc": "This variable sets the distance that the player must move before the screen automatically centers itself when \"lookspring\" is set to \"1\".\nThis variable is only useful to people who only play with the keyboard, have \"lookspring\" set to \"1\" and do not have \"+klook\" or \"+mlook\" enabled at that time.\nWhen the player nmoves the distance specified in this variable the screen will pop back to the center position.",
       "group-id": "53",
       "type": "float"
     },
     "v_centerspeed": {
       "default": "500",
-      "desc": "This variable sets how quickly your view returns to the center after looking up\nor down and moving after that and \"lookspring\" is set to \"1\". This variable is \nonly useful to people who only play with the keyboard, have \"lookspring\" set to\n\"1\" and do not have \"+klook\" or \"+mlook\" enabled at that time. When the player \nmoves the distance specified in this variable the screen will pop back to the \ncenter position.",
+      "desc": "This variable sets how quickly your view returns to the center after looking up or down and moving after that and \"lookspring\" is set to \"1\".\nThis variable is only useful to people who only play with the keyboard, have \"lookspring\" set to \"1\" and do not have \"+klook\" or \"+mlook\" enabled at that time.\nWhen the player moves the distance specified in this variable the screen will pop back to the center position.",
       "group-id": "53",
       "type": "float"
     },
@@ -20810,16 +21060,16 @@
     },
     "v_dlightcshift": {
       "default": "1",
-      "desc": "Turning this variable on will blend light when you're inside a light bubble. Also need to set gl_flashblend 1",
+      "desc": "Turning this variable on will blend light when you're inside a light bubble.\nAlso need to set gl_flashblend 1.",
       "group-id": "39",
       "type": "boolean",
       "values": [
         {
-          "description": "Off",
+          "description": "Off.",
           "name": "false"
         },
         {
-          "description": "On",
+          "description": "On.",
           "name": "true"
         }
       ]
@@ -20832,13 +21082,13 @@
     },
     "v_idlescale": {
       "default": "0",
-      "desc": "This variable controls the amount that the screen should sway automatically.\nWhen this variable is set to a value above \"0\" the screen will start swaying in \nall directions, similar as if the player was drunk of had a concussion. If you \nwant to have some real fun, set this variable to a value of \"100\" and run around \nsome maps. The larger the value for this variable the more the screen will sway \nfrom side to side.",
+      "desc": "This variable controls the amount that the screen should sway automatically.\nWhen this variable is set to a value above \"0\" the screen will start swaying in all directions, similar as if the player was drunk of had a concussion.\nIf you want to have some real fun, set this variable to a value of \"100\" and run around some maps.\nThe larger the value for this variable the more the screen will sway from side to side.",
       "group-id": "53",
       "type": "integer"
     },
     "v_ipitch_cycle": {
       "default": "1",
-      "desc": "This variable controls the speed at which the screen should sway up and down\nwhen \"v_idlescale\" is set to a value above \"0\".",
+      "desc": "This variable controls the speed at which the screen should sway up and down when \"v_idlescale\" is set to a value above \"0\".",
       "group-id": "53",
       "type": "float"
     },
@@ -20850,13 +21100,13 @@
     },
     "v_iroll_cycle": {
       "default": "0.5",
-      "desc": "This variable controls the speed at which the screen should roll clockwise and \ncounter clockwise when \"v_idlescale\" is set to a value above \"0\".",
+      "desc": "This variable controls the speed at which the screen should roll clockwise and counter clockwise when \"v_idlescale\" is set to a value above \"0\".",
       "group-id": "53",
       "type": "float"
     },
     "v_iroll_level": {
       "default": "0.1",
-      "desc": "This variable controls the distance the screen should roll clockwise and counter\nclockwise when \"v_idlescale\" is set to a value above \"0\".",
+      "desc": "This variable controls the distance the screen should roll clockwise and counter clockwise when \"v_idlescale\" is set to a value above \"0\".",
       "group-id": "53",
       "type": "float"
     },
@@ -20874,14 +21124,14 @@
     },
     "v_kickpitch": {
       "default": "0.0",
-      "desc": "This variable controls the distance that the screen should move up or down when \nthe player is shot. Most players set this variable to \"0\" in order to remove the \nscreen tilting effect when they are injured by a shot. This allows them to keep \na perfect aim while being fired upon.",
+      "desc": "This variable controls the distance that the screen should move up or down when the player is shot.\nMost players set this variable to \"0\" in order to remove the screen tilting effect when they are injured by a shot.\nThis allows them to keep a perfect aim while being fired upon.",
       "group-id": "53",
       "remarks": "v_kicktime must be >0 for this to take effect.",
       "type": "float"
     },
     "v_kickroll": {
       "default": "0.0",
-      "desc": "This variable controls the distance that the screen should roll clockwise or \ncounter clockwise when the player is shot. Most players set this variable to \"0\"\nin order to remove the screen tilting effect when they are injured by a shot. \nThis allows them to keep a perfect aim while being fired upon.",
+      "desc": "This variable controls the distance that the screen should roll clockwise or counter clockwise when the player is shot.\nMost players set this variable to \"0\" in order to remove the screen tilting effect when they are injured by a shot.\nThis allows them to keep a perfect aim while being fired upon.",
       "group-id": "53",
       "remarks": "v_kicktime must be >0 for this to take effect.",
       "type": "float"
@@ -20894,31 +21144,31 @@
     },
     "v_pentcshift": {
       "default": "0.5",
-      "desc": "This variable (0..1) will add a temporary red hue to your screen if you are carry the Pent powerup. Requires gl_polyblend 1",
+      "desc": "This variable (0..1) will add a temporary red hue to your screen if you are carry the Pent powerup. Requires gl_polyblend 1.",
       "group-id": "39",
       "type": "float"
     },
     "v_quadcshift": {
       "default": "0.5",
-      "desc": "This variable (0..1) will add a temporary blue hue to your screen if you are carry the Quad powerup. Requires gl_polyblend 1",
+      "desc": "This variable (0..1) will add a temporary blue hue to your screen if you are carry the Quad powerup. Requires gl_polyblend 1.",
       "group-id": "39",
       "type": "float"
     },
     "v_ringcshift": {
       "default": "0.5",
-      "desc": "This variable (0..1) will add a temporary yellow hue to your screen if you are carry the Ring powerup. Requires gl_polyblend 1",
+      "desc": "This variable (0..1) will add a temporary yellow hue to your screen if you are carry the Ring powerup. Requires gl_polyblend 1.",
       "group-id": "39",
       "type": "float"
     },
     "v_suitcshift": {
       "default": "0.5",
-      "desc": "This variable (0..1) will add a temporary green hue to your screen if you are carry the Suit powerup. Requires gl_polyblend 1",
+      "desc": "This variable (0..1) will add a temporary green hue to your screen if you are carry the Suit powerup. Requires gl_polyblend 1.",
       "group-id": "39",
       "type": "float"
     },
     "v_viewheight": {
       "default": "0",
-      "desc": "New variable v_viewheight can be used to get the effect of negative/zero values \nof cl_bobcycle etc in qw 2.33 . Negative values of v_viewheight = lower viewheight, \npositive = higher. Can't go below -7 or above 4 because that's the range you can get \nwith qw 2.33 by exploiting the bob cycle bug. Using v_viewheight automatically \nturns off weapon model bobbing (cl_bob*).",
+      "desc": "New variable v_viewheight can be used to get the effect of negative/zero values \nof cl_bobcycle etc in qw 2.33.\nNegative values of v_viewheight = lower viewheight, \npositive = higher.\nCan't go below -7 or above 4 because that's the range you can get with qw 2.33 by exploiting the bob cycle bug.\n\nUsing v_viewheight automatically turns off weapon model bobbing (cl_bob*).",
       "group-id": "53",
       "type": "float"
     },
@@ -20929,11 +21179,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Size of depth-buffer will be system default",
+          "description": "Size of depth-buffer will be system default.",
           "name": "false"
         },
         {
-          "description": "Request 24-bit depth-buffer",
+          "description": "Request 24-bit depth-buffer.",
           "name": "true"
         }
       ]
@@ -20943,7 +21193,7 @@
       "type": ""
     },
     "vid_borderless": {
-      "desc": "When in windowed mode, window will not have a border",
+      "desc": "When in windowed mode, window will not have a border.",
       "group-id": "52",
       "type": "boolean",
       "values": [
@@ -20959,9 +21209,9 @@
     },
     "vid_colorbits": {
       "default": "0",
-      "desc": "Determines the color mode",
+      "desc": "Determines the color mode.",
       "group-id": "52",
-      "remarks": "Highest quality is \\\"24\\\"",
+      "remarks": "Highest quality is \"24\"",
       "type": "integer"
     },
     "vid_conaspect": {
@@ -20977,12 +21227,12 @@
       ]
     },
     "vid_config_x": {
-      "desc": "This variable sets the width of the vid_mode 2 window, the minimum possible\nvalue is \"640\".",
+      "desc": "This variable sets the width of the vid_mode 2 window, the minimum possible value is \"640\".",
       "group-id": "52",
       "type": "float"
     },
     "vid_config_y": {
-      "desc": "This variable sets the width of the vid_mode 2 window, the minimum possible\nvalue is \"400\"",
+      "desc": "This variable sets the width of the vid_mode 2 window, the minimum possible value is \"400\"",
       "group-id": "52",
       "type": "float"
     },
@@ -20995,27 +21245,27 @@
     },
     "vid_conscale": {
       "default": "2.0",
-      "desc": "If vid_conwidth & vid_conheight are set to 0, vid_conheight will be scaled by the value of this variable",
+      "desc": "If vid_conwidth & vid_conheight are set to 0, vid_conheight will be scaled by the value of this variable.",
       "group-id": "52",
       "type": "float"
     },
     "vid_conwidth": {
       "default": "0",
-      "desc": "Height of the text layer",
+      "desc": "Height of the text layer.",
       "group-id": "52",
-      "remarks": "Can\\'t be higher than the height of the current game resolution",
+      "remarks": "Cannot be higher than the height of the current game resolution.",
       "type": "integer"
     },
     "vid_customheight": {
-      "desc": "Screen resolution width for custom screen mode",
+      "desc": "Screen resolution width for custom screen mode.",
       "group-id": "52",
-      "remarks": "vid_mode must be -1",
+      "remarks": "vid_mode must be -1.",
       "type": "integer"
     },
     "vid_customwidth": {
-      "desc": "Screen resolution height for custom screen mode",
+      "desc": "Screen resolution height for custom screen mode.",
       "group-id": "52",
-      "remarks": "vid_mode must be -1",
+      "remarks": "vid_mode must be -1.",
       "type": "integer"
     },
     "vid_depthbits": {
@@ -21037,7 +21287,7 @@
     },
     "vid_flashonactivity": {
       "default": "1",
-      "desc": "When there is activity in the server, ezQuake's taskbar window will flash. Activity includes chat, high priority messages, disconnection from server.",
+      "desc": "When there is activity in the server, ezQuake's taskbar window will flash.\nActivity includes chat, high priority messages, disconnection from server.",
       "group-id": "52",
       "type": "float"
     },
@@ -21048,11 +21298,11 @@
       "type": "boolean",
       "values": [
         {
-          "description": "Old way of restoring gamma",
+          "description": "Old way of restoring gamma.",
           "name": "false"
         },
         {
-          "description": "Force restore in 1 sec",
+          "description": "Force restore in 1 sec.",
           "name": "true"
         }
       ]
@@ -21114,7 +21364,7 @@
     },
     "vid_fullscreen": {
       "default": "1",
-      "desc": "Enables fullscreen mode, when disabled, sets windowed mode",
+      "desc": "Enables fullscreen mode, when disabled, sets windowed mode.",
       "group-id": "52",
       "type": "boolean",
       "values": [
@@ -21129,7 +21379,7 @@
       ]
     },
     "vid_fullscreen_mode": {
-      "desc": "This variable sets the full screen video mode that the game will switch to when\nthe \"vid_fullscreen\" command is executed.",
+      "desc": "This variable sets the full screen video mode that the game will switch to when the \"vid_fullscreen\" command is executed.",
       "group-id": "52",
       "type": "float"
     },
@@ -21159,13 +21409,13 @@
     },
     "vid_grab_keyboard": {
       "default": "1",
-      "desc": "If set, grabs keyboard hotkeys.  May need to be enabled/disabled depending on your window manager.",
+      "desc": "If set, grabs keyboard hotkeys.\nMay need to be enabled/disabled depending on your window manager.",
       "group-id": "9",
       "type": "boolean"
     },
     "vid_height": {
       "default": "0",
-      "desc": "Determines width of screen resolution when in fullscreen mode",
+      "desc": "Determines width of screen resolution when in fullscreen mode.",
       "group-id": "52",
       "remarks": "This value is ignored if vid_usedesktopres is set.",
       "type": "integer"
@@ -21200,24 +21450,24 @@
       "type": "boolean"
     },
     "vid_mode": {
-      "desc": "This variables sets the next video mode to be used, any change of this variable\nwill cause the video mode to be changed immediately.",
-      "group-id": "52",
+      "desc": "This variables sets the next video mode to be used.\nAny change of this variable will cause the video mode to be changed immediately.",
+      "group-id": "23",
       "type": "float"
     },
     "vid_nopageflip": {
-      "desc": "This variable toggles the use of page-flipping during supported video modes. By default the game will allow for page-flipping for video modes that support this \nfeature. For example if a given VESA mode can support page flipping, then it \ndefaults to page-flipped operation.  A VESA mode can be forced to \nnon-page-flipped operation by setting the \"vid_nopageflip\" variable to \"1\", then\nsetting the mode (note that \"vid_nopageflip\" takes operation on the next, \nnot the current video mode, and note that it then stays in effect permanently, \neven when the client is exited and restarted, unless it is manually set back to \"0\").\nIf there is not enough memory for two pages in a VESA mode, or if the adapter \ndoesn't support page flipping, then the mode will automatically be \nnon-page-flipped.  \nPage-flipping works by drawing multiple virtual game screens at the same time in \nthe video memory and then switching among them to display the current \ngamescreen. Page-flipped modes thus use less system memory than non-page-flipped \nmodes, but require more video memory. When using page-flipping, visual quality \nmay be higher, but performance of the game can change to better or worse, \ndepending on the graphics adapter and other hardware (see the discussion of the \nPentium Pro below, for a discussion of why page flipping can be faster but is \nsometimes much slower on that processor). However in most cases the performance \n(and thus frame rate) will be increased, but for people with hardware that has \nproblems with page-flipping \"vid_nopageflip 1\" may help.\nThe Pentium Pro is an example for such a hardware: it is an okay client platform (sniff!), \nbut it has one weak spot, it is by default very slow on writes to video memory.  \nThis means that in default hardware configurations, you are usually much better \noff setting \"vid_nopageflip\" to \"1\" if you use VESA modes, so drawing is done to \nsystem memory instead of to video memory. Remember that you must set the mode\nafter setting \"vid_nopageflip\" to \"1\" in order to get \"vid_nopageflip\" to take\neffect. \"vid_nopageflip 1\" can sometimes be faster on a Pentium too, but not by nearly as much in general, and it's often slower.",
-      "group-id": "52",
+      "desc": "This variable toggles the use of page-flipping during supported video modes.\nBy default the game will allow for page-flipping for video modes that support this feature.\nFor example if a given VESA mode can support page flipping, then it defaults to page-flipped operation.\nA VESA mode can be forced to non-page-flipped operation by setting the \"vid_nopageflip\" variable to \"1\", then setting the mode (note that \"vid_nopageflip\" takes operation on the next, not the current video mode, and note that it then stays in effect permanently, even when the client is exited and restarted, unless it is manually set back to \"0\").\nIf there is not enough memory for two pages in a VESA mode, or if the adapter doesn't support page flipping, then the mode will automatically be nnon-page-flipped.\n\nPage-flipping works by drawing multiple virtual game screens at the same time in the video memory and then switching among them to display the current gamescreen. Page-flipped modes thus use less system memory than non-page-flipped modes, but require more video memory.\nWhen using page-flipping, visual quality may be higher, but performance of the game can change to better or worse, depending on the graphics adapter and other hardware (see the discussion of the Pentium Pro below, for a discussion of why page flipping can be faster but is sometimes much slower on that processor). However in most cases the performance (and thus frame rate) will be increased, but for people with hardware that has problems with page-flipping \"vid_nopageflip 1\" may help.\nThe Pentium Pro is an example for such a hardware: it is an okay client platform (sniff!), but it has one weak spot, it is by default very slow on writes to video memory.\nThis means that in default hardware configurations, you are usually much better off setting \"vid_nopageflip\" to \"1\" if you use VESA modes, so drawing is done to system memory instead of to video memory.\nRemember that you must set the mode after setting \"vid_nopageflip\" to \"1\" in order to get \"vid_nopageflip\" to take effect. \"vid_nopageflip 1\" can sometimes be faster on a Pentium too, but not by nearly as much in general, and it's often slower.",
+      "group-id": "23",
       "type": "float"
     },
     "vid_renderer": {
       "default": "0",
-      "desc": "Selects which rendering mode to use",
+      "desc": "Selects which rendering mode to use.",
       "group-id": "52",
       "remarks": "(variable only available if multiple renderers available)",
       "type": "enum",
       "values": [
         {
-          "description": "OpenGL, classic",
+          "description": "OpenGL, classic.",
           "name": "0"
         },
         {
@@ -21227,8 +21477,8 @@
       ]
     },
     "vid_resetonswitch": {
-      "group-id": "52",
-      "remarks": "ezQuake and the screen gets garbaged. When enabled, the client will reset your Windows video mode \nevery time you press alt-tab. Note that some NVidia drivers lock up your system completely \nwhen you alt-tab. vid_resetonswitch will not help in this case (try starting ezQuake with -dibonly).",
+      "group-id": "23",
+      "remarks": "This is a workaround for the bug in some NVidia drivers, when you alt-tab out of ezQuake and the screen gets garbaged.\nWhen enabled, the client will reset your Windows video mode every time you press alt-tab. Note that some NVidia drivers lock up your system completely when you alt-tab: vid_resetonswitch will not help in this case (try starting ezQuake with -dibonly).",
       "type": "boolean",
       "values": [
         {
@@ -21236,7 +21486,7 @@
           "name": "false"
         },
         {
-          "description": "Enable (This is a workaround for the bug in some NVidia drivers, when you alt-tab out of",
+          "description": "Enable.",
           "name": "true"
         }
       ]
@@ -21257,8 +21507,8 @@
       "type": ""
     },
     "vid_stretch_by_2": {
-      "group-id": "52",
-      "remarks": "half-resolution in each direction and stretched up to the specified size.)",
+      "group-id": "23",
+      "remarks": "This variable toggles whether in \"vid_mode 2\" the picture should be rendered at half-resolution in each direction and stretched up to the specified size.",
       "type": "boolean",
       "values": [
         {
@@ -21266,7 +21516,7 @@
           "name": "false"
         },
         {
-          "description": "Enable (This variable toggles whether in \"vid_mode 2\" the picture should be rendered at",
+          "description": "Enable.",
           "name": "true"
         }
       ]
@@ -21279,7 +21529,7 @@
     },
     "vid_verbose": {
       "default": "0",
-      "desc": "If set, display graphics info on every vid_restart",
+      "desc": "If set, display graphics info on every vid_restart.",
       "group-id": "52",
       "type": "boolean"
     },
@@ -21301,20 +21551,20 @@
     },
     "vid_vsync_lag_fix": {
       "default": "0",
-      "desc": "Enables experimental fix for a delay vertical synchronization mode",
+      "desc": "Enables experimental fix for a delay vertical synchronization mode.",
       "group-id": "52",
-      "remarks": "When vid_vsync is set to 1, an artificial delay in the input can appear, enabling this should eliminate the delay",
+      "remarks": "When vid_vsync is set to 1, an artificial delay in the input can appear, enabling this should eliminate the delay.",
       "type": "boolean"
     },
     "vid_vsync_lag_tweak": {
       "default": "1.0",
       "desc": "Custom value for experimental vertical synchronization delay reduction.",
       "group-id": "52",
-      "remarks": "Too low values (0.2 or lower) may significantly decrease FPS and make it not synced with display frequency. Too high values (10 and above) may turn off the effect of video lag fix completely. Use the lowest value that keeps stable FPS for you.",
+      "remarks": "Too low values (0.2 or lower) may significantly decrease FPS and make it not synced with display frequency.\nToo high values (10 and above) may turn off the effect of video lag fix completely.\nUse the lowest value that keeps stable FPS for you.",
       "type": "float"
     },
     "vid_wideaspect": {
-      "desc": "Recalculates screen proportions so that they suit wide-screen displays. If you toggle this variable from 0 to 1, it will recalculate your field of view (fov) and screen proportions (conwidth/conheight ratio) so that the resulting image looks similar on a 16:10 screen as it did on 4:3 screen.",
+      "desc": "Recalculates screen proportions so that they suit wide-screen displays.\nIf you toggle this variable from 0 to 1, it will recalculate your field of view (fov) and screen proportions (conwidth/conheight ratio) so that the resulting image looks similar on a 16:10 screen as it did on 4:3 screen.",
       "group-id": "52",
       "remarks": "The effect of the variable is only changing values of \"fov\" and \"vid_conheight\" variables when you toggle the value of this variable. The algorithm used to get resulting values is described in the QuakeWorld wiki.",
       "type": "boolean",
@@ -21331,7 +21581,7 @@
     },
     "vid_width": {
       "default": "0",
-      "desc": "Determines width of screen resolution when in fullscreen mode",
+      "desc": "Determines width of screen resolution when in fullscreen mode.",
       "group-id": "52",
       "remarks": "This value is ignored if vid_usedesktopres is set.",
       "type": "integer"
@@ -21357,13 +21607,13 @@
     },
     "vid_win_save_pos": {
       "default": "1",
-      "desc": "If set, window position variables will be set as window moved around screen",
+      "desc": "If set, window position variables will be set as window moved around screen.",
       "group-id": "52",
       "type": "boolean"
     },
     "vid_win_save_size": {
       "default": "1",
-      "desc": "If set, window size variables will be set as window resized",
+      "desc": "If set, window size variables will be set as window resized.",
       "group-id": "52",
       "type": "boolean"
     },
@@ -21374,17 +21624,17 @@
       "type": "integer"
     },
     "vid_window_x": {
-      "desc": "This variable sets the x-axis location of the top left corner of the game window \non the desktop.",
+      "desc": "This variable sets the x-axis location of the top left corner of the game window on the desktop.",
       "group-id": "52",
       "type": "float"
     },
     "vid_window_y": {
-      "desc": "This variable sets the y-axis location of the top left corner of the game window \non the desktop.",
+      "desc": "This variable sets the y-axis location of the top left corner of the game window on the desktop.",
       "group-id": "52",
       "type": "float"
     },
     "vid_windowed_mode": {
-      "desc": "This variable sets the windowed video mode that the game will switch to when the \n\"vid_windowed\" command is executed.",
+      "desc": "This variable sets the windowed video mode that the game will switch to when the \"vid_windowed\" command is executed.",
       "group-id": "52",
       "type": "float"
     },
@@ -21396,7 +21646,7 @@
     },
     "vid_ypos": {
       "default": "39",
-      "desc": "Vertical position of the client window",
+      "desc": "Vertical position of the client window.",
       "group-id": "52",
       "type": "integer"
     },
@@ -21404,11 +21654,11 @@
       "default": "100",
       "desc": "This variable determines how large the viewable screen size is.",
       "group-id": "53",
-      "remarks": "Value range is 30-120.  Values 100 & 110 are affected by cl_sbar",
+      "remarks": "Value range is 30-120.\nValues 100 & 110 are affected by cl_sbar.",
       "type": "enum",
       "values": [
         {
-          "description": "Minimum screen size",
+          "description": "Minimum screen size.",
           "name": "30"
         },
         {
@@ -21444,40 +21694,40 @@
     },
     "w_switch": {
       "default": "",
-      "desc": "This variable allows you to define the highest weapon that the client should switch \nto when picking it up. The possible arguments of \"w_switch\" refer to the impulse \nthat is used to switch to a certain weapon:",
+      "desc": "This variable allows you to define the highest weapon that the client should switch to when picking it up.\nThe possible arguments of \"w_switch\" refer to the impulse that is used to switch to a certain weapon:",
       "group-id": "37",
       "type": "enum",
       "values": [
         {
-          "description": "Axe",
+          "description": "Axe.",
           "name": "1"
         },
         {
-          "description": "Shotgun",
+          "description": "Shotgun.",
           "name": "2"
         },
         {
-          "description": "Double-Barreled Shotgun",
+          "description": "Double-Barreled Shotgun.",
           "name": "3"
         },
         {
-          "description": "Nailgun",
+          "description": "Nailgun.",
           "name": "4"
         },
         {
-          "description": "Super Nailgun",
+          "description": "Super Nailgun.",
           "name": "5"
         },
         {
-          "description": "Grenade Launcher",
+          "description": "Grenade Launcher.",
           "name": "6"
         },
         {
-          "description": "Rocket Launcher",
+          "description": "Rocket Launcher.",
           "name": "7"
         },
         {
-          "description": "ThunderBolt",
+          "description": "ThunderBolt.",
           "name": "8"
         }
       ]
@@ -21486,7 +21736,7 @@
       "default": "0",
       "desc": "This server-side cvar is mirrored to serverinfo as a hint to clients on whether the server is using the so-called watervised maps.",
       "group-id": "34",
-      "remarks": "It's a bad idea to use watervis 1 if the maps the server is using are not watervised. Liquids will appear 'transparent' but you won't be able to see any items/players/etc through it.  And it is a bad idea anyway because Quake maps were not designed for transparent water (or other liquids); enabling it changes gameplay, decreases fps and produces more network traffic and puts non-GL players at a disadvantage because the software renderer doesn't support transparent water (yet).\nNot saved to config with cfg_save command.",
+      "remarks": "It's a bad idea to use watervis 1 if the maps the server is using are not watervised.\nLiquids will appear 'transparent' but you won't be able to see any items/players/etc through it.\nIt is a bad idea anyway because Quake maps were not designed for transparent water (or other liquids); enabling it changes gameplay, decreases fps and produces more network traffic and puts non-GL players at a disadvantage because the software renderer doesn't support transparent water (yet).\nNot saved to config with cfg_save command.",
       "type": "boolean",
       "values": [
         {
@@ -21501,7 +21751,7 @@
     },
     "zombietime": {
       "default": "2",
-      "desc": "The number of minutes that the server will keep the character of a player on \nthe map who seems to have disconnected.",
+      "desc": "The number of minutes that the server will keep the character of a player on the map who seems to have disconnected.",
       "group-id": "43",
       "type": "integer"
     }


### PR DESCRIPTION
A bunch of tidying & consolidation of the formatting of what is already there in commands+variables, before I tackle describing more stuff that only has placeholders, or even doing large scale rewording.

## General
- removed over-escaped backslashes, extraneous whitespace
- removed most excessive linebreaks - there were plenty from an era where I assume the console wasn't word-wrapped as well, but with the variable console line length, they end up creating some broken random whitespace depending on settings. Since there's still quite the WALLS of text, some extra linebreaks (*actual* newlines) have been placed to keep some "air" in the text blocks
- streamlined some wording, fixed some broken english
- consistent formatting of lists within cvar/cmd descriptions (not individual value descriptions)

## Commands
- examples are separated with two linebreaks for spacing
- "notes" and equivalent moved to "remarks" fields - they exist in commands too, but were just not used at all
- spellchecked
- consistent capitalization per acronym and when starting sentences
- consistent mandatory params noted with <> (dominant style), less than 50% were noted with parenthesis

## Variables
- bunch of quick fixes: simple typos, obviously broken descriptions with var/values mixed up
- moved some parameter lists from descriptions to values
- end var descs and remarks with a dot because they are mostly proper sentences/paragraphs. Mostly left the value descriptions as is for now: it's a 50/50 split between dot/no dot and while it would look cleaner without, it's not always clear cut

I think I'll open a Discussion regarding style guides. I've noticed some patterns (or lack thereof) and taken some notes along the way.