### PR TITLE
Adapt PM_TraceLine to transparent entities

### DIFF
--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -2141,6 +2141,10 @@ void CL_SetSolidEntities (void)
 				break;
 
 			pmove.physents[pmove.numphysent].model = cl.clipmodels[state->modelindex];
+#if defined(FTE_PEXT_TRANS)
+			pmove.physents[pmove.numphysent].is_transparent =
+				state->trans > 0 && state->trans < 255 ? true : false;
+#endif
 			VectorCopy (state->origin, pmove.physents[pmove.numphysent].origin);
 			pmove.numphysent++;
 		}

--- a/src/pmove.h
+++ b/src/pmove.h
@@ -29,6 +29,9 @@ typedef struct {
 	cmodel_t	*model;		// only for bsp models
 	vec3_t		mins, maxs;	// only for non-bsp models
 	int			info;		// for client or server to identify
+#if defined(FTE_PEXT_TRANS)
+	qbool		is_transparent;
+#endif
 } physent_t;
 
 typedef enum {

--- a/src/pmovetst.c
+++ b/src/pmovetst.c
@@ -233,6 +233,13 @@ trace_t PM_TraceLine (vec3_t start, vec3_t end)
 
 	for (i = 0; i < pmove.numphysent; i++) {
 		pe = &pmove.physents[i];
+
+#if defined(FTE_PEXT_TRANS)
+		if (cls.fteprotocolextensions & FTE_PEXT_TRANS && pe->is_transparent) {
+			continue;
+		}
+#endif
+
 		// get the clipping hull
 		hull = (pe->model) ? (&pmove.physents[i].model->hulls[0]) : (CM_HullForBox(pe->mins, pe->maxs));
 


### PR DESCRIPTION
Previously, it was not possible to point through the glass, the fix is shown in the screenshot.

![point-through-glass](https://github.com/user-attachments/assets/bf42f7a1-8b48-4c17-a7fa-6dfe57506199)
