### PR TITLE
VX_TRACKER: Add r_tracker_weapon_first

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -17436,6 +17436,12 @@
         }
       ]
     },
+    "r_tracker_weapon_first": {
+      "default": "0",
+      "desc": "Print the weapon icon or name before the player name.",
+      "group-id": "40",
+      "type": "boolean"
+    },
     "r_tracker_x": {
       "default": "0",
       "desc": "Adjusts the position of extra frag messages window.",


### PR DESCRIPTION
By default, tracker messages are formatted as:
ToT_white rl wigorf!

When r_tracker_weapon_first is set to 1, the format becomes: rl ToT_white wigorf!