### PR TITLE
MENU: evaluate enums case-insensitively

### DIFF
--- a/src/settings_page.c
+++ b/src/settings_page.c
@@ -180,7 +180,7 @@ static int Enum_Find_ValueCode(setting* set)
 
 	for (i = 0; i <= set->max; i++)
 	{
-		if (!strcmp(VARSVAL(set->cvar), ENUM_VALUE(set, i)))
+		if (!strcasecmp(VARSVAL(set->cvar), ENUM_VALUE(set, i)))
 			return i;
 	}
 	return ENUM_ITEM_NOT_FOUND;


### PR DESCRIPTION
Prevents the menu showing "Custom" on legit values written with different capitalization. (The actual cvars do not care).
i.e gl_texturemode gl_linear would not match GL_LINEAR even though it is part of the enum.