### PR TITLE
SMARTSPAWN: Do not fire with +attack to spawn

### DIFF
--- a/cl_input.c
+++ b/cl_input.c
@@ -31,6 +31,7 @@ cvar_t cl_c2sImpulseBackup = { "cl_c2sImpulseBackup","3" };
 cvar_t cl_c2sdupe = { "cl_c2sdupe", "0" };
 cvar_t cl_forwardspeed = { "cl_forwardspeed","400" };
 cvar_t cl_smartjump = { "cl_smartjump", "1" };
+cvar_t cl_smartspawn = { "cl_smartspawn", "0" };
 cvar_t cl_iDrive = { "cl_iDrive", "0", 0, Rulesets_OnChange_cl_iDrive };
 cvar_t cl_movespeedkey = { "cl_movespeedkey","2.0" };
 cvar_t cl_nodelta = { "cl_nodelta","0" };
@@ -906,8 +907,16 @@ void CL_FinishMove(usercmd_t* cmd)
 	}
 
 	// figure button bits
-	if (in_attack.state & 3)
-		cmd->buttons |= 1;
+	if (in_attack.state & 3) {
+		if (cl_smartspawn.integer && !cl.spectator && (cl.stats[STAT_HEALTH] <= 0)) {
+			// Treat +attack as +jump while player is dead with cl_smartspawn
+			// and immediately -attack to prevent shooting.
+			cmd->buttons |= BUTTON_JUMP;
+			IN_AttackUp();
+		} else {
+			cmd->buttons |= BUTTON_ATTACK;
+		}
+	}
 	in_attack.state &= ~2;
 
 	if (in_jump.state & 3)
@@ -1214,6 +1223,7 @@ void CL_InitInput(void)
 	Cvar_SetCurrentGroup(CVAR_GROUP_INPUT_KEYBOARD);
 
 	Cvar_Register(&cl_smartjump);
+	Cvar_Register(&cl_smartspawn);
 	Cvar_Register(&cl_weaponhide);
 	Cvar_Register(&cl_weaponpreselect);
 	Cvar_Register(&cl_weaponforgetorder);

--- a/help_variables.json
+++ b/help_variables.json
@@ -2702,6 +2702,23 @@
         }
       ]
     },
+    "cl_smartspawn": {
+      "default": "0",
+      "desc": "When dead, +attack will spawn and immediately -attack to prevent weapon firing when spawning.",
+      "group-id": "9",
+      "remarks": "Spawning by jumping is preferred. This helps prevent unintentional +attack spawns.",
+      "type": "enum",
+      "values": [
+        {
+          "description": "+attack will spawn and potentially fire weapon",
+          "name": "0"
+        },
+        {
+          "description": "+attack will spawn and not fire weapon",
+          "name": "1"
+        }
+      ]
+    },
     "cl_solid_players": {
       "default": "1",
       "desc": "If not set then client will not perform collision detection against other players.",

--- a/menu_options.c
+++ b/menu_options.c
@@ -178,7 +178,7 @@ const char* scr_sshot_format_enum[] = {
 	"JPG", "jpg", "PNG", "png", "TGA", "tga" };
 
 extern cvar_t mvd_autotrack, mvd_moreinfo, mvd_status, cl_weaponpreselect, cl_weaponhide, con_funchars_mode, con_notifytime, scr_consize, ignore_opponents, _con_notifylines,
-	ignore_qizmo_spec, ignore_spec, msg_filter, crosshair, crosshairsize, cl_smartjump, scr_coloredText,
+	ignore_qizmo_spec, ignore_spec, msg_filter, crosshair, crosshairsize, cl_smartjump, cl_smartspawn, scr_coloredText,
 	cl_rollangle, cl_rollspeed, v_gunkick, v_kickpitch, v_kickroll, v_kicktime, v_viewheight, match_auto_sshot, match_auto_record, match_auto_logconsole,
 	r_fastturb, r_grenadetrail, cl_drawgun, r_viewmodelsize, r_viewmodeloffset, scr_clock, scr_gameclock, show_fps, rate, cl_c2sImpulseBackup,
 	name, team, skin, topcolor, bottomcolor, cl_teamtopcolor, cl_teambottomcolor, cl_teamquadskin, cl_teampentskin, cl_teambothskin, /*cl_enemytopcolor, cl_enemybottomcolor, */
@@ -866,6 +866,7 @@ setting settplayer_arr[] = {
 	ADDSET_CUSTOM	("Always Run", AlwaysRunRead, AlwaysRunToggle, "Maximum forward speed at all times."),
 	ADDSET_ADVANCED_SECTION(),
     ADDSET_BOOL		("Smart Jump", cl_smartjump),
+	ADDSET_BOOL		("Smart Spawn", cl_smartspawn),
 	ADDSET_NAMED	("Movement Scripts", allow_scripts, allowscripts_enum),
 	ADDSET_BASIC_SECTION(),
 	


### PR DESCRIPTION
**Adds:** `cl_smartspawn`
  - `0` disabled (default)
  - `1` enabled

**Description:**
When dead, `+attack` will spawn and immediately `-attack` to prevent weapon firing when spawning.

**Rationale:**
A best practice is to spawn without shooting. Spawning by shooting has numerous disadvantages:
  * wastes ammo
  * prevents an aimed shot for at least one reload cycle
  * can accidentally hurt or kill a teammate (Murphy's Law)
  * may reveal your spawn location via bullet impacts on a far wall to an enemy that otherwise
    would not know
  * inadvertently distorts a players true sg efficiency as most spawn shots are misses

**Solution:**
Add a command, like `cl_smartjump`, that better matches the player's intended behavior.

**Implementation:**
When a player is dead, an attack command (`+attack` / `+fire`) is treated as a jump instead
of an attack.

**Rulesets:**
Allowed by all. This is easily achievable with weapon scripts.