### PR TITLE
MENU: tweak/add 2 vars, reformat var description pop-up

### DIFF
--- a/help.c
+++ b/help.c
@@ -26,6 +26,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include <jansson.h>
 
+extern void CharsToBrown(char*, char*);
+extern char* CharsToBrownStatic(char* in);
+
 typedef enum {
 	t_boolean,
 	t_enum,         // "value1, value2, value_wih_spaces"
@@ -275,7 +278,7 @@ static void Help_DescribeVar(const json_variable_t *var)
 
 		Com_Printf("\n");
 		con_ormask = 128;
-		Com_Printf("value\n");
+		Com_Printf("values\n");
 		con_ormask = 0;
 		con_margin = CONSOLE_HELP_MARGIN;
 		for (i = 0; i < valueCount; ++i) {
@@ -545,16 +548,14 @@ void Help_DescribeCvar (cvar_t *v)
 
 void Help_VarDescription (const char *varname, char* buf, size_t bufsize)
 {
-	extern void CharsToBrown(char*, char*);
 	extern cvar_t menu_advanced;
 	const json_variable_t *var;
 
 	var = JSON_Variable_Load (varname);
 	
 	if(menu_advanced.integer && strlen(varname)){
-		strlcat(buf, "Variable name: ", bufsize);
+		strlcat(buf, CharsToBrownStatic("Variable Name: "), bufsize);
 		strlcat(buf, varname, bufsize);
-		CharsToBrown(buf, buf + strlen (buf) - strlen(varname));
 		strlcat(buf, "\n", bufsize);
 	}
 	
@@ -566,19 +567,14 @@ void Help_VarDescription (const char *varname, char* buf, size_t bufsize)
 		strlcat (buf, "\n", bufsize);
 	}
 
-	if (var->remarks) {
-		strlcat (buf, "remarks: ", bufsize);
-		strlcat (buf, var->remarks, bufsize);
-		strlcat (buf, "\n", bufsize);
-	}
-
 	if (var->values)
 	{
 		size_t valueCount = json_array_size(var->values);
 		size_t i = 0;
 
 		strlcat (buf, "\n", bufsize);
-		strlcat (buf, "value\n", bufsize);
+		strlcat (buf, CharsToBrownStatic("values"), bufsize);
+		strlcat (buf, "\n", bufsize);
 		for (i = 0; i < valueCount; ++i) {
 			const json_t* value = json_array_get(var->values, i);
 			const char*   name = json_string_value(json_object_get(value, "name"));
@@ -596,18 +592,25 @@ void Help_VarDescription (const char *varname, char* buf, size_t bufsize)
 			case t_enum:
 			default:
 				if (var->value_type == t_boolean && !strcmp(name, "false"))
-					strlcat (buf, "0", bufsize);
+					strlcat (buf, CharsToBrownStatic("0"), bufsize);
 				else if (var->value_type == t_boolean && !strcmp(name, "true"))
-					strlcat (buf, "1", bufsize);
+					strlcat (buf, CharsToBrownStatic("1"), bufsize);
 				else
-					strlcat (buf, name, bufsize);
+					strlcat (buf, CharsToBrownStatic((char*)name), bufsize);
 
-				strlcat (buf, ": ", bufsize);
+				strlcat (buf, " - ", bufsize);
 				strlcat (buf, description, bufsize);
 				strlcat (buf, "\n", bufsize);
 				break;
 			}
 		}
+	}
+
+	if (var->remarks) {
+		strlcat(buf, CharsToBrownStatic("remarks"), bufsize);
+		strlcat(buf, "\n", bufsize);
+		strlcat(buf, var->remarks, bufsize);
+		strlcat(buf, "\n", bufsize);
 	}
 }
 

--- a/menu_options.c
+++ b/menu_options.c
@@ -53,7 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 extern cvar_t r_farclip, gl_max_size, gl_miptexLevel;
 extern cvar_t r_bloom;
-extern cvar_t gl_flashblend, r_dynamic, gl_lightmode;
+extern cvar_t gl_flashblend, r_dynamic, gl_lightmode, gl_modulate;
 
 typedef enum {
 	OPTPG_MISC,
@@ -1227,6 +1227,7 @@ setting settsystem_arr[] = {
 	ADDSET_NUMBER	("Gamma", v_gamma, 0.3, 3.0, 0.1),
 	ADDSET_NUMBER	("Contrast", v_contrast, 1, 5, 0.1),
 	ADDSET_ADVANCED_SECTION(),
+	ADDSET_NUMBER	("Lightmap Intensity", gl_modulate, 0.5, 3.0, 0.1),
 	ADDSET_BOOL		("Clear Video Buffer", gl_clear),
 	ADDSET_NUMBER	("Anisotropy Filter", gl_anisotropy, 0, 16, 1),
 	ADDSET_ENUM		("Quality Mode", gl_texturemode, gl_texturemode_enum),

--- a/menu_options.c
+++ b/menu_options.c
@@ -1224,7 +1224,7 @@ setting settsystem_arr[] = {
 
 	//Video
 	ADDSET_SEPARATOR("Video"),
-	ADDSET_NUMBER	("Gamma", v_gamma, 0.1, 2.0, 0.1),
+	ADDSET_NUMBER	("Gamma", v_gamma, 0.3, 3.0, 0.1),
 	ADDSET_NUMBER	("Contrast", v_contrast, 1, 5, 0.1),
 	ADDSET_ADVANCED_SECTION(),
 	ADDSET_BOOL		("Clear Video Buffer", gl_clear),


### PR DESCRIPTION
- changed gamma range to match actual var
- added gl_modulate
- reformatted variable description pop-up to closer match /describe format: section order, section headers, coloring and list separators
- some grammar along the way (value/values)