### PR TITLE
Add con_margin_left

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -3431,6 +3431,12 @@
         }
       ]
     },
+    "con_margin_left": {
+      "default": "0",
+      "desc": "If set, messages are padded on the left by the number of spaces defined in the variable",
+      "group-id": "47",
+      "type": "integer"
+    },
     "con_mm2_only": {
       "default": "0",
       "desc": "If set, notification area is limited to mm2 (/say_team) messages.",

--- a/src/console.c
+++ b/src/console.c
@@ -79,6 +79,7 @@ cvar_t      con_shift               = {"con_shift", "-10"};
 cvar_t      cl_textEncoding         = {"cl_textencoding", "0"};
 cvar_t      con_mm2_only            = {"con_mm2_only", "0"};
 cvar_t      con_proportional        = {"con_proportional", "0"};
+cvar_t      con_margin_left         = {"con_margin_left", "0"};
 
 #ifdef _WIN32
 cvar_t      con_toggle_deadkey      = {"con_deadkey", "1"};
@@ -477,6 +478,7 @@ void Con_Init (void) {
 	Cvar_Register (&con_shift); 
 	Cvar_Register (&con_mm2_only);
 	Cvar_Register (&con_proportional);
+	Cvar_Register (&con_margin_left);
 
 	Cvar_ResetCurrentGroup();
 
@@ -677,7 +679,7 @@ void Con_PrintW(wchar *txt)
 					Con_Linefeed();
 				}
 				y = con.current % con_totallines;
-				idx = y * con_linewidth + con.x;
+				idx = y * con_linewidth + con.x + con_margin_left.integer;
 				con.text[idx] = c | (c > 0 && c <= 0x7F ? (mask | con_ormask) : 0);	// only apply mask if in 'standard' charset
 				memset(&con.clr[idx], 0, sizeof(clrinfo_t)); // zeroing whole struct
 				con.clr[idx].c = color;


### PR DESCRIPTION
If set, messages are padded by the number of spaces defined in the variable.

`con_margin_left 0`
![con-margin-left-0](https://github.com/user-attachments/assets/aba4b9cb-9f4d-43a7-a531-ce58c22224c8)

`con_margin_left 4`
![con-margin-left-4](https://github.com/user-attachments/assets/b825c2ce-9f94-43ed-b6ff-fcb0d9410c65)
