### PR TITLE
BUG: fix potential race condition with hybrid servers with null check

### DIFF
--- a/src/pmovetst.c
+++ b/src/pmovetst.c
@@ -60,7 +60,13 @@ PM_PointContents
 */
 int PM_PointContents (vec3_t p)
 {
-	hull_t *hull = &pmove.physents[0].model->hulls[0];
+	hull_t *hull;
+	
+	// Safety check for NULL model in case entity updates arrive out of order
+	if (!pmove.physents[0].model)
+		return CONTENTS_EMPTY;
+	
+	hull = &pmove.physents[0].model->hulls[0];
 	return CM_HullPointContents (hull, hull->firstclipnode, p);
 }
 


### PR DESCRIPTION
My friend buckshot runs the denver.crxquake.com:26000 hybrid server that accepts NQ and QW clients. I never really had problems connecting on my main windows machine though there were strange crashes here and there when trying on different machines. However, I switched to linux on my gaming box and ezquake on linux ALWAYS crashes when trying to connect to it. No crashes connecting to any regular QW servers, just this hybrid. I did some digging and found a race condition where it looks like entity updates are starting before the modellist is finished loading on this particular server. This patch fixes it and now ezquake on linux works fine on this hybrid server. Probably an edge case here but surely others have encountered it.