### PR TITLE
Fix build on FreeBSD/powerpc

### DIFF
--- a/host.c
+++ b/host.c
@@ -337,7 +337,7 @@ void SYSINFO_Init(void)
 	SYSINFO_processor_description = cpu_model;
 
 	gettimeofday(&old_tp, NULL);
-#ifdef __powerpc64__
+#ifdef __powerpc__
 	__asm__ __volatile__("mfspr %%r3, 268": "=r" (old_tsc));
 #else
 	old_tsc = rdtsc();
@@ -345,7 +345,7 @@ void SYSINFO_Init(void)
 	do {
 		gettimeofday(&tp, NULL);
 	} while ((tp.tv_sec - old_tp.tv_sec) * 1000000. + tp.tv_usec - old_tp.tv_usec < 1000000.);
-#ifdef __powerpc64__
+#ifdef __powerpc__
 	__asm__ __volatile__("mfspr %%r3, 268": "=r" (tsc_freq));
 #else
 	tsc_freq = rdtsc();


### PR DESCRIPTION
While the code was fixed for powerpc64 (and powerpc64le), it still fails to build on powerpc (32-bit). Since it's possible to use the same way on 32-bits, do it to fix build.
It may fail on the early powerpc chips, but I doubt they are able to run a modern OS with OpenGL anyway.