### PR TITLE
VID: mac and gnome windowed/fullscreen issue

### DIFF
--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -1657,7 +1657,8 @@ void VID_Minimize (void)
 
 void VID_Restore (void)
 {
-	if (!sdl_window) {
+	if (!sdl_window || (SDL_GetWindowFlags(sdl_window) & SDL_WINDOW_INPUT_FOCUS)) {
+		Con_Printf("vid restore no restore");
 		return;
 	}
 


### PR DESCRIPTION
VID: on both mac and gnome sometimes a fullscreened application gets marked as windowed and things like match_auto_unminimize cause the fullscreen "window" to toggle to windowed mode on match start requiring them to fullscreen it again.  if the "window" is focused do not attempt to restore the state.