### PR TITLE
HUD: missing BG on "powerbar" hud_frags when flipped

### DIFF
--- a/hud_frags.c
+++ b/hud_frags.c
@@ -248,6 +248,7 @@ static void Frags_DrawHorizontalHealthBar(player_info_t* info, int x, int y, int
 			Draw_AlphaFillRGB(x + width - (int)health_width - (int)max_health_width, y, max_health_width, health_height, RGBA_TO_COLOR(255, 0, 0, 128));
 		}
 
+		Draw_AlphaFillRGB(x, y + health_height, width, armor_height, RGBAVECT_TO_COLOR(armor_color_noarmor->color));
 		if (armor_width > 0 && health > 0) {
 			Draw_AlphaFillRGB(x + width - (int)armor_width, y + health_height, armor_width, armor_height, armor_color);
 		}


### PR DESCRIPTION
In "powerbar" styles, players displayed flipped with hud_frags_fliptext did not have a background on their armour bar.
![flipnobg](https://user-images.githubusercontent.com/64284375/123511047-5a5a7380-d67f-11eb-8845-484f37268dd4.png)
