### PR TITLE
HELP: Make scr_scoreboard_borderless desc. logical

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -18663,16 +18663,16 @@
     },
     "scr_scoreboard_borderless": {
       "default": "1",
-      "desc": "Controls scoreboard border behavior.",
+      "desc": "Disables the border around the scoreboard.",
       "group-id": "47",
       "type": "boolean",
       "values": [
         {
-          "description": "no scoreboard border will be displayed.",
+          "description": "Scoreboard will have a border.",
           "name": "false"
         },
         {
-          "description": "scoreboard border will be displayed.",
+          "description": "Scoreboard will not have a border.",
           "name": "true"
         }
       ]


### PR DESCRIPTION
Found by dracs.
The behaviour is 0 = not borderless, 1 = borderless
The help says 0 = borderless, 1 = not borderless
This commit at least flips it around.
IMHO should become scr_scoreboard_border with 0 = no border, 1 = border and `if border, draw_stuff` in sbar.c but twisting the wording around means 0 config changes.
I didn't want to keep "controls behaviour" in main desc. because it's really on/off, not style1/2/3/4, wasn't sure about saying "toggles" either because I expect 0 to be off and 1 to be on...