### PR TITLE
MACOS: fix fixbundle.sh due to latest macOS toolchain breakage

### DIFF
--- a/misc/install/fixbundle.sh
+++ b/misc/install/fixbundle.sh
@@ -89,8 +89,8 @@ done
 
 function fix_symbols {
 	for DEP in $(get_deps "$1"); do
-		codesign --remove-signature "$1"
 		install_name_tool -change "$DEP" "@executable_path/../Frameworks/$(basename $(realpath $DEP))" "$1"
+		codesign --remove-signature "$1"
 		codesign -s - "$1"
 	done
 }


### PR DESCRIPTION
Fixes #624.

Maybe wait for confirmation in #624, but it seems to make more sensible install_name_tool rewrites than before.
