### PR TITLE
SERVER BROWSER: fix race condition in SB_PingTree_ScanProxies

### DIFF
--- a/src/EX_browser_pathfind.c
+++ b/src/EX_browser_pathfind.c
@@ -395,12 +395,6 @@ int SB_PingTree_SendQueryThread(void *thread_arg)
 	Sys_TimerResolution_RequestMinimum(&timersession);
 
 	for (i = 0; i < queue->items; i++) {
-		// Bounds check
-		if (i >= queue->items) {
-			Com_DPrintf("SB_PingTree_SendQueryThread: index out of bounds\n");
-			break;
-		}
-
 		if (!queue->data[i].done) {
 			struct sockaddr_storage addr_to;
 			netadr_t netadr;


### PR DESCRIPTION
Change proxy_request_queue to heap allocation and added some safety checks and stuff.