### PR TITLE
OSX: qw urls are now passed in to ezquake from osx via drag and drop …

### DIFF
--- a/common.c
+++ b/common.c
@@ -749,7 +749,7 @@ void COM_InitArgv(int argc, char **argv)
 	for (i = 0, com_argc = 0; com_argc < MAX_NUM_ARGVS - 1 && i < argc; ++i) {
 		if (argv[i]) {
 			// follow qw urls if they are our argument without a +qwurl command
-			if (!strncmp(argv[i], "qw://", 5) && (i == 0 || strncmp(argv[i - 1], "+qwurl", 5)) && com_argc < MAX_NUM_ARGVS - 1) {
+			if (!strncmp(argv[i], "qw://", 5) && (i == 0 || strncmp(argv[i - 1], "+qwurl", 6)) && com_argc < MAX_NUM_ARGVS - 1) {
 				largv[com_argc++] = "+qwurl";
 				largv[com_argc++] = argv[i];
 			}

--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -897,7 +897,11 @@ static void HandleEvents(void)
 			break;
 		case SDL_DROPFILE:
 			/* TODO: Add handling for different file types */
-			Cbuf_AddText("playdemo ");
+			if (strncmp(event.drop.file, "qw://", 5) == 0) {
+				Cbuf_AddText("qwurl ");
+			} else {
+				Cbuf_AddText("playdemo ");
+			}
 			Cbuf_AddText(event.drop.file);
 			Cbuf_AddText("\n");
 			SDL_free(event.drop.file);


### PR DESCRIPTION
OSX: qw urls are now passed in to ezquake from osx via drag and drop emulation, so handle that use case and do not attempt to open qw:// urls as demos.  init_url_handler called from sys_posix.c and defined in sys_osx.m probably aren't needed anymore, leaving in case there is still some use case for that logic.