### PR TITLE
Add anti-lag docs, regression tests and UI hooks

### DIFF
--- a/ANTI_LAG_REPORT.md
+++ b/ANTI_LAG_REPORT.md
@@ -1,0 +1,419 @@
+# Anti-Lag / Lag Compensation Report (idTech2, ezquake-source)
+
+Date: 2026-03-04
+Branch context: `antilag`
+
+## 1) Executive Summary
+
+Your branch already contains meaningful anti-lag infrastructure: per-client history buffers, command-time based target selection, rewound collision checks, projectile hooks, and demo/debug introspection.
+
+The current system is a solid foundation, but it is not yet "best possible" for competitive correctness. The main missing pieces are:
+
+- Robust target-time calculation (command timestamp + one-way latency + interpolation, with anti-spoof sanity checks).
+- History quality (time-bounded records with discontinuity markers and richer state: bbox/stance/alive).
+- Edge-case correctness (very old target times, teleports, stale history, projectile lifetime semantics).
+- Strict safety rails (max unlag, max command-time error, ping cutoffs, stuck/restore policy).
+- Deterministic validation (automated regression scenarios for jitter/loss/corner shots/teleports).
+
+The recommended endpoint is a **hybrid backward-reconciliation design**:
+
+- Full lag compensation for instant-hit and melee traces.
+- Optional projectile policy tiers (off / limited 50 ms / full experimental).
+- Explicit anti-abuse caps.
+- Deep observability for tuning and disputes.
+
+## 2) Current Branch Assessment (What Exists Today)
+
+### Core data model and hooks
+
+- Per-client history and lagged entities exist in server state:
+  - `antilag_positions[MAX_ANTILAG_POSITIONS]`, `laggedents[MAX_CLIENTS]` in [`src/server.h`](src/server.h).
+  - `MAX_ANTILAG_POSITIONS` is `128`.
+- `MOVE_LAGGED` and `FL_LAGGEDMOVE` exist for lagged tracing paths in [`src/sv_world.h`](src/sv_world.h) and [`src/server.h`](src/server.h).
+
+### Rewind-time target selection
+
+- Per-command `target_time` computed in [`src/sv_user.c`](src/sv_user.c) around lines 4394-4457.
+- Uses `frame->sv_time` (snapshot send-time saved in [`src/sv_ents.c`](src/sv_ents.c):565), optional prediction offset, interpolation/extrapolation between stored positions.
+
+### Trace integration
+
+- Lagged traces are integrated in [`src/sv_world.c`](src/sv_world.c):
+  - setup in `SV_AntilagClipSetUp` (owner/attacker based)
+  - extra checks in `SV_AntilagClipCheck`
+  - consumed from `SV_Trace`
+- PR1/PR2 instant-hit and melee traces (`traceline`/`tracebox`/`TraceCapsule`) now share unified anti-lag trace policy routing.
+
+### Projectile integration
+
+- Projectiles can be traced with lagged mode via `SV_PushEntity`/`SV_Physics_Toss` when enabled in [`src/sv_phys.c`](src/sv_phys.c):403-407 and 750.
+
+### Debugging and demo introspection
+
+- Hidden MVD debug stream for server rewind positions exists in [`src/sv_user.c`](src/sv_user.c):4183+.
+- Client parse and visual debug hooks exist in [`src/cl_parse.c`](src/cl_parse.c):4286+ and related client debug cvars.
+
+## 3) Key Gaps and Risks
+
+### A) Time selection and trust model
+
+- Current target-time logic is heuristic and not explicitly validated against command timestamp abuse.
+- No explicit equivalent of Source-style "delta too large, fall back to latency-based tick" guard.
+
+Impact:
+- Vulnerable to edge desync and potentially manipulated command timing in bad conditions.
+
+### B) History structure is too minimal
+
+- Stored rewind record currently holds only `origin` + `localtime`.
+- Missing explicit rewind state fields (bbox mins/maxs, alive/dead, duck/stance, teleport/discontinuity marker).
+
+Impact:
+- Incorrect rewinds around stance/size transitions and discontinuous moves.
+
+### C) Out-of-range history edge case
+
+- In `SV_ExecuteClientMessage` interpolation search, index `j` can run below valid historical floor before dereference (`base = ... [j % MAX_ANTILAG_POSITIONS]`) around lines 4443-4449 in [`src/sv_user.c`](src/sv_user.c).
+
+Impact:
+- Potential invalid indexing/undefined behavior in extreme lag + short history scenarios.
+
+### D) Teleport/discontinuity reset coverage
+
+- Reset helper exists (`SV_AntilagReset`), but only clearly called from PR2 `setorigin` path.
+
+Impact:
+- Teleports or sharp discontinuities outside that path can pollute rewind history.
+
+### E) Projectile semantics are underspecified
+
+- Half-Life paper and Unlagged both treat projectile lag compensation as fundamentally trickier than instant-hit.
+- Current owner-based lagged collision for projectiles needs strict policy and guardrails.
+
+Impact:
+- Fairness paradoxes, dodge inconsistency, harder-to-debug outcomes.
+
+### F) Scaling/perf controls
+
+- Rewind candidate set is broad (`MAX_CLIENTS`), and there is limited selective filtering by attack ray/context.
+
+Impact:
+- Worst-case cost spikes under high player count or aggressive projectile modes.
+
+## 4) External Findings (Primary Sources)
+
+### Valve/Bernier model
+
+- Lag compensation = rewind server-side world state to what attacker saw, execute command, restore.
+- Must include **both connection latency and interpolation latency**.
+- Projectile lag compensation is non-trivial and often excluded by default.
+
+### Source SDK implementation patterns
+
+- Keep bounded history (`sv_maxunlag`), prune by time.
+- Compute correction from outgoing latency + interpolation ticks.
+- Clamp correction and reject implausible command-time deltas (>200 ms in reference implementation).
+- Guard teleports/discontinuities and stuck restore cases.
+- Support rewind modes (bounds only vs full hitboxes vs along-ray optimization).
+
+### Unlagged (Quake 3) patterns
+
+- Backward reconciliation for instant-hit traces with command timestamp.
+- Store enough history for high ping but cap realistically.
+- Reset history on major discontinuities (teleports).
+- Built-in frame-delay correction and optional projectile nudge model.
+- Separate "true state" from "rendered/smoothed state" for skip correction.
+
+## 4.1) Opportunity Catalog (Methods + idTech2 Fit)
+
+This is the complete practical menu for FPS anti-lag in an idTech2 family engine:
+
+1. **No rewind (classic lead-your-shots)**  
+   Fit: trivial, lowest CPU, lowest fairness for high ping.
+
+2. **Hitscan backward reconciliation (server rewind at fire time)**  
+   Fit: best ROI, competitive standard, recommended core.
+
+3. **Backward reconciliation + interpolation compensation**  
+   Fit: required for correctness when targets are render-interpolated client-side.
+
+4. **Bounds-only rewind (AABB/capsule), not full hitbox animation**  
+   Fit: high performance, strong baseline for idTech2 where many mods use bbox collisions.
+
+5. **Full hitbox rewind (pose-aware)**
+   Fit: highest precision but higher complexity; only needed if gameplay depends on detailed hitboxes.
+
+6. **Along-ray rewind optimization (only rewind entities intersecting attack ray corridor)**  
+   Fit: strong optimization at high player counts and for expensive hitbox modes.
+
+7. **Projectile compensation: disabled**  
+   Fit: simplest/fair conservative baseline; many classic engines keep this default.
+
+8. **Projectile compensation: limited fixed window (e.g. built-in 50 ms style)**  
+   Fit: practical compromise; lowers paradox frequency vs full projectile rewind.
+
+9. **Projectile compensation: owner-latency full rewind**  
+   Fit: possible but high paradox risk and balancing cost; recommend opt-in only.
+
+10. **Client-authoritative hit confirmation with server audit**  
+    Fit: usually not appropriate for competitive idTech2 servers due trust/cheat risk.
+
+11. **Full rollback netcode (rewind entire sim and replay)**  
+    Fit: generally overkill for idTech2 FPS; high complexity, major deterministic constraints.
+
+12. **Per-weapon adaptive anti-lag policy table**  
+    Fit: highly recommended. lets hitscan, melee, and projectile classes use different compensation rigor.
+
+Recommended idTech2 target combination:
+
+- Method 2 + 3 + 4 as default core.
+- Method 6 for scale/perf.
+- Method 8 optional, Method 9 experimental/admin-only.
+- Method 12 mandatory for long-term maintainability.
+
+## 5) Recommended "Best Possible" Design for idTech2
+
+## 5.1 Design goals
+
+- Competitive fairness over visual illusion.
+- Server authority preserved at all times.
+- Deterministic replay/debug capability.
+- Hard bounded CPU/memory cost.
+- Tunable policy by ruleset.
+
+## 5.2 Data model (server)
+
+Create a richer rewind record (per player, ring buffer):
+
+- `server_time` (double or int ms)
+- `origin`
+- `mins`, `maxs`
+- `velocity` (optional but useful for controlled extrapolation)
+- `alive` / `solid` / `ducked_or_size_class`
+- `teleport_or_discontinuity` bit
+- optional `anim/frame` if hitbox model needs it
+
+History policy:
+
+- Time-bounded first (`sv_antilag_maxunlag`), capacity-bounded second.
+- Prune old entries each server frame.
+- Never interpolate across discontinuity markers.
+
+## 5.3 Target-time derivation
+
+Per incoming usercmd:
+
+1. Start with client command time reference.
+2. Compute one-way correction from measured network latency.
+3. Add client interpolation delay estimate.
+4. Clamp to `[0, sv_antilag_maxunlag]`.
+5. Validate against latency-derived expectation:
+   - If command-derived delta exceeds threshold (`sv_antilag_max_cmd_delta`), fall back to latency-derived target.
+
+This mirrors proven Source behavior while fitting idTech2 command flow.
+
+## 5.4 Rewind execution model
+
+For each lag-compensated trace/hull test:
+
+- Build candidate list (alive, relevant team, PVS/radius/ray overlap filters).
+- For each candidate, fetch two history records bracketing target time.
+- Interpolate state (never extrapolate beyond allowed micro-window).
+- Perform trace against rewound candidate state.
+
+Implementation choice in this codebase:
+
+- Keep your current **trace-space offset approach** (not global mutation) for safety and minimal side effects.
+- Add optional "full entity rewind + restore" path only if future hitbox/animation needs require it.
+
+## 5.5 Weapon policy
+
+Use explicit per-weapon anti-lag mode table:
+
+- Instant-hit: full lag compensation (default on).
+- Melee/hull traces: full lag compensation.
+- Projectiles:
+  - Mode 0: off (most conservative)
+  - Mode 1: 50 ms built-in correction equivalent (recommended default)
+  - Mode 2: full owner-latency compensation (experimental/admin only)
+
+Rationale: preserves fairness and avoids projectile paradox explosion.
+
+## 5.6 Safety rails
+
+- `sv_antilag_maxunlag` (hard cap, default 0.2-0.3s for competitive)
+- `sv_antilag_max_cmd_delta` (anti-spoof threshold)
+- `sv_antilag_ping_limit` (disable/limit compensation above threshold)
+- Teleport distance/discontinuity cut (`sv_antilag_teleport_dist`)
+- Optional stuck-prevention restore policy for full rewind mode
+
+## 5.7 Observability
+
+Keep and expand existing MVD debug stream:
+
+- target_time chosen
+- attacker latency/interp inputs
+- per-target rewind result: exact/interpolated/fallback/missed
+- rejected due to cap/invalid time
+- counters exported for server stats/console
+
+## 5.8 Rollout strategy
+
+- Dark-launch instrumentation first.
+- Hitscan-only enablement next.
+- Projectile limited mode after validation.
+- Full projectile mode only if competitive data supports it.
+
+## 6) Recommended Cvar/API Surface
+
+Keep compatibility with existing `sv_antilag*` but add structured controls:
+
+- `sv_antilag` (`0` off, `1` hitscan/melee, `2` include projectile policy)
+- `sv_antilag_maxunlag` (seconds, hard cap)
+- `sv_antilag_max_cmd_delta` (seconds, anti-spoof)
+- `sv_antilag_projectile_mode` (`0/1/2` as above)
+- `sv_antilag_rollout_stage` (`0` instrumentation only, `1` hitscan/melee, `2` projectile-limited gated, `3` full projectile eligible)
+- `sv_antilag_projectile_playtest_signoff` (`0/1` rollout gate for projectile enablement at stage 2+)
+- `sv_antilag_projectile_full_admin` (`0/1` admin gate for allowing projectile mode `2`)
+- `sv_antilag_ping_limit`
+- `sv_antilag_teleport_dist`
+- `sv_antilag_debug` (verbosity level)
+
+Suggested internal API:
+
+- `SV_Antilag_BeginForCommand(client_t* attacker, const usercmd_t* cmd, antilag_ctx_t* ctx)`
+- `SV_Antilag_ResolveTargetState(antilag_ctx_t* ctx, int target_entnum, rewind_state_t* out)`
+- `SV_Antilag_End(antilag_ctx_t* ctx)`
+
+## 7) Checkboxed Implementation Plan
+
+## Phase 0: Baseline + guardrails
+
+- [x] Add `docs/` design note for anti-lag invariants and threat model.
+- [x] Add `sv_antilag_maxunlag`, `sv_antilag_max_cmd_delta`, `sv_antilag_ping_limit` cvars.
+- [x] Wire startup defaults by ruleset (competitive/casual).
+
+## Phase 1: Data model hardening
+
+- [x] Replace minimal `antilag_position_t` with richer rewind record (time, origin, mins/maxs, flags).
+- [x] Convert history management to time-pruned ring semantics (not just count).
+- [x] Add discontinuity marker flag and helper.
+
+## Phase 2: Correct time math
+
+- [x] Implement target-time computation from cmd timestamp + measured latency + interpolation.
+- [x] Add delta sanity check with fallback to latency-derived target time.
+- [x] Clamp to max-unlag window and reject outliers with debug counters.
+
+## Phase 3: Fix known correctness bugs
+
+- [x] Fix out-of-range history indexing in `SV_ExecuteClientMessage` interpolation search.
+- [x] Handle no-bracket cases explicitly (use oldest/newest valid record with policy).
+- [x] Guard zero/negative interpolation denominators.
+
+## Phase 4: Teleport/discontinuity correctness
+
+- [x] Call `SV_AntilagReset` (or new discontinuity insert) from all teleport/setorigin paths (PR1 + PR2 + engine events).
+- [x] Add jump-distance discontinuity detection in history writer.
+- [x] Ensure spawn/death transitions create clean rewind boundaries.
+
+## Phase 5: Rewind candidate filtering and perf
+
+- [x] Add candidate prefilter: connected, alive, relevant team, possibly visible, broadphase overlap.
+- [x] Add optional ray-based narrowing ("along ray" style) for expensive modes.
+- [x] Add perf counters and server frame budget alarms.
+
+## Phase 6: Hitscan/melee integration finalization
+
+- [x] Route all instant-hit and melee hull traces through unified anti-lag resolver.
+- [x] Validate parity across `pr_cmds.c` and `pr2_cmds.c` paths.
+- [x] Add deterministic replay tests for classic edge cases (peek shot, crossing strafe, jitter target).
+- [x] Extend deterministic replay command with trace-policy parity checks (hitscan/melee mode gates, bot bypass, null attacker safety).
+
+## Phase 7: Projectile policy implementation
+
+- [x] Implement `sv_antilag_projectile_mode` with three tiers (off/50ms/full).
+- [x] Add owner-staleness guard: projectile compensation must not use stale owner context beyond threshold.
+- [x] Add opt-in per-mod/per-weapon toggles.
+- [x] Add deterministic projectile-policy replay coverage (mode tier gates, owner freshness/state guards, opt-in/allow/deny precedence, blend fraction checks).
+
+## Phase 8: Debug and tooling
+
+- [x] Expand hidden MVD block with reason codes and timing fields.
+- [x] Add server commands to dump recent per-client anti-lag decisions.
+- [x] Add client HUD debug overlay for rewind deltas and fallback reasons.
+- [x] Extend tooling ergonomics: dump commands now include cumulative counters, HUD extended mode includes command-window and server/target timing.
+- [x] Decouple HUD summary from spectator-only gating (stats can be shown whenever debug payload is available; line overlays remain spectator/demo-focused).
+
+## Phase 9: Validation harness
+
+- [x] Build scripted bot scenarios with controlled latency/jitter/loss/reorder.
+- [x] Record golden outcomes for hit registration.
+- [x] Add CI test target that runs anti-lag regression suite headless.
+- [x] Enforce strict golden integrity (duplicate-name rejection, fail on unmatched golden rows) and broaden scenario matrix (`no_pred`, command-msec clamping, delta-guard disabled, heavy-loss window).
+
+## Phase 10: Rollout
+
+- [x] Ship instrumentation-only build to collect baseline metrics.
+- [x] Enable hitscan/melee anti-lag by default after metric pass.
+- [x] Enable projectile limited mode only after dedicated playtest signoff.
+- [x] Keep full projectile mode admin-only until statistically validated.
+
+## Phase 11: Documentation and operations
+
+- [x] Publish admin tuning guide (recommended cvar presets by server type).
+- [x] Publish player-facing explanation of paradoxes and fairness tradeoffs.
+- [x] Add troubleshooting matrix ("shot around corner", high jitter, false misses).
+
+Phase 11 documentation deliverables:
+
+- `docs/ANTI_LAG_ADMIN_TUNING.md`
+- `docs/ANTI_LAG_PLAYER_FAIRNESS.md`
+- `docs/ANTI_LAG_TROUBLESHOOTING.md`
+
+## 8) Pitfall Matrix (Quick Reference)
+
+- Incorrect command time trust -> clamp + delta sanity fallback.
+- History too short/too sparse -> time-bounded history + min sampling frequency.
+- Teleport poisoning -> discontinuity markers + reset hooks.
+- Stance/bbox mismatch -> store mins/maxs and state flags per record.
+- Projectile fairness paradox -> limited mode default; full mode opt-in.
+- Performance spikes -> candidate filtering + mode-based rewind depth.
+- Dispute/debug blindness -> always-on counters + MVD rewind traces.
+
+## 9) Recommended Defaults (Competitive)
+
+- `sv_antilag 1`
+- `sv_antilag_projectile_mode 1` (limited 50 ms model) or `0` for strictest tournaments
+- `sv_antilag_maxunlag 0.25`
+- `sv_antilag_max_cmd_delta 0.20`
+- `sv_antilag_ping_limit 400`
+- `sv_antilag_teleport_dist 64`
+
+## 10) Sources
+
+Primary sources used:
+
+- Valve Developer Community, Lag Compensation:
+  - https://developer.valvesoftware.com/wiki/Lag_compensation
+- Yahn Bernier, *Latency Compensating Methods in Client/Server In-game Protocol Design and Optimization*:
+  - https://www.gamedevs.org/uploads/latency-compensation-in-client-server-protocols.pdf
+- Unlagged documentation (Quake 3):
+  - Networking primer: https://www.ra.is/unlagged/network.html
+  - Code integration: https://www.ra.is/unlagged/code.html
+  - Walkthroughs: https://www.ra.is/unlagged/walkthroughs.html
+  - FAQ: https://www.ra.is/unlagged/faq.html
+  - Solution/tradeoffs: https://www.ra.is/unlagged/solution.html
+- Valve lag compensation code reference (Source SDK lineage):
+  - https://swarm.workshop.perforce.com/files/guest/knut_wikstrom/ValveSDKCodedlls/player_lagcompensation.cpp
+
+Repository code analyzed:
+
+- [`src/server.h`](src/server.h)
+- [`src/sv_user.c`](src/sv_user.c)
+- [`src/sv_world.c`](src/sv_world.c)
+- [`src/sv_phys.c`](src/sv_phys.c)
+- [`src/sv_ents.c`](src/sv_ents.c)
+- [`src/pr_cmds.c`](src/pr_cmds.c)
+- [`src/pr2_cmds.c`](src/pr2_cmds.c)
+- [`src/cl_parse.c`](src/cl_parse.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.22)
 
 project(ezquake C)
 
+option(ENABLE_ANTILAG_REGRESSION_TESTS "Build and register anti-lag regression tests" ON)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     enable_language(OBJC)
 endif()
@@ -903,6 +905,32 @@ else()
 endif()
 
 set_target_properties(ezquake PROPERTIES OUTPUT_NAME ${EXECUTABLE_NAME})
+
+if(ENABLE_ANTILAG_REGRESSION_TESTS)
+    add_executable(antilag_phase9_regression
+            ${PROJECT_SOURCE_DIR}/tests/antilag/phase9_regression.c
+    )
+    target_include_directories(antilag_phase9_regression PRIVATE
+            ${SOURCE_DIR}/qwprot/src
+    )
+    if(MATH)
+        target_link_libraries(antilag_phase9_regression PRIVATE ${MATH})
+    endif()
+
+    enable_testing()
+    add_test(
+            NAME antilag_phase9_regression
+            COMMAND antilag_phase9_regression
+                    --network ${PROJECT_SOURCE_DIR}/tests/antilag/phase9_network_scenarios.csv
+                    --golden ${PROJECT_SOURCE_DIR}/tests/antilag/phase9_golden.csv
+    )
+    set_tests_properties(antilag_phase9_regression PROPERTIES
+            TIMEOUT 30
+            PASS_REGULAR_EXPRESSION "PHASE9_REGRESSION_PASS"
+            FAIL_REGULAR_EXPRESSION "PHASE9_REGRESSION_FAIL"
+            LABELS "antilag;regression"
+    )
+endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     get_target_property(version git_version GIT_DESCRIBE)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ On Linux, `./build-linux.sh` produces an ezQuake binary in the top directory.
 For a more in-depth description of how to build on all platforms, have a look at 
 [BUILD.md](BUILD.md).
 
+## Anti-Lag Docs
+
+- [Anti-Lag Invariants and Threat Model](docs/ANTI_LAG_INVARIANTS.md)
+- [Anti-Lag Admin Tuning Guide](docs/ANTI_LAG_ADMIN_TUNING.md)
+- [Anti-Lag Fairness Guide for Players](docs/ANTI_LAG_PLAYER_FAIRNESS.md)
+- [Anti-Lag Troubleshooting Matrix](docs/ANTI_LAG_TROUBLESHOOTING.md)
+
 ## Nightly builds
 
 Nightly builds can be found [here][nightly]

--- a/cmake/GitUtils.cmake
+++ b/cmake/GitUtils.cmake
@@ -95,23 +95,12 @@ function(git_extract_version target_var)
     set(VERSION_MINOR 0)
     set(VERSION_PATCH 0)
 
-    string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" SEMVER_MATCH "${GIT_DESCRIBE}")
-    list(LENGTH SEMVER_MATCH PARTS_SIZE)
-
-    if(SEMVER_MATCH)
-        if(PARTS_SIZE GREATER 0)
-            list(GET SEMVER_MATCH 0 VERSION_MAJOR)
-        endif()
-
-        if(PARTS_SIZE GREATER 1)
-            list(GET SEMVER_MATCH 1 VERSION_MINOR)
-        endif()
-
-        if(PARTS_SIZE GREATER 2)
-            list(GET SEMVER_MATCH 2 VERSION_PATCH)
-        endif()
+    if(GIT_DESCRIBE MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*")
+        set(VERSION_MAJOR "${CMAKE_MATCH_1}")
+        set(VERSION_MINOR "${CMAKE_MATCH_2}")
+        set(VERSION_PATCH "${CMAKE_MATCH_3}")
     else()
-        message(WARNING "Upstream tags missing. Using default version 0.0.0")
+        message(WARNING "Upstream semver tags missing. Using default version 0.0.0")
     endif()
 
     set_target_properties(${target_var} PROPERTIES

--- a/docs/ANTI_LAG_ADMIN_TUNING.md
+++ b/docs/ANTI_LAG_ADMIN_TUNING.md
@@ -1,0 +1,208 @@
+# Anti-Lag Admin Tuning Guide
+
+This guide is for server operators running anti-lag in production.
+
+## Goals
+
+- Keep hit registration fair across mixed pings.
+- Keep paradox frequency understandable and bounded.
+- Keep CPU cost predictable under load.
+- Keep rollout and escalation operationally safe.
+
+## Core Controls
+
+- `sv_antilag`
+  - `0`: disable anti-lag gameplay rewinds
+  - `1`: hitscan/melee rewinds
+  - `2`: include projectile policy path
+- `sv_antilag_rollout_stage`
+  - `0`: instrumentation-only (records decisions, no lagged trace application)
+  - `1`: hitscan/melee enabled
+  - `2`: projectile limited eligible with signoff
+  - `3`: full projectile eligibility with admin gate
+- `sv_antilag_projectile_mode`
+  - `0`: off
+  - `1`: limited window
+  - `2`: full owner-latency projectile rewind
+- `sv_antilag_projectile_playtest_signoff`
+  - `0/1` rollout gate for projectile enablement at stage `2+`
+- `sv_antilag_projectile_full_admin`
+  - `0/1` admin gate for allowing effective projectile mode `2`
+- `sv_antilag_maxunlag`
+  - hard rewind depth cap in seconds
+- `sv_antilag_max_cmd_delta`
+  - anti-spoof drift threshold in seconds
+- `sv_antilag_ping_limit`
+  - optional hard ping gate in milliseconds (`0` means disabled)
+- `sv_antilag_teleport_dist`
+  - discontinuity distance threshold in world units
+- `sv_antilag_prefilter_pvs`, `sv_antilag_prefilter_team`
+  - candidate filtering toggles
+- `sv_antilag_ray_narrow`, `sv_antilag_ray_narrow_pad`
+  - along-ray narrowing controls
+- `sv_antilag_frame_budget_ms`
+  - soft per-frame budget alarm threshold
+
+## Recommended Presets by Server Type
+
+### Tournament / Strict Competitive
+
+- `sv_antilag 1`
+- `sv_antilag_rollout_stage 1`
+- `sv_antilag_projectile_mode 0`
+- `sv_antilag_projectile_playtest_signoff 0`
+- `sv_antilag_projectile_full_admin 0`
+- `sv_antilag_maxunlag 0.25`
+- `sv_antilag_max_cmd_delta 0.20`
+- `sv_antilag_ping_limit 400`
+- `sv_antilag_teleport_dist 64`
+- `sv_antilag_prefilter_pvs 1`
+- `sv_antilag_prefilter_team 1`
+- `sv_antilag_ray_narrow 1`
+- `sv_antilag_ray_narrow_pad 16`
+- `sv_antilag_frame_budget_ms 0.75`
+
+Why: strongest fairness predictability, lowest projectile paradox risk.
+
+### Public Competitive (Mixed Ping)
+
+- `sv_antilag 2`
+- `sv_antilag_rollout_stage 2`
+- `sv_antilag_projectile_mode 1`
+- `sv_antilag_projectile_playtest_signoff 1`
+- `sv_antilag_projectile_full_admin 0`
+- `sv_antilag_maxunlag 0.25`
+- `sv_antilag_max_cmd_delta 0.20`
+- `sv_antilag_ping_limit 500`
+- `sv_antilag_teleport_dist 64`
+- `sv_antilag_prefilter_pvs 1`
+- `sv_antilag_prefilter_team 1`
+- `sv_antilag_ray_narrow 1`
+- `sv_antilag_ray_narrow_pad 16`
+- `sv_antilag_frame_budget_ms 1.00`
+
+Why: keeps projectile support limited and controlled while serving broader pings.
+
+### Casual / Community
+
+- `sv_antilag 2`
+- `sv_antilag_rollout_stage 2`
+- `sv_antilag_projectile_mode 1`
+- `sv_antilag_projectile_playtest_signoff 1`
+- `sv_antilag_projectile_full_admin 0`
+- `sv_antilag_maxunlag 0.50`
+- `sv_antilag_max_cmd_delta 0.35`
+- `sv_antilag_ping_limit 0`
+- `sv_antilag_teleport_dist 96`
+- `sv_antilag_prefilter_pvs 1`
+- `sv_antilag_prefilter_team 1`
+- `sv_antilag_ray_narrow 1`
+- `sv_antilag_ray_narrow_pad 24`
+- `sv_antilag_frame_budget_ms 1.50`
+
+Why: prioritizes accessibility for higher latency players.
+
+### Experimental Projectile Full (Admin-Only Validation)
+
+- `sv_antilag 2`
+- `sv_antilag_rollout_stage 3`
+- `sv_antilag_projectile_mode 2`
+- `sv_antilag_projectile_playtest_signoff 1`
+- `sv_antilag_projectile_full_admin 1`
+- keep all other values from the target baseline preset above
+
+Why: only for controlled sessions with explicit monitoring and rollback plan.
+
+## Rollout Runbook
+
+1. Stage 0 baseline
+- Set `sv_antilag_rollout_stage 0`.
+- Keep intended long-term cvars preconfigured.
+- Collect decision metrics and operator observations for representative matches.
+
+2. Stage 1 activation
+- Set `sv_antilag_rollout_stage 1`.
+- Keep projectile gates disabled.
+- Validate with:
+  - `sv_antilag_rollout_status`
+  - `sv_antilag_dumpall 4`
+  - `sv_antilag_replaytests`
+
+3. Stage 2 projectile-limited activation
+- Set `sv_antilag_rollout_stage 2`.
+- Set `sv_antilag_projectile_playtest_signoff 1`.
+- Keep `sv_antilag_projectile_mode 1` and `sv_antilag_projectile_full_admin 0`.
+- Run dedicated playtest sessions and compare disputes vs baseline.
+
+4. Stage 3 eligibility (still limited by admin gate)
+- Set `sv_antilag_rollout_stage 3`.
+- Keep `sv_antilag_projectile_full_admin 0` for normal production.
+- Enable `sv_antilag_projectile_full_admin 1` only in controlled validation windows.
+
+Rollback rule:
+- For immediate gameplay rollback without losing instrumentation, set `sv_antilag_rollout_stage 0`.
+
+## Live Monitoring Checklist
+
+- `sv_antilag_rollout_status`
+  - confirms requested vs effective modes
+- `sv_antilag_dump <player> 8`
+  - inspect reason flags and timing deltas for specific disputes
+- `sv_antilag_dumpall 2`
+  - sweep latest decisions across active clients
+- `sv_antilag_replaytests`
+  - verify deterministic policy invariants after config changes
+
+Watch for:
+
+- Frequent `ping_reject` on target population.
+- Frequent `cmd_fallback` / `clamp_unlag` spikes.
+- Repeated `rollout_gate` when gameplay anti-lag is expected.
+- Clip/build counters growing faster than frame budget permits.
+
+## Config Snippets
+
+Tournament baseline:
+
+```cfg
+set sv_antilag 1
+set sv_antilag_rollout_stage 1
+set sv_antilag_projectile_mode 0
+set sv_antilag_projectile_playtest_signoff 0
+set sv_antilag_projectile_full_admin 0
+set sv_antilag_maxunlag 0.25
+set sv_antilag_max_cmd_delta 0.20
+set sv_antilag_ping_limit 400
+set sv_antilag_teleport_dist 64
+set sv_antilag_prefilter_pvs 1
+set sv_antilag_prefilter_team 1
+set sv_antilag_ray_narrow 1
+set sv_antilag_ray_narrow_pad 16
+set sv_antilag_frame_budget_ms 0.75
+```
+
+Public mixed-ping baseline:
+
+```cfg
+set sv_antilag 2
+set sv_antilag_rollout_stage 2
+set sv_antilag_projectile_mode 1
+set sv_antilag_projectile_playtest_signoff 1
+set sv_antilag_projectile_full_admin 0
+set sv_antilag_maxunlag 0.25
+set sv_antilag_max_cmd_delta 0.20
+set sv_antilag_ping_limit 500
+set sv_antilag_teleport_dist 64
+set sv_antilag_prefilter_pvs 1
+set sv_antilag_prefilter_team 1
+set sv_antilag_ray_narrow 1
+set sv_antilag_ray_narrow_pad 16
+set sv_antilag_frame_budget_ms 1.00
+```
+
+## Change Control Recommendations
+
+- Apply anti-lag changes one dimension at a time.
+- Record exact cvar snapshots before and after each change.
+- Run at least one deterministic replay check after significant updates.
+- Preserve at least one week of operator dispute notes before deciding on stage escalation.

--- a/docs/ANTI_LAG_INVARIANTS.md
+++ b/docs/ANTI_LAG_INVARIANTS.md
@@ -1,0 +1,194 @@
+# Anti-Lag Invariants and Threat Model
+
+This document defines the non-negotiable correctness and safety rules for server-side anti-lag.
+
+Related operations docs:
+
+- `docs/ANTI_LAG_ADMIN_TUNING.md`
+- `docs/ANTI_LAG_PLAYER_FAIRNESS.md`
+- `docs/ANTI_LAG_TROUBLESHOOTING.md`
+
+## Scope
+
+- Engine: idTech2 / QuakeWorld-style server-authoritative networking.
+- Feature area: rewind-based hit registration for instant-hit/melee (projectiles optional by policy).
+- Code owners: server networking + movement/trace maintainers.
+
+## Security and Fairness Threat Model
+
+Primary threats:
+
+- Timestamp abuse: client attempts to force rewind far beyond fair window.
+- High-ping exploitation: extreme latency used to gain unfair corner-shot advantage.
+- History poisoning: teleports/discontinuities producing invalid interpolation.
+- Stance mismatch: bbox/size changes not reflected in rewind state.
+- Performance DoS: expensive rewind work amplified by player count/projectile settings.
+
+Non-goals:
+
+- Client-authoritative hit decisions.
+- Unlimited rewind in support of arbitrarily high ping.
+
+## Anti-Lag Invariants
+
+1. Server authority
+- All hit confirmation stays server-side.
+- Client data can influence only bounded rewind targets.
+
+2. Bounded rewind
+- Rewind time is capped by `sv_antilag_maxunlag`.
+- Additional command-time drift is capped by `sv_antilag_max_cmd_delta`.
+
+3. Ping policy
+- Compensation is optionally limited by `sv_antilag_ping_limit`.
+- When limit is exceeded, anti-lag is reduced/disabled for that command path.
+
+4. History correctness
+- History is maintained as a bounded ring buffer.
+- History is additionally pruned by configured max-unlag time window.
+- Each record stores at least time, origin, mins, maxs, and flags.
+
+5. Discontinuity safety
+- Teleports/discontinuous moves must not be interpolated across.
+- Discontinuities are explicitly marked in history.
+
+6. Deterministic interpolation
+- Rewind interpolation factor is clamped to `[0,1]`.
+- Invalid brackets fall back to nearest valid sample.
+- If target time is outside stored history, fallback policy is explicit:
+  - older than window => oldest sample
+  - newer than window => newest sample
+
+7. Operational safety
+- Feature can be disabled via `sv_antilag`.
+- Debug traces remain available for post-match verification.
+- Server tracks anti-lag fallback/reject clamp counters per client.
+
+8. Projectile policy safety (Phase 7)
+- Projectile rewind is controlled by `sv_antilag_projectile_mode`:
+  - `0`: off
+  - `1`: limited window (`sv_antilag_projectile_nudge`, default 50ms-equivalent)
+  - `2`: full owner-latency rewind
+- Guardrails:
+  - `sv_antilag_projectile_mode` and `sv_antilag_projectile_optin` are clamped to `0..2`.
+  - `sv_antilag_projectile_nudge` and `sv_antilag_projectile_owner_stale` are clamped to `>= 0`.
+- Legacy compatibility: `sv_antilag_projectiles` is synchronized with mode controls:
+  - setting legacy `0` forces mode `0`
+  - setting legacy `1` promotes mode `0` to mode `1` (keeps mode `2` unchanged)
+  - setting mode `0/1/2` mirrors legacy toggle off/on automatically
+- Projectile rewind is rejected when owner lagged context is stale:
+  - guard threshold: `sv_antilag_projectile_owner_stale`
+  - stale/no-owner/no-history => no projectile rewind
+- Projectile rewind can be policy-gated per mod/weapon:
+  - `sv_antilag_projectile_optin`
+  - `sv_antilag_projectile_allow` / `sv_antilag_projectile_deny`
+  - explicit entity opt-in via `FL_LAGGEDMOVE`
+
+9. Debug observability safety (Phase 8)
+- Hidden MVD anti-lag debug packets include reason flags and timing/counter fields.
+- Server keeps a bounded per-client anti-lag decision history ring for operator inspection.
+- Runtime inspection commands:
+  - `sv_antilag_dump <userid/name> [count]`
+  - `sv_antilag_dumpall [count]`
+  - `sv_antilag_rollout_status`
+  - Dump output includes both cumulative totals and per-decision snapshots.
+- Client overlay can display rewind deltas and fallback reasons via:
+  - `cl_debug_antilag_hud` (`1` summary, `2` extended counters)
+  - Extended mode also shows command-window and server/target timing values.
+  - Line-segment visualizations (`cl_debug_antilag_lines`) remain demo/spectator-oriented.
+
+10. Rollout safety (Phase 10)
+- Rollout control is driven by `sv_antilag_rollout_stage` (clamped to `0..3`).
+- Stage behavior:
+  - `0`: instrumentation-only baseline. Server still records anti-lag decisions, but trace policy never applies `MOVE_LAGGED`.
+  - `1`: hitscan/melee anti-lag can be applied.
+  - `2`: projectile anti-lag can be applied only if `sv_antilag_projectile_playtest_signoff=1`.
+  - `3`: full projectile mode (`sv_antilag_projectile_mode=2`) is allowed only if `sv_antilag_projectile_full_admin=1`.
+- Projectile rollout gates are clamped to boolean:
+  - `sv_antilag_projectile_playtest_signoff`
+  - `sv_antilag_projectile_full_admin`
+- Full projectile mode requests are downgraded to limited mode when admin gate is disabled.
+- Decision telemetry marks stage-gated instrumentation-only operation with `rollout_gate` reason flag.
+
+11. Validation harness safety (Phase 9)
+- Scripted latency/jitter/loss/reorder scenarios are stored in:
+  - `tests/antilag/phase9_network_scenarios.csv`
+- Golden outcomes are stored in:
+  - `tests/antilag/phase9_golden.csv`
+- Harness guarantees:
+  - scenario names must be unique (no duplicate network/golden keys)
+  - every executed scenario must have a golden row
+  - every golden row for `network`/`hitreg` must be matched (no stale extras)
+- Headless regression runner:
+  - executable target: `antilag_phase9_regression`
+  - ctest name: `antilag_phase9_regression`
+  - pass marker: `PHASE9_REGRESSION_PASS`
+
+## Configuration Profiles
+
+Two startup profiles are recognized:
+
+- Competitive profile: lower rewind cap, stricter drift cap, ping limit enabled.
+- Casual profile: larger rewind cap, looser drift cap, ping limit disabled.
+- Rollout baseline defaults to `sv_antilag_rollout_stage 0` (instrumentation-only).
+
+Profile selection is based on active `ruleset` name at startup:
+
+- Competitive-like: `smackdown`, `smackdrive`, `qcon`, `thunderdome`, `mtfl`.
+- Casual/default: everything else.
+
+## Deterministic Replay Checks (Phase 6/7)
+
+- Command: `sv_antilag_replaytests`
+- Scenarios:
+  - `peek_shot`
+  - `crossing_strafe`
+  - `jitter_target`
+  - `policy_hitscan_mode1`
+  - `policy_melee_mode1`
+  - `policy_hitscan_mode0`
+  - `policy_hitscan_rollout_stage0`
+  - `policy_projectile_mode1_off`
+  - `policy_hitscan_bot_bypass`
+  - `policy_melee_null_attacker`
+  - `policy_projectile_mode2_full`
+  - `policy_projectile_mode1_limited`
+  - `policy_projectile_rollout_stage2_no_signoff`
+  - `policy_projectile_rollout_stage2_signoff`
+  - `policy_projectile_rollout_stage0_off`
+  - `policy_projectile_mode2_admin_gate`
+  - `policy_projectile_mode2_admin_gate_blend`
+  - `policy_projectile_mode0_off`
+  - `policy_projectile_owner_stale`
+  - `policy_projectile_owner_stale_unbounded`
+  - `policy_projectile_optin1_requires_optin`
+  - `policy_projectile_optin1_flag`
+  - `policy_projectile_optin1_allow`
+  - `policy_projectile_optin2_flag_only_off`
+  - `policy_projectile_optin2_allow`
+  - `policy_projectile_deny_overrides_allow`
+  - `policy_projectile_owner_bot_bypass`
+  - `policy_projectile_owner_state_gate`
+  - `policy_projectile_owner_spectator_gate`
+  - `policy_projectile_owner_no_history`
+  - `policy_projectile_blend_mode1_nudged`
+  - `policy_projectile_blend_mode2_full`
+  - `policy_projectile_blend_mode1_zero_nudge`
+  - `policy_projectile_blend_nonpositive_depth`
+- Pass criteria:
+  - Resolver mode remains `antilag_resolve_interpolate`.
+  - Rewound origin matches deterministic expected value within a small epsilon.
+  - Trace-policy scenarios produce exact expected `MOVE_*` flags.
+  - Projectile blend scenarios match expected nudge/full fractions within epsilon.
+- Output:
+  - Success: `sv_antilag_replaytests: all deterministic replay scenarios passed`
+  - Failure: per-scenario mismatch details and final failing count.
+
+## Validation Checklist
+
+- Rewind never reads outside history bounds.
+- Teleport events produce discontinuity boundaries.
+- High jitter/loss does not crash or produce NaN traces.
+- Disabling anti-lag immediately clears active history state.
+- Competitive defaults are applied only when cvars are unset.
+- Command-time outliers increment fallback counters and use latency-derived target time.

--- a/docs/ANTI_LAG_PLAYER_FAIRNESS.md
+++ b/docs/ANTI_LAG_PLAYER_FAIRNESS.md
@@ -1,0 +1,83 @@
+# Anti-Lag Fairness Guide for Players
+
+This page explains what anti-lag does, why paradoxes happen, and what to expect in play.
+
+## What Anti-Lag Does
+
+When you fire, the server estimates where opponents were at your shot time and evaluates the hit against that rewound state.
+
+This helps players with non-zero latency register hits closer to what they saw.
+
+## What Anti-Lag Does Not Do
+
+- It does not make ping irrelevant.
+- It does not make every duel look identical for both players.
+- It does not let clients decide hits. The server remains authoritative.
+
+## Why "Shot Around Corner" Can Happen
+
+Two facts can both be true:
+
+- You reached cover on your screen.
+- The shooter fired earlier on their screen, before your cover transition.
+
+Server anti-lag can legitimately resolve that as a hit from the shooter perspective. This is a normal tradeoff in client/server shooters.
+
+## Fairness Tradeoffs
+
+No anti-lag model satisfies every perspective at the same time. The engine chooses a bounded compromise:
+
+- Better shot validation for moderate latency.
+- Bounded rewind caps to reduce abuse and extreme paradoxes.
+- Optional ping limits and projectile policy tiers.
+
+## Hitscan, Melee, and Projectile Differences
+
+- Hitscan and melee can be compensated directly against historical target positions.
+- Projectiles are harder because they persist through time and involve movement overlap, ownership timing, and dodge perception.
+- For this reason, many servers keep projectile compensation limited or disabled.
+
+## Rollout and Policy You May See
+
+Server operators can run staged rollout:
+
+- Stage 0: instrumentation only (no gameplay anti-lag effect).
+- Stage 1: hitscan/melee anti-lag.
+- Stage 2: limited projectile anti-lag (after playtest signoff).
+- Stage 3: full projectile mode eligibility (admin-gated).
+
+Even when `sv_antilag_projectile_mode` is set to full, server gates may keep effective behavior limited.
+
+## What Improves Your Experience
+
+- Stable ping matters more than absolute minimum ping.
+- Lower jitter and packet loss reduce fallback behavior.
+- Correct rates/network settings reduce interpolation and command-timing mismatch.
+
+## Common Misconceptions
+
+- "Anti-lag is cheating for high ping."
+  - Anti-lag is bounded and server-controlled; it is designed to reduce, not create, unfairness.
+- "If I die behind cover, anti-lag is broken."
+  - That can be an expected paradox under valid rewind rules.
+- "Projectile anti-lag should always be full."
+  - Full projectile rewind has the highest paradox risk and is usually the most restricted mode.
+
+## When to Report an Issue
+
+Report if behavior is frequent, reproducible, and outside expected tradeoffs:
+
+- repeated impossible-looking outcomes in low-latency sessions
+- sustained false misses with clear line of fire
+- visible mismatch bursts correlated with server instability
+
+Useful report details:
+
+- approximate timestamp and map
+- your ping/jitter/loss at the moment
+- demo if available
+- weapon class (hitscan, melee, projectile)
+
+## Summary
+
+Anti-lag improves fairness overall, but cannot eliminate all perspective conflicts. Bounded rewinds plus staged rollout are intentional safeguards, not failures.

--- a/docs/ANTI_LAG_TROUBLESHOOTING.md
+++ b/docs/ANTI_LAG_TROUBLESHOOTING.md
@@ -1,0 +1,59 @@
+# Anti-Lag Troubleshooting Matrix
+
+Use this matrix to triage anti-lag complaints quickly and consistently.
+
+## Quick Triage Workflow
+
+1. Confirm active rollout and effective modes.
+- Run `sv_antilag_rollout_status`.
+
+2. Inspect per-client decision history.
+- Run `sv_antilag_dump <userid/name> 8`.
+
+3. Check whether behavior is policy-expected or anomalous.
+- Compare reason flags and timing deltas against the matrix below.
+
+4. Validate baseline invariants.
+- Run `sv_antilag_replaytests`.
+
+## Troubleshooting Matrix
+
+| Symptom | Typical cause(s) | Verify with | Immediate mitigation | Long-term fix |
+|---|---|---|---|---|
+| "Shot around corner" reports | Expected bounded rewind paradox; high shooter latency; larger unlag window | `sv_antilag_dump` reason flags and rewind ms | Reduce `sv_antilag_maxunlag`; enable/adjust `sv_antilag_ping_limit` | Keep tournament profile for competitive play; communicate player fairness guide |
+| High-jitter player gets inconsistent hit registration | command-time fallback and clamp behavior due jitter/loss | `cmd_fallback`, `clamp_unlag`, `clamp_future` in dump | Raise network quality expectations; cap extreme ping with `sv_antilag_ping_limit` | Improve network path/QoS; keep anti-spoof thresholds tuned |
+| Frequent false misses for attacker | stale/no bracket history, severe packet loss, rapid discontinuities | `history_miss`, fallback(o/n/b), decision timing fields | Verify `sv_antilag_maxunlag` not too low; verify teleport/discontinuity behavior | Stabilize packet quality; keep history/discontinuity invariants |
+| Projectile feels unfair/inconsistent | projectile mode too aggressive for environment; owner context staleness | projectile mode effective value, owner stale rejects | Force limited projectile mode (`mode 1`) or disable (`mode 0`) | Keep full projectile mode admin-only and playtest-gated |
+| Projectile full mode appears not to engage | rollout/admin gates are suppressing mode 2 | `sv_antilag_rollout_status` requested vs effective mode | Set stage/signoff/admin gates explicitly for validation windows | Maintain staged rollout with explicit change control |
+| Anti-lag appears "off" despite `sv_antilag 1/2` | rollout stage 0 instrumentation-only | `rollout_gate` reason flag and rollout status command | Set `sv_antilag_rollout_stage 1` (or higher as needed) | Standardize startup config and verification checklist |
+| Server frame spikes when many players are fighting | broad candidate set and expensive clip checks | dump totals clip/build counters; frame budget alarms | tighten `sv_antilag_frame_budget_ms`; keep `prefilter_*` and `ray_narrow` enabled | keep ray narrowing tuned; avoid full projectile in large public sessions |
+| Team mode shows unnecessary anti-lag candidate work | team filtering not active or unsupported team metadata | dump team prefilter counters | set `sv_antilag_prefilter_team 1` | ensure ruleset/team metadata is consistent |
+| Complaints spike after config deploy | multi-variable change without baseline comparison | compare pre/post dumps and rollout status | rollback stage to 0 or revert last config change | apply one-dimensional config changes with replay test gate |
+
+## Reason Flag Interpretation
+
+- `ping_reject`: command path exceeded ping gate; anti-lag reduced/disabled for that request.
+- `cmd_fallback`: command-derived target was implausible; latency-derived target used.
+- `clamp_unlag`: rewind depth hit hard cap.
+- `clamp_future`: target clamped to present/future boundary protection.
+- `oldest` / `newest` / `bad_interval` / `history_miss`: history bracket quality issues.
+- `rollout_gate`: gameplay rewind prevented by rollout stage policy.
+
+## Suggested Escalation Policy
+
+- Severity 1 (single anecdotal report)
+  - collect `sv_antilag_dump` evidence before changes
+- Severity 2 (repeated reproducible behavior)
+  - temporary mitigation by narrowing cap or forcing projectile limited/off
+- Severity 3 (widespread regressions)
+  - set `sv_antilag_rollout_stage 0` immediately, keep instrumentation on, triage offline
+
+## Operator Checklist for Match Days
+
+- Run `sv_antilag_rollout_status` before first match.
+- Verify expected effective modes.
+- Keep a known-good preset snapshot ready.
+- If anomalies emerge:
+  - capture dumps for involved clients
+  - avoid multiple simultaneous cvar changes
+  - rerun deterministic replay checks before re-enabling escalated modes

--- a/help_commands.json
+++ b/help_commands.json
@@ -1718,6 +1718,20 @@
   "stopsound_script": {
     "system-generated": true
   },
+  "sv_antilag_dump": {
+    "description": "Print cumulative anti-lag counters plus recent anti-lag decisions for one client.",
+    "syntax": "<userid/name> [count]"
+  },
+  "sv_antilag_dumpall": {
+    "description": "Print cumulative anti-lag counters plus recent anti-lag decisions for all active clients with recorded samples.",
+    "syntax": "[count]"
+  },
+  "sv_antilag_replaytests": {
+    "description": "Run deterministic anti-lag replay scenarios on the server and print pass/fail results."
+  },
+  "sv_antilag_rollout_status": {
+    "description": "Print anti-lag rollout stage plus requested/effective gameplay and projectile modes."
+  },
   "sv_democancel": {
     "system-generated": true
   },

--- a/help_variables.json
+++ b/help_variables.json
@@ -1386,6 +1386,12 @@
         }
       ]
     },
+    "cl_debug_antilag_hud": {
+      "default": "0",
+      "desc": "Shows anti-lag timing, rewind deltas and reason flags from debug anti-lag hidden data. Set to 2 for extended counters.",
+      "group-id": "21",
+      "type": "integer"
+    },
     "cl_debug_antilag_lines": {
       "default": "0",
       "desc": "Chooses if lines are drawn between the different player positions on supported .mvd/qtv streams.",
@@ -20509,6 +20515,65 @@
       "group-id": "43",
       "type": "float"
     },
+    "sv_antilag_projectile_full_admin": {
+      "default": "0",
+      "desc": "Admin gate for full projectile anti-lag mode.",
+      "group-id": "43",
+      "remarks": "When 0, requested sv_antilag_projectile_mode 2 is downgraded to limited mode 1 even at rollout stage 3.",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Keep full projectile mode locked.",
+          "name": "false"
+        },
+        {
+          "description": "Allow full projectile mode when rollout stage permits it.",
+          "name": "true"
+        }
+      ]
+    },
+    "sv_antilag_projectile_playtest_signoff": {
+      "default": "0",
+      "desc": "Gate for enabling projectile anti-lag during rollout.",
+      "group-id": "43",
+      "remarks": "When 0, projectile anti-lag is forced off regardless of sv_antilag_projectile_mode.",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Disable projectile rollout enablement.",
+          "name": "false"
+        },
+        {
+          "description": "Allow projectile rollout enablement for stage 2 and higher.",
+          "name": "true"
+        }
+      ]
+    },
+    "sv_antilag_rollout_stage": {
+      "default": "0",
+      "desc": "Controls anti-lag rollout stage and effective gameplay enablement.",
+      "group-id": "43",
+      "remarks": "0 instrumentation-only, 1 hitscan/melee, 2 projectile limited (requires playtest signoff), 3 full projectile eligibility (still requires admin gate).",
+      "type": "integer",
+      "values": [
+        {
+          "description": "Instrumentation only; no lagged trace application.",
+          "name": "0"
+        },
+        {
+          "description": "Enable hitscan and melee anti-lag.",
+          "name": "1"
+        },
+        {
+          "description": "Permit limited projectile anti-lag after signoff.",
+          "name": "2"
+        },
+        {
+          "description": "Permit full projectile mode if admin gate is enabled.",
+          "name": "3"
+        }
+      ]
+    },
     "sv_allowlastscores": {
       "group-id": "43",
       "type": ""
@@ -20546,6 +20611,13 @@
     "sv_default_name": {
       "group-id": "43",
       "type": "string"
+    },
+    "sv_debug_antilag": {
+      "default": "0",
+      "desc": "Controls server-side anti-lag debug verbosity and hidden MVD anti-lag payload emission.",
+      "group-id": "43",
+      "remarks": "0 = disabled. 1 = emit hidden anti-lag packets for debug-capable clients/demos. 2+ = also print timing/fallback diagnostics to console.",
+      "type": "integer"
     },
     "sv_demoClearOld": {
       "group-id": "43",

--- a/src/cl_cam.c
+++ b/src/cl_cam.c
@@ -102,6 +102,7 @@ void Cam_SetViewPlayer (void)
 
 	if (new_track != cl.viewplayernum) {
 		memset(cl.antilag_positions, 0, sizeof(cl.antilag_positions));
+		memset(cl.antilag_stats, 0, sizeof(cl.antilag_stats));
 	}
 	cl.viewplayernum = new_track;
 }

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -271,6 +271,7 @@ cvar_t cl_debug_antilag_view    = { "cl_debug_antilag_view", "0" };
 cvar_t cl_debug_antilag_ghost   = { "cl_debug_antilag_ghost", "0" };
 cvar_t cl_debug_antilag_self    = { "cl_debug_antilag_self", "0" };
 cvar_t cl_debug_antilag_lines   = { "cl_debug_antilag_lines", "0" };
+cvar_t cl_debug_antilag_hud     = { "cl_debug_antilag_hud", "0" };
 cvar_t cl_debug_antilag_send    = { "cl_debug_antilag_send", "0" };
 
 // weapon-switching debugging
@@ -1972,6 +1973,7 @@ static void CL_InitLocal(void)
 	Cvar_Register(&cl_debug_antilag_ghost);
 	Cvar_Register(&cl_debug_antilag_self);
 	Cvar_Register(&cl_debug_antilag_lines);
+	Cvar_Register(&cl_debug_antilag_hud);
 	Cvar_Register(&cl_debug_antilag_send);
 
 	// debugging weapons

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -4196,15 +4196,38 @@ void CL_ParseHiddenDataMessage(void)
 	while (true) {
 		int size = LittleLong(MSG_ReadLong());
 		int protocol_version = 0, type;
+		int remaining;
 
 		if (size == -1) {
 			break;
 		}
+		if (size < 0) {
+			Con_DPrintf("CL_ParseHiddenDataMessage: invalid hidden block size %d\n", size);
+			break;
+		}
+
+		remaining = net_message.cursize - msg_readcount;
+		if (remaining < (int)sizeof(short)) {
+			Con_DPrintf("CL_ParseHiddenDataMessage: truncated hidden block header remaining=%d\n", remaining);
+			break;
+		}
 
 		type = LittleLong(MSG_ReadShort());
-		while (type == 0xFFFF && size > 0) {
+		while (type == 0xFFFF) {
+			remaining = net_message.cursize - msg_readcount;
+			if (remaining < (int)sizeof(short)) {
+				Con_DPrintf("CL_ParseHiddenDataMessage: truncated extended hidden header\n");
+				return;
+			}
 			type = LittleLong(MSG_ReadShort());
 			++protocol_version;
+		}
+
+		remaining = net_message.cursize - msg_readcount;
+		if (size > remaining) {
+			Con_DPrintf("CL_ParseHiddenDataMessage: truncated hidden block size=%d remaining=%d\n", size, remaining);
+			MSG_ReadSkip(max(0, remaining));
+			break;
 		}
 
 		if (protocol_version != 0) {
@@ -4286,7 +4309,19 @@ static void CL_ParseDemoInfo(int size)
 static void CL_ParseAntilagPosition(int size)
 {
 	mvdhidden_antilag_position_header_t header;
+	antilag_stats_t *stats = NULL;
 	int old_readcount = msg_readcount;
+	int payload_bytes;
+	int player_bytes;
+	int extra_bytes;
+	qbool has_extra = false;
+	int source_player;
+
+	if (size < sizeof_mvdhidden_antilag_position_header_t) {
+		Con_DPrintf("CL_ParseAntilagPosition: short block size=%d\n", size);
+		MSG_ReadSkip(max(0, size));
+		return;
+	}
 
 	header.playernum = MSG_ReadByte();
 	header.players = MSG_ReadByte();
@@ -4294,21 +4329,95 @@ static void CL_ParseAntilagPosition(int size)
 	header.server_time = LittleFloat(MSG_ReadFloat());
 	header.target_time = LittleFloat(MSG_ReadFloat());
 
-	size -= (msg_readcount - old_readcount);
-	if (size != header.players * sizeof_mvdhidden_antilag_position_t) {
-		Con_DPrintf("unexpected size: %d vs %d (%d players)\n", size, header.players * sizeof_mvdhidden_antilag_position_t, header.players);
-		MSG_ReadSkip(size);
+	payload_bytes = size - (msg_readcount - old_readcount);
+	player_bytes = header.players * sizeof_mvdhidden_antilag_position_t;
+	if (payload_bytes < player_bytes) {
+		Con_DPrintf("unexpected size: %d < %d (%d players)\n", payload_bytes, player_bytes, header.players);
+		MSG_ReadSkip(max(0, payload_bytes));
 	}
 	else if (header.playernum != cl.viewplayernum) {
-		MSG_ReadSkip(size);
+		MSG_ReadSkip(payload_bytes);
 	}
 	else {
 		mvdhidden_antilag_position_t position;
+		float command_target_time = 0;
+		float latency_target_time = 0;
+		float one_way_latency = 0;
+		float interp_delay = 0;
+		float command_window = 0;
+		float build_seconds = 0;
+		unsigned int reason_flags = 0;
+		unsigned short ping_ms = 0;
+		unsigned short scanned = 0;
+		unsigned short kept = 0;
+		unsigned short prefiltered = 0;
+		unsigned short pvs_rejects = 0;
+		unsigned short team_rejects = 0;
+		unsigned short oldest_fallbacks = 0;
+		unsigned short newest_fallbacks = 0;
+		unsigned short bad_interval_fallbacks = 0;
+		unsigned short history_misses = 0;
+		byte net_drop = 0;
 		int i;
 
+		extra_bytes = payload_bytes - player_bytes;
+		if (extra_bytes >= sizeof_mvdhidden_antilag_position_extra_t) {
+			has_extra = true;
+			reason_flags = LittleLong(MSG_ReadLong());
+			command_target_time = LittleFloat(MSG_ReadFloat());
+			latency_target_time = LittleFloat(MSG_ReadFloat());
+			one_way_latency = LittleFloat(MSG_ReadFloat());
+			interp_delay = LittleFloat(MSG_ReadFloat());
+			command_window = LittleFloat(MSG_ReadFloat());
+			build_seconds = LittleFloat(MSG_ReadFloat());
+			ping_ms = LittleShort(MSG_ReadShort());
+			scanned = LittleShort(MSG_ReadShort());
+			kept = LittleShort(MSG_ReadShort());
+			prefiltered = LittleShort(MSG_ReadShort());
+			pvs_rejects = LittleShort(MSG_ReadShort());
+			team_rejects = LittleShort(MSG_ReadShort());
+			oldest_fallbacks = LittleShort(MSG_ReadShort());
+			newest_fallbacks = LittleShort(MSG_ReadShort());
+			bad_interval_fallbacks = LittleShort(MSG_ReadShort());
+			history_misses = LittleShort(MSG_ReadShort());
+			net_drop = MSG_ReadByte();
+			MSG_ReadSkip(3);
+			extra_bytes -= sizeof_mvdhidden_antilag_position_extra_t;
+		}
+		if (extra_bytes > 0) {
+			MSG_ReadSkip(extra_bytes);
+		}
+
 		memset(&cl.antilag_positions, 0, sizeof(cl.antilag_positions));
+		source_player = bound(0, header.playernum, MAX_CLIENTS - 1);
+		stats = &cl.antilag_stats[source_player];
+		memset(stats, 0, sizeof(*stats));
+		stats->server_time = header.server_time;
+		stats->target_time = header.target_time;
+		if (has_extra) {
+			stats->reason_flags = reason_flags;
+			stats->command_target_time = command_target_time;
+			stats->latency_target_time = latency_target_time;
+			stats->one_way_latency = one_way_latency;
+			stats->interp_delay = interp_delay;
+			stats->command_window = command_window;
+			stats->build_seconds = build_seconds;
+			stats->ping_ms = ping_ms;
+			stats->scanned = scanned;
+			stats->kept = kept;
+			stats->prefiltered = prefiltered;
+			stats->pvs_rejects = pvs_rejects;
+			stats->team_rejects = team_rejects;
+			stats->oldest_fallbacks = oldest_fallbacks;
+			stats->newest_fallbacks = newest_fallbacks;
+			stats->bad_interval_fallbacks = bad_interval_fallbacks;
+			stats->history_misses = history_misses;
+			stats->net_drop = net_drop;
+		}
+
 		for (i = 0; i < header.players; ++i) {
 			qbool clientpos_valid = false;
+			vec3_t delta;
 
 			position.playernum = MSG_ReadByte();
 			clientpos_valid = position.playernum & MVD_PEXT1_ANTILAG_CLIENTPOS;
@@ -4328,6 +4437,11 @@ static void CL_ParseAntilagPosition(int size)
 				cl.antilag_positions[position.playernum].present = true;
 				VectorCopy(position.clientpos, cl.antilag_positions[position.playernum].clientpos);
 				cl.antilag_positions[position.playernum].clientpresent = clientpos_valid;
+				if (clientpos_valid && stats) {
+					VectorSubtract(position.pos, position.clientpos, delta);
+					stats->client_rewind_distance += VectorLength(delta);
+					stats->client_rewind_samples += 1.0;
+				}
 			}
 		}
 	}

--- a/src/client.h
+++ b/src/client.h
@@ -541,6 +541,26 @@ typedef struct antilag_pos_s {
 typedef struct antilag_stats_s {
 	double      client_rewind_distance;
 	double      client_rewind_samples;
+	double      server_time;
+	double      target_time;
+	double      command_target_time;
+	double      latency_target_time;
+	double      one_way_latency;
+	double      interp_delay;
+	double      command_window;
+	double      build_seconds;
+	unsigned int reason_flags;
+	unsigned int ping_ms;
+	unsigned int scanned;
+	unsigned int kept;
+	unsigned int prefiltered;
+	unsigned int pvs_rejects;
+	unsigned int team_rejects;
+	unsigned int oldest_fallbacks;
+	unsigned int newest_fallbacks;
+	unsigned int bad_interval_fallbacks;
+	unsigned int history_misses;
+	unsigned int net_drop;
 } antilag_stats_t;
 
 // cl.paused flags

--- a/src/hud_autoid.c
+++ b/src/hud_autoid.c
@@ -350,51 +350,142 @@ void SCR_DrawAntilagIndicators(void)
 	int i;
 	extern cvar_t cl_debug_antilag_lines;
 	extern cvar_t cl_debug_antilag_view;
+	extern cvar_t cl_debug_antilag_hud;
+	antilag_stats_t *stats;
+	char reasons[256];
+	char line[256];
+	unsigned int known_flags;
+	unsigned int unknown_flags;
+	int x = 8;
+	int y = 40;
+	double rewind_ms;
+	double command_delta_ms;
+	double latency_delta_ms;
+	double avg_rewind_delta;
 
-	if (!cl_debug_antilag_lines.integer || (!cls.demoplayback && !cl.spectator) || cl.intermission) {
+	if (cl.intermission) {
 		return;
 	}
 
-	for (i = 0; i < autoid_count; ++i) {
-		color_t r_color = RGBA_TO_COLOR(255, 0, 0, 255);
-		color_t c_color = RGBA_TO_COLOR(0, 255, 0, 255);
-		color_t rc_color = RGBA_TO_COLOR(0, 0, 255, 255);
-		float r_x1 = autoids[i].rewind_x1 * vid.width / glwidth;
-		float r_y1 = (glheight - autoids[i].rewind_y1) * vid.height / glheight;
-		float r_x2 = autoids[i].rewind_x2 * vid.width / glwidth;
-		float r_y2 = (glheight - autoids[i].rewind_y2) * vid.height / glheight;
-		float c_x1 = autoids[i].client_x1 * vid.width / glwidth;
-		float c_y1 = (glheight - autoids[i].client_y1) * vid.height / glheight;
-		float c_x2 = autoids[i].client_x2 * vid.width / glwidth;
-		float c_y2 = (glheight - autoids[i].client_y2) * vid.height / glheight;
+	if (cl_debug_antilag_lines.integer && (cls.demoplayback || cl.spectator)) {
+		for (i = 0; i < autoid_count; ++i) {
+			color_t r_color = RGBA_TO_COLOR(255, 0, 0, 255);
+			color_t c_color = RGBA_TO_COLOR(0, 255, 0, 255);
+			color_t rc_color = RGBA_TO_COLOR(0, 0, 255, 255);
+			float r_x1 = autoids[i].rewind_x1 * vid.width / glwidth;
+			float r_y1 = (glheight - autoids[i].rewind_y1) * vid.height / glheight;
+			float r_x2 = autoids[i].rewind_x2 * vid.width / glwidth;
+			float r_y2 = (glheight - autoids[i].rewind_y2) * vid.height / glheight;
+			float c_x1 = autoids[i].client_x1 * vid.width / glwidth;
+			float c_y1 = (glheight - autoids[i].client_y1) * vid.height / glheight;
+			float c_x2 = autoids[i].client_x2 * vid.width / glwidth;
+			float c_y2 = (glheight - autoids[i].client_y2) * vid.height / glheight;
 
-		if (cl_debug_antilag_view.integer == 0) {
-			// player shown in current server position, draw from rewound & client
-			if (autoids[i].rewind_valid) {
-				Draw_AlphaLineRGB(r_x1, r_y1, r_x2, r_y2, 2, r_color);
+			if (cl_debug_antilag_view.integer == 0) {
+				// player shown in current server position, draw from rewound & client
+				if (autoids[i].rewind_valid) {
+					Draw_AlphaLineRGB(r_x1, r_y1, r_x2, r_y2, 2, r_color);
+				}
+				if (autoids[i].client_valid) {
+					Draw_AlphaLineRGB(c_x1, c_y1, c_x2, c_y2, 2, c_color);
+				}
 			}
-			if (autoids[i].client_valid) {
-				Draw_AlphaLineRGB(c_x1, c_y1, c_x2, c_y2, 2, c_color);
+			else if (cl_debug_antilag_view.integer == 1) {
+				// player shown in rewound position, draw from current & client
+				if (autoids[i].rewind_valid) {
+					Draw_AlphaLineRGB(r_x1, r_y1, r_x2, r_y2, 2, r_color);
+				}
+				if (autoids[i].rewind_valid && autoids[i].client_valid) {
+					Draw_AlphaLineRGB(c_x1, c_y1, r_x1, r_y1, 2, rc_color);
+				}
+			}
+			else if (cl_debug_antilag_view.integer == 2) {
+				// player shown in client position, draw to current & rewound
+				if (autoids[i].rewind_valid && autoids[i].client_valid) {
+					Draw_AlphaLineRGB(r_x1, r_y1, c_x1, c_y1, 2, rc_color);
+				}
+				if (autoids[i].client_valid) {
+					Draw_AlphaLineRGB(c_x1, c_y1, c_x2, c_y2, 2, c_color);
+				}
 			}
 		}
-		else if (cl_debug_antilag_view.integer == 1) {
-			// player shown in rewound position, draw from current & client
-			if (autoids[i].rewind_valid) {
-				Draw_AlphaLineRGB(r_x1, r_y1, r_x2, r_y2, 2, r_color);
-			}
-			if (autoids[i].rewind_valid && autoids[i].client_valid) {
-				Draw_AlphaLineRGB(c_x1, c_y1, r_x1, r_y1, 2, rc_color);
-			}
-		}
-		else if (cl_debug_antilag_view.integer == 2) {
-			// player shown in client position, draw to current & rewound
-			if (autoids[i].rewind_valid && autoids[i].client_valid) {
-				Draw_AlphaLineRGB(r_x1, r_y1, c_x1, c_y1, 2, rc_color);
-			}
-			if (autoids[i].client_valid) {
-				Draw_AlphaLineRGB(c_x1, c_y1, c_x2, c_y2, 2, c_color);
-			}
-		}
+	}
+
+	if (!cl_debug_antilag_hud.integer || cl.viewplayernum < 0 || cl.viewplayernum >= MAX_CLIENTS) {
+		return;
+	}
+
+	stats = &cl.antilag_stats[cl.viewplayernum];
+	if (stats->server_time <= 0 && stats->target_time <= 0 && !stats->reason_flags && stats->client_rewind_samples <= 0) {
+		return;
+	}
+
+	reasons[0] = '\0';
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_DISABLED) strlcat(reasons, "disabled|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_ENABLED) strlcat(reasons, "enabled|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_PING_REJECT) strlcat(reasons, "ping_reject|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_CMD_FALLBACK) strlcat(reasons, "cmd_fallback|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_CLAMP_MAXUNLAG) strlcat(reasons, "clamp_unlag|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_CLAMP_FUTURE) strlcat(reasons, "clamp_future|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_PREFILTER_PVS) strlcat(reasons, "prefilter_pvs|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_PREFILTER_TEAM) strlcat(reasons, "prefilter_team|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_HIST_OLDEST) strlcat(reasons, "oldest|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_HIST_NEWEST) strlcat(reasons, "newest|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_HIST_BAD_INTERVAL) strlcat(reasons, "bad_interval|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_HIST_MISS) strlcat(reasons, "history_miss|", sizeof(reasons));
+	if (stats->reason_flags & MVD_PEXT1_ANTILAG_REASON_ROLLOUT_GATE) strlcat(reasons, "rollout_gate|", sizeof(reasons));
+	known_flags =
+		MVD_PEXT1_ANTILAG_REASON_DISABLED
+		| MVD_PEXT1_ANTILAG_REASON_ENABLED
+		| MVD_PEXT1_ANTILAG_REASON_PING_REJECT
+		| MVD_PEXT1_ANTILAG_REASON_CMD_FALLBACK
+		| MVD_PEXT1_ANTILAG_REASON_CLAMP_MAXUNLAG
+		| MVD_PEXT1_ANTILAG_REASON_CLAMP_FUTURE
+		| MVD_PEXT1_ANTILAG_REASON_PREFILTER_PVS
+		| MVD_PEXT1_ANTILAG_REASON_PREFILTER_TEAM
+		| MVD_PEXT1_ANTILAG_REASON_HIST_OLDEST
+		| MVD_PEXT1_ANTILAG_REASON_HIST_NEWEST
+		| MVD_PEXT1_ANTILAG_REASON_HIST_BAD_INTERVAL
+		| MVD_PEXT1_ANTILAG_REASON_HIST_MISS
+		| MVD_PEXT1_ANTILAG_REASON_ROLLOUT_GATE;
+	unknown_flags = stats->reason_flags & ~known_flags;
+	if (unknown_flags) {
+		char token[32];
+
+		snprintf(token, sizeof(token), "unknown:0x%08x|", unknown_flags);
+		strlcat(reasons, token, sizeof(reasons));
+	}
+	if (!reasons[0]) {
+		strlcpy(reasons, "none", sizeof(reasons));
+	}
+	else if (reasons[strlen(reasons) - 1] == '|') {
+		reasons[strlen(reasons) - 1] = '\0';
+	}
+
+	rewind_ms = max(0.0, (stats->server_time - stats->target_time) * 1000.0);
+	command_delta_ms = (stats->command_target_time - stats->target_time) * 1000.0;
+	latency_delta_ms = (stats->latency_target_time - stats->target_time) * 1000.0;
+	avg_rewind_delta = (stats->client_rewind_samples > 0 ? (stats->client_rewind_distance / stats->client_rewind_samples) : 0.0);
+	snprintf(line, sizeof(line), "AL rewind=%0.1fms avg=%0.1fu ping=%ums drop=%u", rewind_ms, avg_rewind_delta, stats->ping_ms, stats->net_drop);
+	Draw_String(x, y, line);
+	y += 8;
+	snprintf(line, sizeof(line), "AL cmd=%+0.1fms lat=%+0.1fms interp=%0.1fms one-way=%0.1fms win=%0.1fms",
+		command_delta_ms, latency_delta_ms, stats->interp_delay * 1000.0, stats->one_way_latency * 1000.0, stats->command_window * 1000.0);
+	Draw_String(x, y, line);
+	y += 8;
+	snprintf(line, sizeof(line), "AL reason=%s", reasons);
+	Draw_String(x, y, line);
+	y += 8;
+
+	if (cl_debug_antilag_hud.integer >= 2) {
+		snprintf(line, sizeof(line), "AL scanned=%u kept=%u pre=%u pvs=%u team=%u", stats->scanned, stats->kept, stats->prefiltered, stats->pvs_rejects, stats->team_rejects);
+		Draw_String(x, y, line);
+		y += 8;
+		snprintf(line, sizeof(line), "AL fallback o/n/b=%u/%u/%u miss=%u build=%0.3fms", stats->oldest_fallbacks, stats->newest_fallbacks, stats->bad_interval_fallbacks, stats->history_misses, stats->build_seconds * 1000.0);
+		Draw_String(x, y, line);
+		y += 8;
+		snprintf(line, sizeof(line), "AL server=%0.3f target=%0.3f", stats->server_time, stats->target_time);
+		Draw_String(x, y, line);
 	}
 }
 

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -498,14 +498,7 @@ void PF2_traceline(float v1_x, float v1_y, float v1_z,
 	v2[1] = v2_y;
 	v2[2] = v2_z;
 
-	if (sv_antilag.value == 2)
-	{
-		if (!(entnum >= 1 && entnum <= MAX_CLIENTS && svs.clients[entnum - 1].isBot)) {
-			nomonsters |= MOVE_LAGGED;
-		}
-	}
-
-	trace = SV_Trace(v1, vec3_origin, vec3_origin, v2, nomonsters, ent);
+	trace = SV_AntilagTrace(v1, vec3_origin, vec3_origin, v2, nomonsters, ent, antilag_trace_hitscan);
 
 	pr_global_struct->trace_allsolid = trace.allsolid;
 	pr_global_struct->trace_startsolid = trace.startsolid;
@@ -556,7 +549,7 @@ void PF2_TraceCapsule(float v1_x, float v1_y, float v1_z,
 	v4[1] = max_y;
 	v4[2] = max_z;
 
-	trace = SV_Trace(v1, v3, v4, v2, nomonsters, ent);
+	trace = SV_AntilagTrace(v1, v3, v4, v2, nomonsters, ent, antilag_trace_melee);
 
 	pr_global_struct->trace_allsolid = trace.allsolid;
 	pr_global_struct->trace_startsolid = trace.startsolid;

--- a/src/pr_cmds.c
+++ b/src/pr_cmds.c
@@ -660,10 +660,7 @@ void PF_traceline (void)
 	nomonsters = G_FLOAT(OFS_PARM2);
 	ent = G_EDICT(OFS_PARM3);
 
-	if (sv_antilag.value == 2)
-		nomonsters |= MOVE_LAGGED;
-
-	trace = SV_Trace (v1, vec3_origin, vec3_origin, v2, nomonsters, ent);
+	trace = SV_AntilagTrace(v1, vec3_origin, vec3_origin, v2, nomonsters, ent, antilag_trace_hitscan);
 
 	PR_GLOBAL(trace_allsolid) = trace.allsolid;
 	PR_GLOBAL(trace_startsolid) = trace.startsolid;
@@ -2532,7 +2529,7 @@ static void PF_tracebox (void)
         nomonsters = G_FLOAT(OFS_PARM4);
         ent = G_EDICT(OFS_PARM5);
 
-        trace = SV_Trace (v1, mins, maxs, v2, nomonsters, ent);
+        trace = SV_AntilagTrace(v1, mins, maxs, v2, nomonsters, ent, antilag_trace_melee);
 
         PR_GLOBAL(trace_allsolid) = trace.allsolid;
         PR_GLOBAL(trace_startsolid) = trace.startsolid;

--- a/src/server.h
+++ b/src/server.h
@@ -169,9 +169,26 @@ typedef struct
 {
 	double			localtime;
 	vec3_t			origin;
+	vec3_t			mins;
+	vec3_t			maxs;
+	byte			flags;
 } antilag_position_t;
 
+#define ANTILAG_POSITION_DISCONTINUITY  (1 << 0)
+#define ANTILAG_POSITION_ALIVE          (1 << 1)
+
+typedef enum {
+	antilag_resolve_none = 0,
+	antilag_resolve_single,
+	antilag_resolve_oldest,
+	antilag_resolve_newest,
+	antilag_resolve_discontinuity,
+	antilag_resolve_interpolate,
+	antilag_resolve_bad_interval
+} antilag_resolve_mode_t;
+
 #define MAX_ANTILAG_POSITIONS      128
+#define MAX_ANTILAG_DECISIONS      32
 #define MAX_BACK_BUFFERS           128
 #define MAX_STUFFTEXT              256
 #define	CLIENT_LOGIN_LEN            16
@@ -183,6 +200,30 @@ typedef struct
 #ifdef MVD_PEXT1_SERVERSIDEWEAPON
 #define MAX_WEAPONSWITCH_OPTIONS    10
 #endif
+
+typedef struct
+{
+	double			server_time;
+	double			target_time;
+	double			command_target_time;
+	double			latency_target_time;
+	double			one_way_latency;
+	double			interp_delay;
+	double			command_window;
+	double			build_seconds;
+	unsigned int	reason_flags;
+	unsigned short	ping_ms;
+	unsigned short	scanned;
+	unsigned short	kept;
+	unsigned short	prefiltered;
+	unsigned short	pvs_rejects;
+	unsigned short	team_rejects;
+	unsigned short	oldest_fallbacks;
+	unsigned short	newest_fallbacks;
+	unsigned short	bad_interval_fallbacks;
+	unsigned short	history_misses;
+	byte			net_drop;
+} antilag_decision_t;
 
 typedef struct client_s
 {
@@ -205,7 +246,9 @@ typedef struct client_s
 	ctxinfo_t		_userinfoshort_ctx_;	// infostring
 
 	antilag_position_t	antilag_positions[MAX_ANTILAG_POSITIONS];
-	int				antilag_position_next;
+	int				antilag_position_next;   // ring insert index
+	int				antilag_position_count;  // number of valid positions in ring
+	qbool			antilag_pending_discontinuity;
 
 	usercmd_t		lastcmd;			// for filling in big drops and partial predictions
 	double			localtime;			// of last message
@@ -248,6 +291,26 @@ typedef struct client_s
 	unsigned int	laggedents_count;
 	float			laggedents_frac;
 	float           laggedents_time;
+	unsigned int	antilag_requests;
+	unsigned int	antilag_ping_rejects;
+	unsigned int	antilag_cmd_fallbacks;
+	unsigned int	antilag_maxunlag_clamps;
+	unsigned int	antilag_history_misses;
+	unsigned int	antilag_history_oldest_fallbacks;
+	unsigned int	antilag_history_newest_fallbacks;
+	unsigned int	antilag_interp_bad_denom;
+	unsigned int	antilag_candidates_scanned;
+	unsigned int	antilag_candidates_prefiltered;
+	unsigned int	antilag_candidates_pvs_rejects;
+	unsigned int	antilag_candidates_team_rejects;
+	unsigned int	antilag_clip_candidates;
+	unsigned int	antilag_clip_broadphase_rejects;
+	unsigned int	antilag_clip_ray_rejects;
+	unsigned int	antilag_clip_traces;
+	antilag_decision_t antilag_last_decision;
+	antilag_decision_t antilag_recent[MAX_ANTILAG_DECISIONS];
+	unsigned int	antilag_recent_head;
+	unsigned int	antilag_recent_count;
 // }
 
 	// spawn parms are carried from level to level
@@ -711,6 +774,13 @@ extern	cvar_t	sv_paused; // 1 - normal, 2 - auto (single player), 3 - both
 extern	cvar_t	sv_maxspeed;
 extern	cvar_t	sv_mintic, sv_maxtic, sv_maxfps;
 extern	cvar_t	sv_antilag, sv_antilag_no_pred, sv_antilag_projectiles;
+extern	cvar_t	sv_antilag_rollout_stage, sv_antilag_projectile_playtest_signoff, sv_antilag_projectile_full_admin;
+extern	cvar_t	sv_antilag_projectile_mode, sv_antilag_projectile_nudge, sv_antilag_projectile_owner_stale;
+extern	cvar_t	sv_antilag_projectile_optin, sv_antilag_projectile_allow, sv_antilag_projectile_deny;
+extern	cvar_t	sv_antilag_maxunlag, sv_antilag_max_cmd_delta, sv_antilag_ping_limit, sv_antilag_teleport_dist;
+extern	cvar_t	sv_antilag_prefilter_pvs, sv_antilag_prefilter_team;
+extern	cvar_t	sv_antilag_ray_narrow, sv_antilag_ray_narrow_pad;
+extern	cvar_t	sv_antilag_frame_budget_ms;
 
 extern	int current_skill;
 
@@ -896,6 +966,17 @@ void SV_UserInit (void);
 void SV_TogglePause (const char *msg, int bit);
 void ProcessUserInfoChange (client_t* sv_client, const char* key, const char* old_value);
 void SV_RotateCmd(client_t* cl, usercmd_t* cmd);
+void SV_AntilagRecord(client_t *cl, qbool discontinuity);
+qbool SV_AntilagFindHistory(client_t *cl, double target_time, const antilag_position_t **base, const antilag_position_t **interpolate);
+qbool SV_AntilagResolvePosition(client_t *cl, double target_time, vec3_t out_origin, antilag_resolve_mode_t *mode);
+void SV_AntilagApplyStartupDefaults(void);
+int SV_AntilagRolloutStageResolved(void);
+int SV_AntilagGameplayModeResolved(void);
+int SV_AntilagProjectileModeResolved(void);
+void SV_AntilagPerfFrameBegin(void);
+void SV_AntilagPerfFrameEnd(void);
+void SV_AntilagPerfAddBuild(double elapsed_seconds, unsigned int scanned, unsigned int kept, unsigned int prefiltered, unsigned int pvs_rejects, unsigned int team_rejects);
+void SV_AntilagPerfAddClip(double elapsed_seconds, unsigned int candidates, unsigned int broadphase_rejects, unsigned int ray_rejects, unsigned int trace_tests);
 
 #ifdef FTE_PEXT2_VOICECHAT
 void SV_VoiceInitClient(client_t *client);

--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -1807,6 +1807,263 @@ void SV_MasterPassword_f (void)
 }
 // <-- QW262
 
+static void SV_AntilagReplayTests_f(void)
+{
+	int failures = SV_AntilagRunReplayTests();
+
+	if (failures > 0) {
+		Con_Printf("sv_antilag_replaytests: %d scenario(s) failed\n", failures);
+	}
+}
+
+static void SV_AntilagAppendReason(char *buffer, size_t size, const char *token)
+{
+	if (!buffer || !size || !token || !token[0]) {
+		return;
+	}
+
+	if (buffer[0]) {
+		strlcat(buffer, "|", size);
+	}
+	strlcat(buffer, token, size);
+}
+
+static void SV_AntilagReasonFlagsToString(unsigned int flags, char *buffer, size_t size)
+{
+	unsigned int known_flags;
+	unsigned int unknown_flags;
+
+	if (!buffer || !size) {
+		return;
+	}
+
+	buffer[0] = '\0';
+	if (flags & MVD_PEXT1_ANTILAG_REASON_DISABLED) SV_AntilagAppendReason(buffer, size, "disabled");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_ENABLED) SV_AntilagAppendReason(buffer, size, "enabled");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_PING_REJECT) SV_AntilagAppendReason(buffer, size, "ping_reject");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_CMD_FALLBACK) SV_AntilagAppendReason(buffer, size, "cmd_fallback");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_CLAMP_MAXUNLAG) SV_AntilagAppendReason(buffer, size, "clamp_unlag");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_CLAMP_FUTURE) SV_AntilagAppendReason(buffer, size, "clamp_future");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_PREFILTER_PVS) SV_AntilagAppendReason(buffer, size, "prefilter_pvs");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_PREFILTER_TEAM) SV_AntilagAppendReason(buffer, size, "prefilter_team");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_HIST_OLDEST) SV_AntilagAppendReason(buffer, size, "oldest");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_HIST_NEWEST) SV_AntilagAppendReason(buffer, size, "newest");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_HIST_BAD_INTERVAL) SV_AntilagAppendReason(buffer, size, "bad_interval");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_HIST_MISS) SV_AntilagAppendReason(buffer, size, "history_miss");
+	if (flags & MVD_PEXT1_ANTILAG_REASON_ROLLOUT_GATE) SV_AntilagAppendReason(buffer, size, "rollout_gate");
+	known_flags =
+		MVD_PEXT1_ANTILAG_REASON_DISABLED
+		| MVD_PEXT1_ANTILAG_REASON_ENABLED
+		| MVD_PEXT1_ANTILAG_REASON_PING_REJECT
+		| MVD_PEXT1_ANTILAG_REASON_CMD_FALLBACK
+		| MVD_PEXT1_ANTILAG_REASON_CLAMP_MAXUNLAG
+		| MVD_PEXT1_ANTILAG_REASON_CLAMP_FUTURE
+		| MVD_PEXT1_ANTILAG_REASON_PREFILTER_PVS
+		| MVD_PEXT1_ANTILAG_REASON_PREFILTER_TEAM
+		| MVD_PEXT1_ANTILAG_REASON_HIST_OLDEST
+		| MVD_PEXT1_ANTILAG_REASON_HIST_NEWEST
+		| MVD_PEXT1_ANTILAG_REASON_HIST_BAD_INTERVAL
+		| MVD_PEXT1_ANTILAG_REASON_HIST_MISS
+		| MVD_PEXT1_ANTILAG_REASON_ROLLOUT_GATE;
+	unknown_flags = flags & ~known_flags;
+	if (unknown_flags) {
+		char token[32];
+
+		snprintf(token, sizeof(token), "unknown:0x%08x", unknown_flags);
+		SV_AntilagAppendReason(buffer, size, token);
+	}
+
+	if (!buffer[0]) {
+		strlcpy(buffer, "none", size);
+	}
+}
+
+static void SV_AntilagDumpClientDecision(client_t *cl, int ordinal, const antilag_decision_t *decision)
+{
+	char reasons[256];
+	double rewind_ms;
+	double cmd_ms;
+	double lat_ms;
+	double build_ms;
+
+	if (!cl || !decision) {
+		return;
+	}
+
+	SV_AntilagReasonFlagsToString(decision->reason_flags, reasons, sizeof(reasons));
+	rewind_ms = max(0.0, (decision->server_time - decision->target_time) * 1000.0);
+	cmd_ms = (decision->command_target_time - decision->target_time) * 1000.0;
+	lat_ms = (decision->latency_target_time - decision->target_time) * 1000.0;
+	build_ms = decision->build_seconds * 1000.0;
+
+	Con_Printf(
+		"  #%d t=%0.3f target=%0.3f rewind=%0.1fms ping=%ums drop=%u reason=%s\n"
+		"     cmd_delta=%+0.1fms lat_delta=%+0.1fms interp=%0.1fms oneway=%0.1fms window=%0.1fms build=%0.3fms\n"
+		"     scanned=%u kept=%u pre=%u pvs=%u team=%u fallback(o/n/b)=%u/%u/%u miss=%u\n",
+		ordinal,
+		decision->server_time,
+		decision->target_time,
+		rewind_ms,
+		(unsigned int)decision->ping_ms,
+		(unsigned int)decision->net_drop,
+		reasons,
+		cmd_ms,
+		lat_ms,
+		decision->interp_delay * 1000.0,
+		decision->one_way_latency * 1000.0,
+		decision->command_window * 1000.0,
+		build_ms,
+		(unsigned int)decision->scanned,
+		(unsigned int)decision->kept,
+		(unsigned int)decision->prefiltered,
+		(unsigned int)decision->pvs_rejects,
+		(unsigned int)decision->team_rejects,
+		(unsigned int)decision->oldest_fallbacks,
+		(unsigned int)decision->newest_fallbacks,
+		(unsigned int)decision->bad_interval_fallbacks,
+		(unsigned int)decision->history_misses);
+}
+
+static void SV_AntilagDumpClientTotals(client_t *cl)
+{
+	unsigned int build_kept;
+
+	if (!cl) {
+		return;
+	}
+
+	build_kept = (cl->antilag_candidates_scanned > cl->antilag_candidates_prefiltered
+		? (cl->antilag_candidates_scanned - cl->antilag_candidates_prefiltered)
+		: 0);
+
+	Con_Printf(
+		"  totals: req=%u ping_reject=%u cmd_fallback=%u clamp=%u hist_miss=%u hist(o/n/b)=%u/%u/%u\n"
+		"          build scanned=%u kept=%u pre=%u pvs=%u team=%u\n"
+		"          clip candidates=%u broadphase=%u ray=%u traces=%u\n",
+		cl->antilag_requests,
+		cl->antilag_ping_rejects,
+		cl->antilag_cmd_fallbacks,
+		cl->antilag_maxunlag_clamps,
+		cl->antilag_history_misses,
+		cl->antilag_history_oldest_fallbacks,
+		cl->antilag_history_newest_fallbacks,
+		cl->antilag_interp_bad_denom,
+		cl->antilag_candidates_scanned,
+		build_kept,
+		cl->antilag_candidates_prefiltered,
+		cl->antilag_candidates_pvs_rejects,
+		cl->antilag_candidates_team_rejects,
+		cl->antilag_clip_candidates,
+		cl->antilag_clip_broadphase_rejects,
+		cl->antilag_clip_ray_rejects,
+		cl->antilag_clip_traces);
+}
+
+static void SV_AntilagDumpClientHistory(client_t *cl, int wanted)
+{
+	int count;
+	int i;
+
+	if (!cl) {
+		return;
+	}
+
+	if (cl->antilag_recent_count == 0) {
+		Con_Printf("%s(%d): no anti-lag decisions recorded\n", cl->name, cl->userid);
+		return;
+	}
+
+	count = bound(1, wanted, MAX_ANTILAG_DECISIONS);
+	count = min(count, (int)cl->antilag_recent_count);
+
+	Con_Printf("%s(%d): showing %d of %u anti-lag decisions\n", cl->name, cl->userid, count, cl->antilag_recent_count);
+	SV_AntilagDumpClientTotals(cl);
+	for (i = 0; i < count; ++i) {
+		int index = (cl->antilag_recent_head + MAX_ANTILAG_DECISIONS - 1 - i) % MAX_ANTILAG_DECISIONS;
+		SV_AntilagDumpClientDecision(cl, i + 1, &cl->antilag_recent[index]);
+	}
+}
+
+static void SV_AntilagDump_f(void)
+{
+	client_t *cl;
+	int uid;
+	int wanted = 8;
+	int i;
+
+	if (Cmd_Argc() < 2 || Cmd_Argc() > 3) {
+		Con_Printf("usage: sv_antilag_dump <userid/name> [count]\n");
+		return;
+	}
+
+	uid = SV_MatchUser(Cmd_Argv(1));
+	if (!uid) {
+		Con_Printf("Couldn't find user %s\n", Cmd_Argv(1));
+		return;
+	}
+	if (Cmd_Argc() == 3) {
+		wanted = Q_atoi(Cmd_Argv(2));
+	}
+
+	for (i = 0, cl = svs.clients; i < MAX_CLIENTS; ++i, ++cl) {
+		if (cl->state < cs_preconnected) {
+			continue;
+		}
+		if (cl->userid == uid) {
+			SV_AntilagDumpClientHistory(cl, wanted);
+			return;
+		}
+	}
+
+	Con_Printf("Couldn't find user %s\n", Cmd_Argv(1));
+}
+
+static void SV_AntilagDumpAll_f(void)
+{
+	client_t *cl;
+	int wanted = 1;
+	int i;
+	int printed = 0;
+
+	if (Cmd_Argc() > 2) {
+		Con_Printf("usage: sv_antilag_dumpall [count]\n");
+		return;
+	}
+	if (Cmd_Argc() == 2) {
+		wanted = Q_atoi(Cmd_Argv(1));
+	}
+
+	for (i = 0, cl = svs.clients; i < MAX_CLIENTS; ++i, ++cl) {
+		if (cl->state < cs_preconnected || cl->antilag_recent_count == 0) {
+			continue;
+		}
+		SV_AntilagDumpClientHistory(cl, wanted);
+		printed++;
+	}
+
+	if (!printed) {
+		Con_Printf("sv_antilag_dumpall: no anti-lag decisions recorded\n");
+	}
+}
+
+static void SV_AntilagRolloutStatus_f(void)
+{
+	int stage = SV_AntilagRolloutStageResolved();
+	int requested_mode = bound(0, sv_antilag.integer, 2);
+	int effective_mode = SV_AntilagGameplayModeResolved();
+	int requested_projectile = bound(0, sv_antilag_projectile_mode.integer, 2);
+	int effective_projectile = SV_AntilagProjectileModeResolved();
+
+	Con_Printf("anti-lag rollout status:\n");
+	Con_Printf("  stage=%d (0 instrumentation, 1 hitscan/melee, 2 projectile-limited, 3 full-projectile-eligible)\n", stage);
+	Con_Printf("  sv_antilag requested=%d effective=%d\n", requested_mode, effective_mode);
+	Con_Printf("  projectile_mode requested=%d effective=%d\n", requested_projectile, effective_projectile);
+	Con_Printf("  playtest_signoff=%d full_admin=%d legacy_projectiles=%d\n",
+		!!sv_antilag_projectile_playtest_signoff.integer,
+		!!sv_antilag_projectile_full_admin.integer,
+		!!sv_antilag_projectiles.integer);
+}
+
 /*
 ==================
 SV_InitOperatorCommands
@@ -1834,6 +2091,10 @@ void SV_InitOperatorCommands (void)
 	Cmd_AddCommand ("check_maps", SV_Check_maps_f);
 	Cmd_AddCommand ("snap", SV_Snap_f);
 	Cmd_AddCommand ("snapall", SV_SnapAll_f);
+	Cmd_AddCommand ("sv_antilag_replaytests", SV_AntilagReplayTests_f);
+	Cmd_AddCommand ("sv_antilag_dump", SV_AntilagDump_f);
+	Cmd_AddCommand ("sv_antilag_dumpall", SV_AntilagDumpAll_f);
+	Cmd_AddCommand ("sv_antilag_rollout_status", SV_AntilagRolloutStatus_f);
 	Cmd_AddCommand ("kick", SV_Kick_f);
 
 	// Add sv_status as client allows 'status' alias to over-ride (ezQuake #532)

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3234,6 +3234,8 @@ void SV_Frame (double time1)
 	// keep the random time dependent
 	rand ();
 
+	SV_AntilagPerfFrameBegin();
+
 	// decide the simulation time
 	if (!sv.paused)
 	{
@@ -3297,6 +3299,8 @@ void SV_Frame (double time1)
 
 	// send a heartbeat to the master if needed
 	Master_Heartbeat ();
+
+	SV_AntilagPerfFrameEnd();
 
 	// collect timing statistics
 	end = Sys_DoubleTime ();
@@ -3447,7 +3451,26 @@ void SV_InitLocal (void)
 
 	Cvar_Register (&sv_antilag);
 	Cvar_Register (&sv_antilag_no_pred);
+	Cvar_Register (&sv_antilag_rollout_stage);
+	Cvar_Register (&sv_antilag_projectile_playtest_signoff);
+	Cvar_Register (&sv_antilag_projectile_full_admin);
 	Cvar_Register (&sv_antilag_projectiles);
+	Cvar_Register (&sv_antilag_projectile_mode);
+	Cvar_Register (&sv_antilag_projectile_nudge);
+	Cvar_Register (&sv_antilag_projectile_owner_stale);
+	Cvar_Register (&sv_antilag_projectile_optin);
+	Cvar_Register (&sv_antilag_projectile_allow);
+	Cvar_Register (&sv_antilag_projectile_deny);
+	Cvar_Register (&sv_antilag_maxunlag);
+	Cvar_Register (&sv_antilag_max_cmd_delta);
+	Cvar_Register (&sv_antilag_ping_limit);
+	Cvar_Register (&sv_antilag_teleport_dist);
+	Cvar_Register (&sv_antilag_prefilter_pvs);
+	Cvar_Register (&sv_antilag_prefilter_team);
+	Cvar_Register (&sv_antilag_ray_narrow);
+	Cvar_Register (&sv_antilag_ray_narrow_pad);
+	Cvar_Register (&sv_antilag_frame_budget_ms);
+	SV_AntilagApplyStartupDefaults();
 
 	Cvar_Register (&pm_bunnyspeedcap);
 	Cvar_Register (&pm_ktjump);

--- a/src/sv_phys.c
+++ b/src/sv_phys.c
@@ -50,9 +50,36 @@ cvar_t	sv_spectatormaxspeed 	= { "sv_spectatormaxspeed", "500"};
 cvar_t	sv_accelerate		= { "sv_accelerate", "10"};
 cvar_t	sv_airaccelerate	= { "sv_airaccelerate", "10"};
 
+static void OnChange_sv_antilag_projectiles(cvar_t *var, char *value, qbool *cancel);
+static void OnChange_sv_antilag_projectile_mode(cvar_t *var, char *value, qbool *cancel);
+static void OnChange_sv_antilag_projectile_nudge(cvar_t *var, char *value, qbool *cancel);
+static void OnChange_sv_antilag_projectile_owner_stale(cvar_t *var, char *value, qbool *cancel);
+static void OnChange_sv_antilag_projectile_optin(cvar_t *var, char *value, qbool *cancel);
+static void OnChange_sv_antilag_rollout_stage(cvar_t *var, char *value, qbool *cancel);
+static void OnChange_sv_antilag_projectile_playtest_signoff(cvar_t *var, char *value, qbool *cancel);
+static void OnChange_sv_antilag_projectile_full_admin(cvar_t *var, char *value, qbool *cancel);
+
 cvar_t	sv_antilag		= { "sv_antilag", "", CVAR_SERVERINFO};
 cvar_t	sv_antilag_no_pred	= { "sv_antilag_no_pred", "", CVAR_SERVERINFO}; // "negative" cvar so it doesn't show on serverinfo for no reason
-cvar_t	sv_antilag_projectiles	= { "sv_antilag_projectiles", "", CVAR_SERVERINFO};
+cvar_t	sv_antilag_rollout_stage	= { "sv_antilag_rollout_stage", "", CVAR_SERVERINFO, OnChange_sv_antilag_rollout_stage };
+cvar_t	sv_antilag_projectile_playtest_signoff	= { "sv_antilag_projectile_playtest_signoff", "", CVAR_SERVERINFO, OnChange_sv_antilag_projectile_playtest_signoff };
+cvar_t	sv_antilag_projectile_full_admin	= { "sv_antilag_projectile_full_admin", "", CVAR_SERVERINFO, OnChange_sv_antilag_projectile_full_admin };
+cvar_t	sv_antilag_projectiles	= { "sv_antilag_projectiles", "", CVAR_SERVERINFO, OnChange_sv_antilag_projectiles };
+cvar_t	sv_antilag_projectile_mode	= { "sv_antilag_projectile_mode", "", CVAR_SERVERINFO, OnChange_sv_antilag_projectile_mode };
+cvar_t	sv_antilag_projectile_nudge	= { "sv_antilag_projectile_nudge", "", CVAR_SERVERINFO, OnChange_sv_antilag_projectile_nudge };
+cvar_t	sv_antilag_projectile_owner_stale	= { "sv_antilag_projectile_owner_stale", "", CVAR_SERVERINFO, OnChange_sv_antilag_projectile_owner_stale };
+cvar_t	sv_antilag_projectile_optin	= { "sv_antilag_projectile_optin", "", CVAR_SERVERINFO, OnChange_sv_antilag_projectile_optin };
+cvar_t	sv_antilag_projectile_allow	= { "sv_antilag_projectile_allow", "" };
+cvar_t	sv_antilag_projectile_deny	= { "sv_antilag_projectile_deny", "" };
+cvar_t	sv_antilag_maxunlag	= { "sv_antilag_maxunlag", "", CVAR_SERVERINFO };
+cvar_t	sv_antilag_max_cmd_delta	= { "sv_antilag_max_cmd_delta", "", CVAR_SERVERINFO };
+cvar_t	sv_antilag_ping_limit	= { "sv_antilag_ping_limit", "", CVAR_SERVERINFO };
+cvar_t	sv_antilag_teleport_dist	= { "sv_antilag_teleport_dist", "", CVAR_SERVERINFO };
+cvar_t	sv_antilag_prefilter_pvs	= { "sv_antilag_prefilter_pvs", "", CVAR_SERVERINFO };
+cvar_t	sv_antilag_prefilter_team	= { "sv_antilag_prefilter_team", "", CVAR_SERVERINFO };
+cvar_t	sv_antilag_ray_narrow	= { "sv_antilag_ray_narrow", "", CVAR_SERVERINFO };
+cvar_t	sv_antilag_ray_narrow_pad	= { "sv_antilag_ray_narrow_pad", "", CVAR_SERVERINFO };
+cvar_t	sv_antilag_frame_budget_ms	= { "sv_antilag_frame_budget_ms", "" };
 
 cvar_t	sv_wateraccelerate	= { "sv_wateraccelerate", "10"};
 cvar_t	sv_friction		= { "sv_friction", "4"};
@@ -66,6 +93,212 @@ cvar_t	pm_pground		= { "pm_pground", "", CVAR_SERVERINFO|CVAR_ROM};
 cvar_t  pm_rampjump     = { "pm_rampjump", "", CVAR_SERVERINFO };
 
 double	sv_frametime;
+static qbool sv_antilag_projectile_syncing = false;
+
+static void SV_AntilagSyncLegacyProjectileToggle(int mode)
+{
+	Cvar_SetIgnoreCallback(&sv_antilag_projectiles, mode > 0 ? "1" : "");
+}
+
+static void SV_AntilagSyncProjectileModeFromLegacyString(const char *legacy_value)
+{
+	int mode = bound(0, sv_antilag_projectile_mode.integer, 2);
+	int desired_mode = mode;
+	qbool legacy_enabled = (Q_atof(legacy_value ? legacy_value : "") != 0.0f);
+
+	if (!legacy_enabled) {
+		desired_mode = 0;
+	}
+	else if (desired_mode == 0) {
+		desired_mode = 1;
+	}
+
+	if (desired_mode == mode) {
+		return;
+	}
+
+	if (desired_mode <= 0) {
+		Cvar_SetIgnoreCallback(&sv_antilag_projectile_mode, "0");
+	}
+	else if (desired_mode == 1) {
+		Cvar_SetIgnoreCallback(&sv_antilag_projectile_mode, "1");
+	}
+	else {
+		Cvar_SetIgnoreCallback(&sv_antilag_projectile_mode, "2");
+	}
+}
+
+static void OnChange_sv_antilag_projectiles(cvar_t *var, char *value, qbool *cancel)
+{
+	(void)var;
+	(void)cancel;
+
+	if (sv_antilag_projectile_syncing) {
+		return;
+	}
+
+	sv_antilag_projectile_syncing = true;
+	SV_AntilagSyncProjectileModeFromLegacyString(value);
+	sv_antilag_projectile_syncing = false;
+}
+
+static void OnChange_sv_antilag_projectile_mode(cvar_t *var, char *value, qbool *cancel)
+{
+	int requested = Q_atoi(value);
+	int mode = bound(0, requested, 2);
+
+	if (requested != mode) {
+		*cancel = true;
+		if (mode <= 0) {
+			Cvar_SetIgnoreCallback(var, "0");
+		}
+		else if (mode == 1) {
+			Cvar_SetIgnoreCallback(var, "1");
+		}
+		else {
+			Cvar_SetIgnoreCallback(var, "2");
+		}
+		SV_AntilagSyncLegacyProjectileToggle(mode);
+		return;
+	}
+
+	if (sv_antilag_projectile_syncing) {
+		return;
+	}
+
+	sv_antilag_projectile_syncing = true;
+	SV_AntilagSyncLegacyProjectileToggle(mode);
+	sv_antilag_projectile_syncing = false;
+}
+
+static void OnChange_sv_antilag_projectile_nudge(cvar_t *var, char *value, qbool *cancel)
+{
+	float requested = Q_atof(value);
+
+	if (requested >= 0.0f) {
+		return;
+	}
+
+	*cancel = true;
+	Cvar_SetIgnoreCallback(var, "0");
+}
+
+static void OnChange_sv_antilag_projectile_owner_stale(cvar_t *var, char *value, qbool *cancel)
+{
+	float requested = Q_atof(value);
+
+	if (requested >= 0.0f) {
+		return;
+	}
+
+	*cancel = true;
+	Cvar_SetIgnoreCallback(var, "0");
+}
+
+static void OnChange_sv_antilag_projectile_optin(cvar_t *var, char *value, qbool *cancel)
+{
+	int requested = Q_atoi(value);
+	int clamped = bound(0, requested, 2);
+
+	if (requested == clamped) {
+		return;
+	}
+
+	*cancel = true;
+	if (clamped <= 0) {
+		Cvar_SetIgnoreCallback(var, "0");
+	}
+	else if (clamped == 1) {
+		Cvar_SetIgnoreCallback(var, "1");
+	}
+	else {
+		Cvar_SetIgnoreCallback(var, "2");
+	}
+}
+
+static void SV_AntilagClampBoolean(cvar_t *var, char *value, qbool *cancel)
+{
+	int requested = Q_atoi(value);
+	int clamped = !!requested;
+
+	if (requested == 0 || requested == 1) {
+		return;
+	}
+
+	*cancel = true;
+	Cvar_SetIgnoreCallback(var, clamped ? "1" : "0");
+}
+
+static void OnChange_sv_antilag_rollout_stage(cvar_t *var, char *value, qbool *cancel)
+{
+	int requested = Q_atoi(value);
+	int clamped = bound(0, requested, 3);
+
+	if (requested == clamped) {
+		return;
+	}
+
+	*cancel = true;
+	if (clamped <= 0) {
+		Cvar_SetIgnoreCallback(var, "0");
+	}
+	else if (clamped == 1) {
+		Cvar_SetIgnoreCallback(var, "1");
+	}
+	else if (clamped == 2) {
+		Cvar_SetIgnoreCallback(var, "2");
+	}
+	else {
+		Cvar_SetIgnoreCallback(var, "3");
+	}
+}
+
+static void OnChange_sv_antilag_projectile_playtest_signoff(cvar_t *var, char *value, qbool *cancel)
+{
+	SV_AntilagClampBoolean(var, value, cancel);
+}
+
+static void OnChange_sv_antilag_projectile_full_admin(cvar_t *var, char *value, qbool *cancel)
+{
+	SV_AntilagClampBoolean(var, value, cancel);
+}
+
+int SV_AntilagRolloutStageResolved(void)
+{
+	return bound(0, sv_antilag_rollout_stage.integer, 3);
+}
+
+int SV_AntilagGameplayModeResolved(void)
+{
+	int mode = bound(0, sv_antilag.integer, 2);
+
+	if (SV_AntilagRolloutStageResolved() <= 0) {
+		return 0;
+	}
+
+	return mode;
+}
+
+int SV_AntilagProjectileModeResolved(void)
+{
+	int mode = bound(0, sv_antilag_projectile_mode.integer, 2);
+	int stage = SV_AntilagRolloutStageResolved();
+
+	if (mode <= 0) {
+		return 0;
+	}
+	if (stage < 2) {
+		return 0;
+	}
+	if (!sv_antilag_projectile_playtest_signoff.integer) {
+		return 0;
+	}
+	if (mode >= 2 && (stage < 3 || !sv_antilag_projectile_full_admin.integer)) {
+		return 1;
+	}
+
+	return mode;
+}
 
 
 // when pm_airstep is 1, set pm_pground to 1, and vice versa
@@ -78,6 +311,87 @@ void OnChange_pm_airstep (cvar_t *var, char *value, qbool *cancel)
 
 
 void SV_Physics_Toss (edict_t *ent);
+
+static qbool SV_AntilagUseCompetitiveDefaults(void)
+{
+	cvar_t *ruleset_var = Cvar_Find("ruleset");
+	const char *ruleset_name = ruleset_var ? ruleset_var->string : "";
+
+	return !strcasecmp(ruleset_name, "smackdown")
+		|| !strcasecmp(ruleset_name, "smackdrive")
+		|| !strcasecmp(ruleset_name, "qcon")
+		|| !strcasecmp(ruleset_name, "thunderdome")
+		|| !strcasecmp(ruleset_name, "mtfl");
+}
+
+void SV_AntilagApplyStartupDefaults(void)
+{
+	qbool competitive = SV_AntilagUseCompetitiveDefaults();
+	int rollout_stage;
+
+	if (!sv_antilag_rollout_stage.string[0]) {
+		Cvar_Set(&sv_antilag_rollout_stage, "0");
+	}
+	if (!sv_antilag_projectile_playtest_signoff.string[0]) {
+		Cvar_Set(&sv_antilag_projectile_playtest_signoff, "0");
+	}
+	if (!sv_antilag_projectile_full_admin.string[0]) {
+		Cvar_Set(&sv_antilag_projectile_full_admin, "0");
+	}
+	rollout_stage = SV_AntilagRolloutStageResolved();
+
+	// Keep explicit user/server config overrides; only fill empty defaults.
+	if (!sv_antilag.string[0]) {
+		Cvar_Set(&sv_antilag, rollout_stage >= 2 ? "2" : "1");
+	}
+	if (!sv_antilag_projectile_mode.string[0]) {
+		if (sv_antilag_projectiles.string[0]) {
+			Cvar_Set(&sv_antilag_projectile_mode, sv_antilag_projectiles.value ? "1" : "0");
+		}
+		else {
+			Cvar_Set(&sv_antilag_projectile_mode, (rollout_stage >= 2 && sv_antilag_projectile_playtest_signoff.integer) ? "1" : "0");
+		}
+	}
+	if (!sv_antilag_projectiles.string[0]) {
+		Cvar_Set(&sv_antilag_projectiles, bound(0, sv_antilag_projectile_mode.integer, 2) ? "1" : "");
+	}
+	if (!sv_antilag_projectile_nudge.string[0]) {
+		Cvar_Set(&sv_antilag_projectile_nudge, "0.05");
+	}
+	if (!sv_antilag_projectile_owner_stale.string[0]) {
+		Cvar_Set(&sv_antilag_projectile_owner_stale, competitive ? "0.25" : "0.40");
+	}
+	if (!sv_antilag_projectile_optin.string[0]) {
+		Cvar_Set(&sv_antilag_projectile_optin, "0");
+	}
+	if (!sv_antilag_maxunlag.string[0]) {
+		Cvar_Set(&sv_antilag_maxunlag, competitive ? "0.25" : "0.50");
+	}
+	if (!sv_antilag_max_cmd_delta.string[0]) {
+		Cvar_Set(&sv_antilag_max_cmd_delta, competitive ? "0.20" : "0.35");
+	}
+	if (!sv_antilag_ping_limit.string[0]) {
+		Cvar_Set(&sv_antilag_ping_limit, competitive ? "400" : "0");
+	}
+	if (!sv_antilag_teleport_dist.string[0]) {
+		Cvar_Set(&sv_antilag_teleport_dist, competitive ? "64" : "96");
+	}
+	if (!sv_antilag_prefilter_pvs.string[0]) {
+		Cvar_Set(&sv_antilag_prefilter_pvs, "1");
+	}
+	if (!sv_antilag_prefilter_team.string[0]) {
+		Cvar_Set(&sv_antilag_prefilter_team, "1");
+	}
+	if (!sv_antilag_ray_narrow.string[0]) {
+		Cvar_Set(&sv_antilag_ray_narrow, "1");
+	}
+	if (!sv_antilag_ray_narrow_pad.string[0]) {
+		Cvar_Set(&sv_antilag_ray_narrow_pad, competitive ? "16" : "24");
+	}
+	if (!sv_antilag_frame_budget_ms.string[0]) {
+		Cvar_Set(&sv_antilag_frame_budget_ms, competitive ? "0.75" : "1.50");
+	}
+}
 
 
 /*
@@ -399,9 +713,7 @@ trace_t SV_PushEntity (edict_t *ent, vec3_t push, unsigned int traceflags)
 	vec3_t	end;
 
 	VectorAdd (ent->v->origin, push, end);
-
-	if ((int)ent->v->flags&FL_LAGGEDMOVE)
-		traceflags |= MOVE_LAGGED;
+	traceflags = SV_AntilagApplyTracePolicy(traceflags, ent, antilag_trace_projectile);
 
 	if (ent->v->movetype == MOVETYPE_FLYMISSILE)
 		trace = SV_Trace (ent->v->origin, ent->v->mins, ent->v->maxs, end, MOVE_MISSILE|traceflags, ent);
@@ -747,7 +1059,7 @@ void SV_Physics_Toss (edict_t *ent)
 
 	// move origin
 	VectorScale (ent->v->velocity, sv_frametime, move);
-	trace = SV_PushEntity (ent, move, (sv_antilag.value == 2 && sv_antilag_projectiles.value) ? MOVE_LAGGED:0);
+	trace = SV_PushEntity(ent, move, 0);
 	if (trace.fraction == 1)
 		return;
 	if (ent->e.free)
@@ -1102,14 +1414,10 @@ void SV_RunBots(void)
 		cl->delta_sequence = -1;	// no delta unless requested
 
 		if (sv_antilag.value) {
-			if (cl->antilag_position_next == 0 || cl->antilag_positions[(cl->antilag_position_next - 1) % MAX_ANTILAG_POSITIONS].localtime < cl->localtime) {
-				cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].localtime = cl->localtime;
-				VectorCopy(cl->edict->v->origin, cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].origin);
-				cl->antilag_position_next++;
-			}
+			SV_AntilagRecord(cl, false);
 		}
 		else {
-			cl->antilag_position_next = 0;
+			SV_AntilagReset(cl->edict);
 		}
 	}
 

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -767,6 +767,7 @@ void SV_WriteClientdataToMessage (client_t *client, sizebuf_t *msg)
 				client->lastteleport_teleport = ((eval_t *)((byte *)(client->edict)->v + fofs_teleported))->_int;
 				if (client->lastteleport_teleport) {
 					MSG_WriteByte(msg, 1); // signal a teleport
+					SV_AntilagReset(client->edict);
 				}
 				else {
 					MSG_WriteByte(msg, 2); // respawn

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -81,6 +81,113 @@ cvar_t sv_debug_weapons = { "sv_debug_weapons", "0" };
 cvar_t sv_debug_usercmd = { "sv_debug_usercmd", "0" };
 cvar_t sv_debug_antilag = { "sv_debug_antilag", "0" };
 
+typedef struct
+{
+	double build_seconds;
+	double clip_seconds;
+	unsigned int build_scanned;
+	unsigned int build_kept;
+	unsigned int build_prefiltered;
+	unsigned int build_pvs_rejects;
+	unsigned int build_team_rejects;
+	unsigned int clip_candidates;
+	unsigned int clip_broadphase_rejects;
+	unsigned int clip_ray_rejects;
+	unsigned int clip_trace_tests;
+} antilag_perf_frame_t;
+
+static antilag_perf_frame_t sv_antilag_perf_frame;
+static double sv_antilag_perf_next_alarm;
+
+typedef struct
+{
+	double target_time;
+	double command_target_time;
+	double latency_target_time;
+	double one_way_latency;
+	double interp_delay;
+	double command_window;
+	unsigned int reason_flags;
+} antilag_target_time_info_t;
+
+static unsigned short SV_AntilagClampU16(unsigned int value)
+{
+	return (unsigned short)min(value, 0xFFFFu);
+}
+
+static void SV_AntilagStoreDecision(client_t *cl, const antilag_decision_t *decision)
+{
+	unsigned int index;
+
+	if (!cl || !decision) {
+		return;
+	}
+
+	index = cl->antilag_recent_head % MAX_ANTILAG_DECISIONS;
+	cl->antilag_recent[index] = *decision;
+	cl->antilag_recent_head = (cl->antilag_recent_head + 1) % MAX_ANTILAG_DECISIONS;
+	if (cl->antilag_recent_count < MAX_ANTILAG_DECISIONS) {
+		cl->antilag_recent_count++;
+	}
+	cl->antilag_last_decision = *decision;
+}
+
+void SV_AntilagPerfFrameBegin(void)
+{
+	memset(&sv_antilag_perf_frame, 0, sizeof(sv_antilag_perf_frame));
+}
+
+void SV_AntilagPerfAddBuild(double elapsed_seconds, unsigned int scanned, unsigned int kept, unsigned int prefiltered, unsigned int pvs_rejects, unsigned int team_rejects)
+{
+	sv_antilag_perf_frame.build_seconds += max(0.0, elapsed_seconds);
+	sv_antilag_perf_frame.build_scanned += scanned;
+	sv_antilag_perf_frame.build_kept += kept;
+	sv_antilag_perf_frame.build_prefiltered += prefiltered;
+	sv_antilag_perf_frame.build_pvs_rejects += pvs_rejects;
+	sv_antilag_perf_frame.build_team_rejects += team_rejects;
+}
+
+void SV_AntilagPerfAddClip(double elapsed_seconds, unsigned int candidates, unsigned int broadphase_rejects, unsigned int ray_rejects, unsigned int trace_tests)
+{
+	sv_antilag_perf_frame.clip_seconds += max(0.0, elapsed_seconds);
+	sv_antilag_perf_frame.clip_candidates += candidates;
+	sv_antilag_perf_frame.clip_broadphase_rejects += broadphase_rejects;
+	sv_antilag_perf_frame.clip_ray_rejects += ray_rejects;
+	sv_antilag_perf_frame.clip_trace_tests += trace_tests;
+}
+
+void SV_AntilagPerfFrameEnd(void)
+{
+	double budget_ms = max(0.0, sv_antilag_frame_budget_ms.value);
+	double total_ms;
+
+	if (budget_ms <= 0) {
+		return;
+	}
+
+	total_ms = (sv_antilag_perf_frame.build_seconds + sv_antilag_perf_frame.clip_seconds) * 1000.0;
+	if (total_ms <= budget_ms) {
+		return;
+	}
+
+	if (sv_antilag_perf_next_alarm > sv.time) {
+		return;
+	}
+	sv_antilag_perf_next_alarm = sv.time + 1.0;
+
+	Con_Printf("antilag budget alarm: total=%0.3fms budget=%0.3fms build=%0.3fms clip=%0.3fms scanned=%u kept=%u prefiltered=%u clip_tests=%u broadphase_rejects=%u ray_rejects=%u\n",
+		total_ms,
+		budget_ms,
+		sv_antilag_perf_frame.build_seconds * 1000.0,
+		sv_antilag_perf_frame.clip_seconds * 1000.0,
+		sv_antilag_perf_frame.build_scanned,
+		sv_antilag_perf_frame.build_kept,
+		sv_antilag_perf_frame.build_prefiltered,
+		sv_antilag_perf_frame.clip_trace_tests,
+		sv_antilag_perf_frame.clip_broadphase_rejects,
+		sv_antilag_perf_frame.clip_ray_rejects);
+}
+
 
 #ifdef MVD_PEXT1_SERVERSIDEWEAPON
 static void SV_UserSetWeaponRank(client_t* cl, const char* new_wrank);
@@ -1035,6 +1142,7 @@ static void Cmd_Begin_f (void)
 		MSG_WriteAngle (&sv_client->netchan.message, 0);
 	}
 
+	SV_AntilagReset(sv_client->edict);
 	sv_client->lastservertimeupdate = -99; // update immediately
 }
 
@@ -2702,6 +2810,7 @@ static void Cmd_Join_f (void)
 	pr_global_struct->self = EDICT_TO_PROG(sv_player);
 	G_FLOAT(OFS_PARM0) = (float) sv_client->vip;
 	PR_GamePutClientInServer(0);
+	SV_AntilagReset(sv_client->edict);
 
 	// look in SVC_DirectConnect() for for extended comment whats this for
 	MVD_PlayerReset(NUM_FOR_EDICT(sv_player) - 1);
@@ -2787,6 +2896,7 @@ static void Cmd_Observe_f (void)
 	pr_global_struct->time = sv.time;
 	pr_global_struct->self = EDICT_TO_PROG(sv_player);
 	PR_GamePutClientInServer(1); // let mod know we put spec not player
+	SV_AntilagReset(sv_client->edict);
 
 	// look in SVC_DirectConnect() for for extended comment whats this for
 	MVD_PlayerReset(NUM_FOR_EDICT(sv_player) - 1);
@@ -4119,6 +4229,372 @@ void SV_RotateCmd(client_t* cl, usercmd_t* cmd_)
 	}
 }
 
+static double SV_AntilagSafeCmdMsec(int msec)
+{
+	return bound(0, msec, 50);
+}
+
+static double SV_AntilagCommandWindowMsec(client_t *cl, const usercmd_t *oldest, const usercmd_t *oldcmd, const usercmd_t *newcmd)
+{
+	double command_window = 0;
+	int net_drop = cl->netchan.dropped;
+
+	if (net_drop < 20 && net_drop > 2) {
+		command_window += (net_drop - 2) * SV_AntilagSafeCmdMsec(cl->lastcmd.msec);
+	}
+	if (net_drop > 1) {
+		command_window += SV_AntilagSafeCmdMsec(oldest->msec);
+	}
+	if (net_drop > 0) {
+		command_window += SV_AntilagSafeCmdMsec(oldcmd->msec);
+	}
+	command_window += SV_AntilagSafeCmdMsec(newcmd->msec);
+
+	return command_window;
+}
+
+static double SV_AntilagInterpolationDelay(const usercmd_t *newcmd, double max_physfps)
+{
+	const double max_prediction = 0.02;
+	double cmd_interval = SV_AntilagSafeCmdMsec(newcmd->msec) * 0.001;
+
+	if (sv_antilag_no_pred.value) {
+		return 0;
+	}
+
+	if (max_physfps < 20 || max_physfps > 1000) {
+		max_physfps = 77.0;
+	}
+
+	if (cmd_interval <= 0) {
+		cmd_interval = 1.0 / max_physfps;
+	}
+
+	return min(max_prediction, max(1.0 / max_physfps, cmd_interval));
+}
+
+static double SV_AntilagComputeTargetTime(client_t *cl, client_frame_t *frame, const usercmd_t *oldest, const usercmd_t *oldcmd, const usercmd_t *newcmd, antilag_target_time_info_t *info)
+{
+	double rtt = max(0.0, frame->ping_time);
+	double one_way = rtt * 0.5;
+	double interp = SV_AntilagInterpolationDelay(newcmd, sv_maxfps.value);
+	double command_window = SV_AntilagCommandWindowMsec(cl, oldest, oldcmd, newcmd) * 0.001;
+	double command_time = frame->sv_time + command_window;
+	double command_target = command_time - interp;
+	double latency_target = sv.time - one_way - interp;
+	double max_cmd_delta = max(0.0, sv_antilag_max_cmd_delta.value);
+	double max_unlag = max(0.0, sv_antilag_maxunlag.value);
+	double target_time = command_target;
+	qbool fallback = false;
+	qbool clamped_maxunlag = false;
+	qbool clamped_future = false;
+
+	if (info) {
+		memset(info, 0, sizeof(*info));
+		info->command_target_time = command_target;
+		info->latency_target_time = latency_target;
+		info->one_way_latency = one_way;
+		info->interp_delay = interp;
+		info->command_window = command_window;
+	}
+
+	if (command_time > sv.time) {
+		command_time = sv.time;
+		command_target = command_time - interp;
+	}
+
+	if (max_cmd_delta > 0 && fabs(command_target - latency_target) > max_cmd_delta) {
+		target_time = latency_target;
+		fallback = true;
+		cl->antilag_cmd_fallbacks++;
+		if (info) {
+			info->reason_flags |= MVD_PEXT1_ANTILAG_REASON_CMD_FALLBACK;
+		}
+	}
+
+	if (max_unlag > 0 && target_time < sv.time - max_unlag) {
+		target_time = sv.time - max_unlag;
+		clamped_maxunlag = true;
+	}
+
+	if (target_time > sv.time) {
+		target_time = sv.time;
+		clamped_future = true;
+	}
+
+	if (clamped_maxunlag || clamped_future) {
+		cl->antilag_maxunlag_clamps++;
+	}
+	if (clamped_maxunlag && info) {
+		info->reason_flags |= MVD_PEXT1_ANTILAG_REASON_CLAMP_MAXUNLAG;
+	}
+	if (clamped_future && info) {
+		info->reason_flags |= MVD_PEXT1_ANTILAG_REASON_CLAMP_FUTURE;
+	}
+
+	if (sv_debug_antilag.integer >= 2 && (fallback || clamped_maxunlag || clamped_future)) {
+		Com_DPrintf("antilag %s: ping=%dms target=%0.3f cmd=%0.3f latency=%0.3f interp=%0.3f drop=%d\n",
+			cl->name,
+			(int)Q_rint(frame->ping_time * 1000.0),
+			target_time,
+			command_target,
+			latency_target,
+			interp,
+			cl->netchan.dropped);
+	}
+
+	if (info) {
+		info->target_time = target_time;
+		info->command_target_time = command_target;
+		info->latency_target_time = latency_target;
+	}
+
+	return target_time;
+}
+
+static qbool SV_AntilagPointInPVS(byte *pvs, vec3_t point)
+{
+	int leafnum;
+
+	if (!pvs) {
+		return true;
+	}
+
+	leafnum = CM_Leafnum(CM_PointInLeaf(point)) - 1;
+	if (leafnum < 0) {
+		return true;
+	}
+
+	return (pvs[leafnum >> 3] & (1 << (leafnum & 7))) != 0;
+}
+
+static qbool SV_AntilagNoFriendlyFire(void)
+{
+	int tp = (int)teamplay.value;
+
+	// Teamplay 3/4 and 21 are known no-teamdamage modes in common QW rulesets.
+	return (tp == 3 || tp == 4 || tp == 21);
+}
+
+static qbool SV_AntilagRelevantTeam(client_t *attacker, client_t *target)
+{
+	if (!sv_antilag_prefilter_team.integer) {
+		return true;
+	}
+	if (!teamplay.value || !SV_AntilagNoFriendlyFire()) {
+		return true;
+	}
+	if (attacker->spectator || target->spectator) {
+		return true;
+	}
+	if (!attacker->team[0] || !target->team[0]) {
+		return true;
+	}
+
+	return strcmp(attacker->team, target->team) != 0;
+}
+
+static void SV_AntilagBuildLaggedEntities(client_t *cl, client_frame_t *frame, const usercmd_t *oldest, const usercmd_t *oldcmd, const usercmd_t *newcmd
+#ifdef MVD_PEXT1_DEBUG
+	, int *antilag_players_present
+#endif
+)
+{
+	const double max_extrapolate = 0.02;
+	double build_start = Sys_DoubleTime();
+	double build_elapsed = 0;
+	double target_time;
+	byte *pvs = NULL;
+	vec3_t pvs_org;
+	antilag_target_time_info_t timing_info;
+	antilag_decision_t decision;
+	unsigned int scanned = 0;
+	unsigned int prefiltered = 0;
+	unsigned int pvs_rejects = 0;
+	unsigned int team_rejects = 0;
+	unsigned int kept = 0;
+	unsigned int oldest_fallbacks = 0;
+	unsigned int newest_fallbacks = 0;
+	unsigned int bad_interval_fallbacks = 0;
+	unsigned int history_misses = 0;
+	int i;
+
+	cl->laggedents_count = 0;
+	cl->laggedents_frac = 1;
+	cl->antilag_requests++;
+	memset(&timing_info, 0, sizeof(timing_info));
+	memset(&decision, 0, sizeof(decision));
+	decision.server_time = sv.time;
+	decision.ping_ms = SV_AntilagClampU16((unsigned int)bound(0, Q_rint(frame->ping_time * 1000.0), 65535));
+	decision.net_drop = (byte)bound(0, cl->netchan.dropped, 255);
+
+	if (!sv_antilag.value) {
+		cl->laggedents_time = sv.time;
+		decision.target_time = sv.time;
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_DISABLED;
+		build_elapsed = Sys_DoubleTime() - build_start;
+		decision.build_seconds = build_elapsed;
+		SV_AntilagStoreDecision(cl, &decision);
+		SV_AntilagPerfAddBuild(build_elapsed, 0, 0, 0, 0, 0);
+		return;
+	}
+	decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_ENABLED;
+	if (sv_antilag.value > 0 && SV_AntilagGameplayModeResolved() == 0) {
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_ROLLOUT_GATE;
+	}
+
+	if (sv_antilag_ping_limit.value > 0 && frame->ping_time * 1000 > sv_antilag_ping_limit.value) {
+		cl->antilag_ping_rejects++;
+		cl->laggedents_time = sv.time;
+		decision.target_time = sv.time;
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_PING_REJECT;
+		if (sv_debug_antilag.integer >= 2) {
+			Com_DPrintf("antilag %s: rejected by ping limit (%dms > %dms)\n",
+				cl->name,
+				(int)Q_rint(frame->ping_time * 1000.0),
+				(int)Q_rint(sv_antilag_ping_limit.value));
+		}
+		build_elapsed = Sys_DoubleTime() - build_start;
+		decision.build_seconds = build_elapsed;
+		SV_AntilagStoreDecision(cl, &decision);
+		SV_AntilagPerfAddBuild(build_elapsed, 0, 0, 0, 0, 0);
+		return;
+	}
+
+	target_time = SV_AntilagComputeTargetTime(cl, frame, oldest, oldcmd, newcmd, &timing_info);
+	decision.target_time = target_time;
+	decision.command_target_time = timing_info.command_target_time;
+	decision.latency_target_time = timing_info.latency_target_time;
+	decision.one_way_latency = timing_info.one_way_latency;
+	decision.interp_delay = timing_info.interp_delay;
+	decision.command_window = timing_info.command_window;
+	decision.reason_flags |= timing_info.reason_flags;
+	if (sv_antilag_prefilter_pvs.integer) {
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_PREFILTER_PVS;
+		VectorAdd(cl->edict->v->origin, cl->edict->v->view_ofs, pvs_org);
+		pvs = CM_FatPVS(pvs_org);
+	}
+	if (sv_antilag_prefilter_team.integer) {
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_PREFILTER_TEAM;
+	}
+
+	for (i = 0; i < MAX_CLIENTS; i++)
+	{
+		client_t *target_cl = &svs.clients[i];
+		antilag_resolve_mode_t resolve_mode = antilag_resolve_none;
+		qbool present = false;
+
+		scanned++;
+		// don't hit dead players
+		if (target_cl->state != cs_spawned || target_cl->antilag_position_count == 0 || (target_cl->spectator == 0 && target_cl->edict->v->health <= 0)) {
+			cl->laggedents[i].present = false;
+			prefiltered++;
+			continue;
+		}
+
+		if (!SV_AntilagRelevantTeam(cl, target_cl)) {
+			cl->laggedents[i].present = false;
+			prefiltered++;
+			team_rejects++;
+			continue;
+		}
+
+		// target player's movement commands are late, extrapolate his position based on velocity
+		if (target_time > target_cl->localtime) {
+			VectorMA(target_cl->edict->v->origin, min(target_time - target_cl->localtime, max_extrapolate), target_cl->edict->v->velocity, cl->laggedents[i].laggedpos);
+			present = true;
+		}
+		else if (!SV_AntilagResolvePosition(target_cl, target_time, cl->laggedents[i].laggedpos, &resolve_mode)) {
+			cl->antilag_history_misses++;
+			history_misses++;
+		}
+		else {
+			present = true;
+		}
+
+		cl->laggedents[i].present = present;
+		if (!present) {
+			continue;
+		}
+
+		if (!SV_AntilagPointInPVS(pvs, cl->laggedents[i].laggedpos)) {
+			cl->laggedents[i].present = false;
+			prefiltered++;
+			pvs_rejects++;
+			continue;
+		}
+		kept++;
+#ifdef MVD_PEXT1_DEBUG
+		++(*antilag_players_present);
+#endif
+
+		switch (resolve_mode) {
+		case antilag_resolve_oldest:
+			cl->antilag_history_oldest_fallbacks++;
+			oldest_fallbacks++;
+			if (sv_debug_antilag.integer >= 3) {
+				Com_DPrintf("antilag %s: target %0.3f fell before history window for %s (oldest fallback)\n",
+					cl->name, target_time, target_cl->name);
+			}
+			break;
+		case antilag_resolve_newest:
+			cl->antilag_history_newest_fallbacks++;
+			newest_fallbacks++;
+			if (sv_debug_antilag.integer >= 3) {
+				Com_DPrintf("antilag %s: target %0.3f newer than history for %s (newest fallback)\n",
+					cl->name, target_time, target_cl->name);
+			}
+			break;
+		case antilag_resolve_bad_interval:
+			cl->antilag_interp_bad_denom++;
+			bad_interval_fallbacks++;
+			if (sv_debug_antilag.integer >= 2) {
+				Com_DPrintf("antilag %s: invalid interpolation bracket for %s (bad interval fallback)\n",
+					cl->name, target_cl->name);
+			}
+			break;
+		default:
+			break;
+		}
+	}
+
+	cl->antilag_candidates_scanned += scanned;
+	cl->antilag_candidates_prefiltered += prefiltered;
+	cl->antilag_candidates_pvs_rejects += pvs_rejects;
+	cl->antilag_candidates_team_rejects += team_rejects;
+
+	cl->laggedents_count = MAX_CLIENTS; // FIXME: well, FTE do it a bit different way...
+	cl->laggedents_time = target_time;
+
+	if (oldest_fallbacks > 0) {
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_HIST_OLDEST;
+	}
+	if (newest_fallbacks > 0) {
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_HIST_NEWEST;
+	}
+	if (bad_interval_fallbacks > 0) {
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_HIST_BAD_INTERVAL;
+	}
+	if (history_misses > 0) {
+		decision.reason_flags |= MVD_PEXT1_ANTILAG_REASON_HIST_MISS;
+	}
+
+	decision.scanned = SV_AntilagClampU16(scanned);
+	decision.kept = SV_AntilagClampU16(kept);
+	decision.prefiltered = SV_AntilagClampU16(prefiltered);
+	decision.pvs_rejects = SV_AntilagClampU16(pvs_rejects);
+	decision.team_rejects = SV_AntilagClampU16(team_rejects);
+	decision.oldest_fallbacks = SV_AntilagClampU16(oldest_fallbacks);
+	decision.newest_fallbacks = SV_AntilagClampU16(newest_fallbacks);
+	decision.bad_interval_fallbacks = SV_AntilagClampU16(bad_interval_fallbacks);
+	decision.history_misses = SV_AntilagClampU16(history_misses);
+	build_elapsed = Sys_DoubleTime() - build_start;
+	decision.build_seconds = build_elapsed;
+
+	SV_AntilagStoreDecision(cl, &decision);
+	SV_AntilagPerfAddBuild(build_elapsed, scanned, kept, prefiltered, pvs_rejects, team_rejects);
+}
+
 /*
 ===================
 SV_ExecuteClientMove
@@ -4184,17 +4660,37 @@ static void SV_DebugWriteServerAntilagPositions(client_t* cl, int present)
 {
 	mvdhidden_block_header_t header;
 	mvdhidden_antilag_position_header_t antilag_header;
+	mvdhidden_antilag_position_extra_t antilag_extra;
 	int i;
-	float target_time = cl->laggedents_time;
 
 	header.type_id = mvdhidden_antilag_position;
-	header.length = sizeof_mvdhidden_antilag_position_header_t + present * sizeof_mvdhidden_antilag_position_t;
+	header.length = sizeof_mvdhidden_antilag_position_header_t + sizeof_mvdhidden_antilag_position_extra_t + present * sizeof_mvdhidden_antilag_position_t;
 
 	antilag_header.incoming_seq = LittleLong(cl->netchan.incoming_sequence);
 	antilag_header.playernum = cl - svs.clients;
 	antilag_header.players = present;
-	antilag_header.server_time = LittleFloat(sv.time);
-	antilag_header.target_time = LittleFloat(target_time);
+	antilag_header.server_time = LittleFloat((float)cl->antilag_last_decision.server_time);
+	antilag_header.target_time = LittleFloat((float)cl->antilag_last_decision.target_time);
+
+	memset(&antilag_extra, 0, sizeof(antilag_extra));
+	antilag_extra.reason_flags = LittleLong(cl->antilag_last_decision.reason_flags);
+	antilag_extra.command_target_time = LittleFloat((float)cl->antilag_last_decision.command_target_time);
+	antilag_extra.latency_target_time = LittleFloat((float)cl->antilag_last_decision.latency_target_time);
+	antilag_extra.one_way_latency = LittleFloat((float)cl->antilag_last_decision.one_way_latency);
+	antilag_extra.interp_delay = LittleFloat((float)cl->antilag_last_decision.interp_delay);
+	antilag_extra.command_window = LittleFloat((float)cl->antilag_last_decision.command_window);
+	antilag_extra.build_seconds = LittleFloat((float)cl->antilag_last_decision.build_seconds);
+	antilag_extra.ping_ms = LittleShort(cl->antilag_last_decision.ping_ms);
+	antilag_extra.scanned = LittleShort(cl->antilag_last_decision.scanned);
+	antilag_extra.kept = LittleShort(cl->antilag_last_decision.kept);
+	antilag_extra.prefiltered = LittleShort(cl->antilag_last_decision.prefiltered);
+	antilag_extra.pvs_rejects = LittleShort(cl->antilag_last_decision.pvs_rejects);
+	antilag_extra.team_rejects = LittleShort(cl->antilag_last_decision.team_rejects);
+	antilag_extra.oldest_fallbacks = LittleShort(cl->antilag_last_decision.oldest_fallbacks);
+	antilag_extra.newest_fallbacks = LittleShort(cl->antilag_last_decision.newest_fallbacks);
+	antilag_extra.bad_interval_fallbacks = LittleShort(cl->antilag_last_decision.bad_interval_fallbacks);
+	antilag_extra.history_misses = LittleShort(cl->antilag_last_decision.history_misses);
+	antilag_extra.net_drop = cl->antilag_last_decision.net_drop;
 
 	if (MVDWrite_HiddenBlockBegin(sizeof_mvdhidden_block_header_t_range0 + header.length)) {
 		header.length = LittleLong(header.length);
@@ -4205,6 +4701,7 @@ static void SV_DebugWriteServerAntilagPositions(client_t* cl, int present)
 		MVD_SZ_Write(&antilag_header.incoming_seq, sizeof(antilag_header.incoming_seq));
 		MVD_SZ_Write(&antilag_header.server_time, sizeof(antilag_header.server_time));
 		MVD_SZ_Write(&antilag_header.target_time, sizeof(antilag_header.target_time));
+		MVD_SZ_Write(&antilag_extra, sizeof(antilag_extra));
 		for (i = 0; i < MAX_CLIENTS; i++) {
 			if (cl->laggedents[i].present) {
 				mvdhidden_antilag_position_t pos = { 0 };
@@ -4391,72 +4888,6 @@ void SV_ExecuteClientMessage (client_t *cl)
 	cl->laggedents_count = 0; // init at least this
 	cl->laggedents_frac = 1; // sv_antilag_frac.value;
 
-	if (sv_antilag.value)
-	{
-//#pragma msg("FIXME: make antilag optionally support non-player ents too")
-
-#define MAX_PREDICTION 0.02
-#define MAX_EXTRAPOLATE 0.02
-
-		double target_time, max_physfps = sv_maxfps.value;
-
-		if (max_physfps < 20 || max_physfps > 1000)
-			max_physfps = 77.0;
-
-		if (sv_antilag_no_pred.value) {
-			target_time = frame->sv_time;
-		} else {
-			// try to figure out what time client is currently predicting, basically this is just 6.5ms with 13ms ping and 13.5ms with higher
-			// might be off with different max_physfps values
-			target_time = min(frame->sv_time + (frame->ping_time < MAX_PREDICTION ? 1/max_physfps : MAX_PREDICTION), sv.time);
-		}
-
-		for (i = 0; i < MAX_CLIENTS; i++)
-		{
-			client_t *target_cl = &svs.clients[i];
-			antilag_position_t *base, *interpolate = NULL;
-			double factor;
-			int j;
-
-			// don't hit dead players
-			if (target_cl->state != cs_spawned || target_cl->antilag_position_next == 0 || (target_cl->spectator == 0 && target_cl->edict->v->health <= 0)) {
-				cl->laggedents[i].present = false;
-				continue;
-			}
-
-			cl->laggedents[i].present = true;
-			++antilag_players_present;
-
-			// target player's movement commands are late, extrapolate his position based on velocity
-			if (target_time > target_cl->localtime) {
-				VectorMA(target_cl->edict->v->origin, min(target_time - target_cl->localtime, MAX_EXTRAPOLATE), target_cl->edict->v->velocity, cl->laggedents[i].laggedpos);
-				continue;
-			}
-
-			// we have only one antilagged position, use that
-			if (target_cl->antilag_position_next == 1) {
-				VectorCopy(target_cl->antilag_positions[0].origin, cl->laggedents[i].laggedpos);
-				continue;
-			}
-
-			// find the position before target time (base) and the one after that (interpolate)
-			for (j = target_cl->antilag_position_next - 2; j > target_cl->antilag_position_next - 1 - MAX_ANTILAG_POSITIONS && j >= 0; j--) {
-				if (target_cl->antilag_positions[j % MAX_ANTILAG_POSITIONS].localtime < target_time)
-					break;
-			}
-
-			base = &target_cl->antilag_positions[j % MAX_ANTILAG_POSITIONS];
-			interpolate = &target_cl->antilag_positions[(j + 1) % MAX_ANTILAG_POSITIONS];
-
-			// we have two positions, just interpolate between them
-			factor = (target_time - base->localtime) / (interpolate->localtime - base->localtime);
-			VectorInterpolate(base->origin, factor, interpolate->origin, cl->laggedents[i].laggedpos);
-		}
-
-		cl->laggedents_count = MAX_CLIENTS; // FIXME: well, FTE do it a bit different way...
-		cl->laggedents_time = target_time;
-	}
-
 	// make sure the reply sequence number matches the incoming
 	// sequence number
 	if (cl->netchan.incoming_sequence >= cl->netchan.outgoing_sequence)
@@ -4614,6 +5045,12 @@ void SV_ExecuteClientMessage (client_t *cl)
 				return;
 			}
 
+#ifdef MVD_PEXT1_DEBUG
+			SV_AntilagBuildLaggedEntities(cl, frame, &oldest, &oldcmd, &newcmd, &antilag_players_present);
+#else
+			SV_AntilagBuildLaggedEntities(cl, frame, &oldest, &oldcmd, &newcmd);
+#endif
+
 #ifdef MVD_PEXT1_HIGHLAGTELEPORT
 			if (cl->mvdprotocolextensions1 & MVD_PEXT1_HIGHLAGTELEPORT) {
 				if (cl->lastteleport_outgoingseq && cl->netchan.incoming_acknowledged < cl->lastteleport_outgoingseq) {
@@ -4637,13 +5074,10 @@ void SV_ExecuteClientMessage (client_t *cl)
 			cl->lastcmd.buttons = 0; // avoid multiple fires on lag
 
 			if (sv_antilag.value) {
-				if (cl->antilag_position_next == 0 || cl->antilag_positions[(cl->antilag_position_next - 1) % MAX_ANTILAG_POSITIONS].localtime < cl->localtime) {
-					cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].localtime = cl->localtime;
-					VectorCopy(cl->edict->v->origin, cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].origin);
-					cl->antilag_position_next++;
-				}
-			} else {
-				cl->antilag_position_next = 0;
+				SV_AntilagRecord(cl, false);
+			}
+			else {
+				SV_AntilagReset(cl->edict);
 			}
 			break;
 
@@ -4678,7 +5112,7 @@ void SV_ExecuteClientMessage (client_t *cl)
 	}
 
 #ifdef MVD_PEXT1_DEBUG_ANTILAG
-	if (antilag_players_present && sv_debug_antilag.value) {
+	if (sv_debug_antilag.value) {
 		SV_DebugWriteServerAntilagPositions(cl, antilag_players_present);
 	}
 #endif

--- a/src/sv_world.c
+++ b/src/sv_world.c
@@ -143,6 +143,10 @@ typedef struct world_s
 	float lagentsfrac;
 	laggedentinfo_t *lagents;
 	unsigned int maxlagents;
+	client_t *owner;
+	qbool ray_narrow;
+	float ray_narrow_pad;
+	float move_radius;
 // }
 } world_t;
 
@@ -618,10 +622,905 @@ void SV_MoveBounds (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, vec3_t b
 
 void SV_AntilagReset (edict_t *ent)
 {
+	client_t *cl;
+
 	if (ent->e.entnum == 0 || ent->e.entnum > MAX_CLIENTS)
 		return;
 
-	svs.clients[ent->e.entnum - 1].antilag_position_next = 0;
+	cl = &svs.clients[ent->e.entnum - 1];
+	cl->antilag_position_next = 0;
+	cl->antilag_position_count = 0;
+	cl->antilag_pending_discontinuity = true;
+	memset(cl->antilag_positions, 0, sizeof(cl->antilag_positions));
+	cl->antilag_recent_head = 0;
+	cl->antilag_recent_count = 0;
+	memset(&cl->antilag_last_decision, 0, sizeof(cl->antilag_last_decision));
+	memset(cl->antilag_recent, 0, sizeof(cl->antilag_recent));
+}
+
+static int SV_AntilagOldestIndex(client_t *cl)
+{
+	int sample_count = bound(0, cl->antilag_position_count, MAX_ANTILAG_POSITIONS);
+
+	if (sample_count <= 0) {
+		return 0;
+	}
+
+	return (cl->antilag_position_next - sample_count + MAX_ANTILAG_POSITIONS) % MAX_ANTILAG_POSITIONS;
+}
+
+static qbool SV_AntilagPositionAlive(client_t *cl)
+{
+	return (cl->spectator || cl->edict->v->health > 0);
+}
+
+void SV_AntilagRecord(client_t *cl, qbool discontinuity)
+{
+	antilag_position_t *position;
+	int index;
+	int newest;
+	qbool mark_discontinuity;
+	qbool alive_now;
+	double history_window;
+	double teleport_dist;
+	vec3_t origin_delta;
+
+	if (!cl || !cl->edict) {
+		return;
+	}
+
+	alive_now = SV_AntilagPositionAlive(cl);
+	mark_discontinuity = (discontinuity || cl->antilag_pending_discontinuity);
+	newest = (cl->antilag_position_next + MAX_ANTILAG_POSITIONS - 1) % MAX_ANTILAG_POSITIONS;
+
+	if (cl->antilag_position_count > 0) {
+		antilag_position_t *newest_position = &cl->antilag_positions[newest];
+		qbool newest_alive = ((newest_position->flags & ANTILAG_POSITION_ALIVE) != 0);
+
+		if (newest_alive != alive_now) {
+			mark_discontinuity = true;
+		}
+
+		teleport_dist = max(0.0, sv_antilag_teleport_dist.value);
+		if (teleport_dist > 0.0) {
+			double teleport_dist_sq = teleport_dist * teleport_dist;
+			double moved_dist_sq;
+
+			VectorSubtract(cl->edict->v->origin, newest_position->origin, origin_delta);
+			moved_dist_sq = DotProduct(origin_delta, origin_delta);
+			if (moved_dist_sq > teleport_dist_sq) {
+				mark_discontinuity = true;
+			}
+		}
+	}
+
+	// Drop duplicate/out-of-order timestamps, but keep discontinuity markers if needed.
+	if (cl->antilag_position_count > 0 && cl->antilag_positions[newest].localtime >= cl->localtime) {
+		if (mark_discontinuity) {
+			cl->antilag_positions[newest].flags |= ANTILAG_POSITION_DISCONTINUITY;
+			cl->antilag_pending_discontinuity = false;
+		}
+		return;
+	}
+
+	index = cl->antilag_position_next;
+	position = &cl->antilag_positions[index];
+	position->localtime = cl->localtime;
+	VectorCopy(cl->edict->v->origin, position->origin);
+	VectorCopy(cl->edict->v->mins, position->mins);
+	VectorCopy(cl->edict->v->maxs, position->maxs);
+	position->flags = 0;
+	if (mark_discontinuity) {
+		position->flags |= ANTILAG_POSITION_DISCONTINUITY;
+	}
+	if (alive_now) {
+		position->flags |= ANTILAG_POSITION_ALIVE;
+	}
+	cl->antilag_pending_discontinuity = false;
+
+	cl->antilag_position_next = (cl->antilag_position_next + 1) % MAX_ANTILAG_POSITIONS;
+	if (cl->antilag_position_count < MAX_ANTILAG_POSITIONS) {
+		cl->antilag_position_count++;
+	}
+
+	history_window = max(0.0, sv_antilag_maxunlag.value);
+	if (history_window <= 0) {
+		return;
+	}
+
+	// Keep only entries inside the configured rewind window.
+	while (cl->antilag_position_count > 1) {
+		int oldest = SV_AntilagOldestIndex(cl);
+
+		if (cl->localtime - cl->antilag_positions[oldest].localtime <= history_window) {
+			break;
+		}
+
+		cl->antilag_position_count--;
+	}
+}
+
+qbool SV_AntilagFindHistory(client_t *cl, double target_time, const antilag_position_t **base, const antilag_position_t **interpolate)
+{
+	const antilag_position_t *previous;
+	const antilag_position_t *current;
+	const antilag_position_t *oldest;
+	const antilag_position_t *newest;
+	int sample_count;
+	int oldest_index;
+	int newest_index;
+	int i;
+
+	if (!cl) {
+		return false;
+	}
+
+	sample_count = bound(0, cl->antilag_position_count, MAX_ANTILAG_POSITIONS);
+	if (sample_count <= 0) {
+		return false;
+	}
+
+	oldest_index = SV_AntilagOldestIndex(cl);
+	newest_index = (cl->antilag_position_next + MAX_ANTILAG_POSITIONS - 1) % MAX_ANTILAG_POSITIONS;
+	oldest = &cl->antilag_positions[oldest_index];
+	newest = &cl->antilag_positions[newest_index];
+
+	if (sample_count == 1 || target_time <= oldest->localtime) {
+		*base = *interpolate = oldest;
+		return true;
+	}
+
+	if (target_time >= newest->localtime) {
+		*base = *interpolate = newest;
+		return true;
+	}
+
+	previous = oldest;
+	for (i = 1; i < sample_count; ++i) {
+		int index = (oldest_index + i) % MAX_ANTILAG_POSITIONS;
+		current = &cl->antilag_positions[index];
+
+		if (target_time <= current->localtime) {
+			if ((previous->flags | current->flags) & ANTILAG_POSITION_DISCONTINUITY) {
+				if (fabs(target_time - previous->localtime) <= fabs(current->localtime - target_time)) {
+					*base = *interpolate = previous;
+				}
+				else {
+					*base = *interpolate = current;
+				}
+			}
+			else {
+				*base = previous;
+				*interpolate = current;
+			}
+			return true;
+		}
+
+		previous = current;
+	}
+
+	*base = *interpolate = newest;
+	return true;
+}
+
+qbool SV_AntilagResolvePosition(client_t *cl, double target_time, vec3_t out_origin, antilag_resolve_mode_t *mode)
+{
+	const antilag_position_t *base = NULL, *interpolate = NULL;
+	const antilag_position_t *oldest;
+	const antilag_position_t *newest;
+	int sample_count;
+	int oldest_index;
+	int newest_index;
+	double span;
+	double factor;
+
+	if (mode) {
+		*mode = antilag_resolve_none;
+	}
+
+	if (!SV_AntilagFindHistory(cl, target_time, &base, &interpolate)) {
+		return false;
+	}
+
+	sample_count = bound(0, cl->antilag_position_count, MAX_ANTILAG_POSITIONS);
+	oldest_index = SV_AntilagOldestIndex(cl);
+	newest_index = (cl->antilag_position_next + MAX_ANTILAG_POSITIONS - 1) % MAX_ANTILAG_POSITIONS;
+	oldest = &cl->antilag_positions[oldest_index];
+	newest = &cl->antilag_positions[newest_index];
+
+	if (base == interpolate) {
+		VectorCopy(base->origin, out_origin);
+
+		if (mode) {
+			if (sample_count == 1) {
+				*mode = antilag_resolve_single;
+			}
+			else if (base == oldest) {
+				*mode = antilag_resolve_oldest;
+			}
+			else if (base == newest) {
+				*mode = antilag_resolve_newest;
+			}
+			else {
+				*mode = antilag_resolve_discontinuity;
+			}
+		}
+		return true;
+	}
+
+	span = interpolate->localtime - base->localtime;
+	if (span <= 0 || IS_NAN(span)) {
+		// Fallback policy for invalid brackets: use nearest sample.
+		if (fabs(target_time - base->localtime) <= fabs(interpolate->localtime - target_time)) {
+			VectorCopy(base->origin, out_origin);
+		}
+		else {
+			VectorCopy(interpolate->origin, out_origin);
+		}
+
+		if (mode) {
+			*mode = antilag_resolve_bad_interval;
+		}
+		return true;
+	}
+
+	factor = (target_time - base->localtime) / span;
+	if (IS_NAN(factor)) {
+		factor = 0;
+	}
+	factor = bound(0, factor, 1);
+	VectorInterpolate(base->origin, factor, interpolate->origin, out_origin);
+
+	if (mode) {
+		*mode = antilag_resolve_interpolate;
+	}
+	return true;
+}
+
+static client_t *SV_AntilagProjectileOwnerClient(edict_t *projectile)
+{
+	edict_t *owner_edict;
+	int owner_entnum;
+
+	if (!projectile || !projectile->v->owner) {
+		return NULL;
+	}
+
+	owner_edict = PROG_TO_EDICT(projectile->v->owner);
+	if (!owner_edict || owner_edict->e.free) {
+		return NULL;
+	}
+
+	owner_entnum = owner_edict->e.entnum;
+	if (owner_entnum < 1 || owner_entnum > MAX_CLIENTS) {
+		return NULL;
+	}
+
+	if (svs.clients[owner_entnum - 1].isBot) {
+		return NULL;
+	}
+
+	return &svs.clients[owner_entnum - 1];
+}
+
+static qbool SV_AntilagListContainsToken(const char *list, const char *token)
+{
+	const char *cursor;
+	const char *start;
+	int token_len;
+	int token_entry_len;
+
+	if (!list || !list[0] || !token || !token[0]) {
+		return false;
+	}
+
+	token_len = (int)strlen(token);
+	if (token_len <= 0) {
+		return false;
+	}
+
+	cursor = list;
+	while (*cursor) {
+		while (*cursor && (*cursor == ',' || *cursor == ';' || *cursor == '|' || *cursor <= ' ')) {
+			cursor++;
+		}
+		if (!*cursor) {
+			break;
+		}
+
+		start = cursor;
+		while (*cursor && *cursor != ',' && *cursor != ';' && *cursor != '|' && *cursor > ' ') {
+			cursor++;
+		}
+
+		token_entry_len = (int)(cursor - start);
+		if (token_entry_len == token_len && !strncasecmp(start, token, token_len)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static qbool SV_AntilagProjectileOptInAllowed(edict_t *projectile)
+{
+	const char *classname = "";
+	qbool explicit_optin;
+	qbool allow_list_match;
+	qbool deny_list_match;
+	int optin_mode;
+
+	if (!projectile) {
+		return false;
+	}
+
+	if (projectile->v->classname) {
+		classname = PR_GetEntityString(projectile->v->classname);
+	}
+
+	explicit_optin = (((int)projectile->v->flags & FL_LAGGEDMOVE) != 0);
+	allow_list_match = SV_AntilagListContainsToken(sv_antilag_projectile_allow.string, classname);
+	deny_list_match = SV_AntilagListContainsToken(sv_antilag_projectile_deny.string, classname);
+	optin_mode = bound(0, sv_antilag_projectile_optin.integer, 2);
+
+	if (deny_list_match) {
+		return false;
+	}
+	if (optin_mode == 0) {
+		return true;
+	}
+	if (optin_mode == 1) {
+		return (explicit_optin || allow_list_match);
+	}
+
+	return allow_list_match;
+}
+
+static qbool SV_AntilagProjectileOwnerFresh(client_t *owner)
+{
+	double stale_limit;
+	double age;
+
+	if (!owner || owner->state != cs_spawned || owner->spectator || owner->laggedents_count == 0) {
+		return false;
+	}
+
+	stale_limit = max(0.0, sv_antilag_projectile_owner_stale.value);
+	age = sv.time - owner->laggedents_time;
+	if (age < 0) {
+		age = 0;
+	}
+
+	if (stale_limit <= 0) {
+		return true;
+	}
+
+	return age <= stale_limit;
+}
+
+static float SV_AntilagProjectileBlendFraction(client_t *owner)
+{
+	float fraction;
+	double nudge_window;
+	double rewind_depth;
+
+	if (!owner) {
+		return 0.0f;
+	}
+
+	fraction = bound(0.0f, owner->laggedents_frac, 1.0f);
+	if (SV_AntilagProjectileModeResolved() != 1) {
+		return fraction;
+	}
+
+	nudge_window = max(0.0, sv_antilag_projectile_nudge.value);
+	if (nudge_window <= 0) {
+		return 0.0f;
+	}
+
+	rewind_depth = sv.time - owner->laggedents_time;
+	if (rewind_depth <= 0) {
+		return fraction;
+	}
+
+	return (float)bound(0.0, (fraction * (nudge_window / rewind_depth)), fraction);
+}
+
+static qbool SV_AntilagProjectileShouldUseLagged(edict_t *projectile, client_t **owner_out)
+{
+	client_t *owner;
+	int mode;
+
+	if (!projectile || SV_AntilagGameplayModeResolved() != 2) {
+		return false;
+	}
+
+	mode = SV_AntilagProjectileModeResolved();
+	if (mode == 0) {
+		return false;
+	}
+
+	if (!SV_AntilagProjectileOptInAllowed(projectile)) {
+		return false;
+	}
+
+	owner = SV_AntilagProjectileOwnerClient(projectile);
+	if (!SV_AntilagProjectileOwnerFresh(owner)) {
+		return false;
+	}
+
+	if (owner_out) {
+		*owner_out = owner;
+	}
+	return true;
+}
+
+int SV_AntilagApplyTracePolicy(int traceflags, edict_t *passedict, antilag_trace_policy_t policy)
+{
+	int flags = (traceflags & ~MOVE_LAGGED);
+	int antilag_mode;
+	int entnum;
+
+	if (!passedict) {
+		return flags;
+	}
+
+	antilag_mode = SV_AntilagGameplayModeResolved();
+	if (!antilag_mode) {
+		return flags;
+	}
+
+	entnum = passedict->e.entnum;
+	if (entnum >= 1 && entnum <= MAX_CLIENTS && svs.clients[entnum - 1].isBot) {
+		return flags;
+	}
+
+	switch (policy) {
+		case antilag_trace_hitscan:
+		case antilag_trace_melee:
+			// Phase 10 policy: rollout stage gates when gameplay rewind can be applied.
+			if (antilag_mode >= 1) {
+				flags |= MOVE_LAGGED;
+			}
+			break;
+		case antilag_trace_projectile:
+			if (SV_AntilagProjectileShouldUseLagged(passedict, NULL)) {
+				flags |= MOVE_LAGGED;
+			}
+			break;
+		default:
+			break;
+	}
+
+	return flags;
+}
+
+trace_t SV_AntilagTrace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int traceflags, edict_t *passedict, antilag_trace_policy_t policy)
+{
+	return SV_Trace(start, mins, maxs, end, SV_AntilagApplyTracePolicy(traceflags, passedict, policy), passedict);
+}
+
+static qbool SV_AntilagReplayVecEqual(vec3_t a, vec3_t b, float epsilon)
+{
+	return fabs(a[0] - b[0]) <= epsilon
+		&& fabs(a[1] - b[1]) <= epsilon
+		&& fabs(a[2] - b[2]) <= epsilon;
+}
+
+static int SV_AntilagReplayScenario(const char *name, const antilag_position_t *positions, int count, double target_time, vec3_t expected_origin, antilag_resolve_mode_t expected_mode)
+{
+	client_t test_client;
+	antilag_resolve_mode_t mode = antilag_resolve_none;
+	vec3_t resolved = { 0 };
+	int i;
+
+	memset(&test_client, 0, sizeof(test_client));
+	if (count <= 0 || count > MAX_ANTILAG_POSITIONS) {
+		Con_Printf("sv_antilag_replaytests: %s invalid test data count=%d\n", name, count);
+		return 1;
+	}
+
+	for (i = 0; i < count; ++i) {
+		test_client.antilag_positions[i] = positions[i];
+	}
+	test_client.antilag_position_count = count;
+	test_client.antilag_position_next = count % MAX_ANTILAG_POSITIONS;
+
+	if (!SV_AntilagResolvePosition(&test_client, target_time, resolved, &mode)) {
+		Con_Printf("sv_antilag_replaytests: %s failed to resolve history\n", name);
+		return 1;
+	}
+
+	if (mode != expected_mode) {
+		Con_Printf("sv_antilag_replaytests: %s mode mismatch got=%d expected=%d\n", name, (int)mode, (int)expected_mode);
+		return 1;
+	}
+
+	if (!SV_AntilagReplayVecEqual(resolved, expected_origin, 0.05f)) {
+		Con_Printf("sv_antilag_replaytests: %s origin mismatch got=(%0.2f %0.2f %0.2f) expected=(%0.2f %0.2f %0.2f)\n",
+			name,
+			resolved[0], resolved[1], resolved[2],
+			expected_origin[0], expected_origin[1], expected_origin[2]);
+		return 1;
+	}
+
+	return 0;
+}
+
+static int SV_AntilagReplayTracePolicyScenario(const char *name, int traceflags, edict_t *passedict, antilag_trace_policy_t policy, int rollout_stage, int antilag_mode, qbool attacker_is_bot, int expected_flags)
+{
+	float saved_antilag_mode;
+	int saved_antilag_mode_integer;
+	float saved_rollout_stage;
+	int saved_rollout_stage_integer;
+	qbool saved_is_bot = false;
+	int entnum = 0;
+	int resolved_flags;
+
+	saved_antilag_mode = sv_antilag.value;
+	saved_antilag_mode_integer = sv_antilag.integer;
+	saved_rollout_stage = sv_antilag_rollout_stage.value;
+	saved_rollout_stage_integer = sv_antilag_rollout_stage.integer;
+
+	sv_antilag.value = (float)bound(0, antilag_mode, 2);
+	sv_antilag.integer = bound(0, antilag_mode, 2);
+	sv_antilag_rollout_stage.value = (float)bound(0, rollout_stage, 3);
+	sv_antilag_rollout_stage.integer = bound(0, rollout_stage, 3);
+
+	if (passedict) {
+		entnum = passedict->e.entnum;
+		if (entnum >= 1 && entnum <= MAX_CLIENTS) {
+			saved_is_bot = svs.clients[entnum - 1].isBot;
+			svs.clients[entnum - 1].isBot = attacker_is_bot;
+		}
+	}
+
+	resolved_flags = SV_AntilagApplyTracePolicy(traceflags, passedict, policy);
+
+	if (passedict && entnum >= 1 && entnum <= MAX_CLIENTS) {
+		svs.clients[entnum - 1].isBot = saved_is_bot;
+	}
+	sv_antilag.value = saved_antilag_mode;
+	sv_antilag.integer = saved_antilag_mode_integer;
+	sv_antilag_rollout_stage.value = saved_rollout_stage;
+	sv_antilag_rollout_stage.integer = saved_rollout_stage_integer;
+
+	if (resolved_flags != expected_flags) {
+		Con_Printf("sv_antilag_replaytests: %s policy mismatch got=0x%X expected=0x%X\n",
+			name, resolved_flags, expected_flags);
+		return 1;
+	}
+
+	return 0;
+}
+
+static int SV_AntilagReplayProjectilePolicyScenario(const char *name, int traceflags, edict_t *projectile, int expected_flags)
+{
+	int resolved_flags = SV_AntilagApplyTracePolicy(traceflags, projectile, antilag_trace_projectile);
+
+	if (resolved_flags != expected_flags) {
+		Con_Printf("sv_antilag_replaytests: %s policy mismatch got=0x%X expected=0x%X\n",
+			name, resolved_flags, expected_flags);
+		return 1;
+	}
+
+	return 0;
+}
+
+static int SV_AntilagReplayFloatScenario(const char *name, float actual, float expected, float epsilon)
+{
+	if (fabs(actual - expected) > epsilon) {
+		Con_Printf("sv_antilag_replaytests: %s float mismatch got=%0.4f expected=%0.4f\n",
+			name, actual, expected);
+		return 1;
+	}
+
+	return 0;
+}
+
+int SV_AntilagRunReplayTests(void)
+{
+	int failures = 0;
+	antilag_position_t positions[4];
+	vec3_t expected;
+	edict_t policy_attacker;
+	int policy_baseflags;
+
+	memset(positions, 0, sizeof(positions));
+
+	// Peek shot: target exits cover between two snapshots.
+	positions[0].localtime = 10.000; VectorSet(positions[0].origin, 0, 0, 0);   positions[0].flags = ANTILAG_POSITION_ALIVE;
+	positions[1].localtime = 10.050; VectorSet(positions[1].origin, 32, 0, 0);  positions[1].flags = ANTILAG_POSITION_ALIVE;
+	positions[2].localtime = 10.100; VectorSet(positions[2].origin, 64, 0, 0);  positions[2].flags = ANTILAG_POSITION_ALIVE;
+	VectorSet(expected, 48, 0, 0);
+	failures += SV_AntilagReplayScenario("peek_shot", positions, 3, 10.075, expected, antilag_resolve_interpolate);
+
+	memset(positions, 0, sizeof(positions));
+	// Crossing strafe: fast side-crossing around shot time.
+	positions[0].localtime = 20.000; VectorSet(positions[0].origin, -80, 0, 0); positions[0].flags = ANTILAG_POSITION_ALIVE;
+	positions[1].localtime = 20.030; VectorSet(positions[1].origin, -20, 0, 0); positions[1].flags = ANTILAG_POSITION_ALIVE;
+	positions[2].localtime = 20.060; VectorSet(positions[2].origin,  20, 0, 0); positions[2].flags = ANTILAG_POSITION_ALIVE;
+	positions[3].localtime = 20.090; VectorSet(positions[3].origin,  80, 0, 0); positions[3].flags = ANTILAG_POSITION_ALIVE;
+	VectorSet(expected, 0, 0, 0);
+	failures += SV_AntilagReplayScenario("crossing_strafe", positions, 4, 20.045, expected, antilag_resolve_interpolate);
+
+	memset(positions, 0, sizeof(positions));
+	// Jitter target: uneven command/sample spacing should still interpolate deterministically.
+	positions[0].localtime = 30.000; VectorSet(positions[0].origin,  0, 0, 0);  positions[0].flags = ANTILAG_POSITION_ALIVE;
+	positions[1].localtime = 30.008; VectorSet(positions[1].origin,  8, 0, 0);  positions[1].flags = ANTILAG_POSITION_ALIVE;
+	positions[2].localtime = 30.041; VectorSet(positions[2].origin, 41, 0, 0);  positions[2].flags = ANTILAG_POSITION_ALIVE;
+	positions[3].localtime = 30.043; VectorSet(positions[3].origin, 43, 0, 0);  positions[3].flags = ANTILAG_POSITION_ALIVE;
+	VectorSet(expected, 24, 0, 0);
+	failures += SV_AntilagReplayScenario("jitter_target", positions, 4, 30.024, expected, antilag_resolve_interpolate);
+
+	memset(&policy_attacker, 0, sizeof(policy_attacker));
+	policy_attacker.e.entnum = 1;
+	policy_baseflags = MOVE_NOMONSTERS;
+
+	// Phase 6/10 policy parity: stage 1 enables hitscan/melee, stage 0 keeps instrumentation-only behavior.
+	failures += SV_AntilagReplayTracePolicyScenario("policy_hitscan_mode1", policy_baseflags, &policy_attacker, antilag_trace_hitscan, 1, 1, false, policy_baseflags | MOVE_LAGGED);
+	failures += SV_AntilagReplayTracePolicyScenario("policy_melee_mode1", policy_baseflags, &policy_attacker, antilag_trace_melee, 1, 1, false, policy_baseflags | MOVE_LAGGED);
+	failures += SV_AntilagReplayTracePolicyScenario("policy_hitscan_mode0", policy_baseflags | MOVE_LAGGED, &policy_attacker, antilag_trace_hitscan, 1, 0, false, policy_baseflags);
+	failures += SV_AntilagReplayTracePolicyScenario("policy_hitscan_rollout_stage0", policy_baseflags | MOVE_LAGGED, &policy_attacker, antilag_trace_hitscan, 0, 2, false, policy_baseflags);
+
+	// Projectile policy remains isolated from mode 1 and bot attackers always bypass lagged rewinds.
+	failures += SV_AntilagReplayTracePolicyScenario("policy_projectile_mode1_off", policy_baseflags, &policy_attacker, antilag_trace_projectile, 1, 1, false, policy_baseflags);
+	failures += SV_AntilagReplayTracePolicyScenario("policy_hitscan_bot_bypass", policy_baseflags, &policy_attacker, antilag_trace_hitscan, 3, 2, true, policy_baseflags);
+	failures += SV_AntilagReplayTracePolicyScenario("policy_melee_null_attacker", policy_baseflags | MOVE_LAGGED, NULL, antilag_trace_melee, 3, 2, false, policy_baseflags);
+
+	// Phase 7 projectile policy matrix: mode tiers, staleness, opt-in/allow/deny, and blend behavior.
+	if (sv.edicts && sv.num_edicts > 1 && pr_edict_size > 0) {
+		edict_t projectile;
+		entvars_t projectile_vars;
+		edict_t *owner_edict = EDICT_NUM(1);
+		client_t *owner_client = &svs.clients[0];
+		double saved_sv_time = sv.time;
+		float saved_antilag_mode = sv_antilag.value;
+		int saved_antilag_mode_integer = sv_antilag.integer;
+		float saved_rollout_stage = sv_antilag_rollout_stage.value;
+		int saved_rollout_stage_integer = sv_antilag_rollout_stage.integer;
+		float saved_playtest_signoff = sv_antilag_projectile_playtest_signoff.value;
+		int saved_playtest_signoff_integer = sv_antilag_projectile_playtest_signoff.integer;
+		float saved_full_admin = sv_antilag_projectile_full_admin.value;
+		int saved_full_admin_integer = sv_antilag_projectile_full_admin.integer;
+		float saved_projectile_mode = sv_antilag_projectile_mode.value;
+		int saved_projectile_mode_integer = sv_antilag_projectile_mode.integer;
+		float saved_optin_mode = sv_antilag_projectile_optin.value;
+		int saved_optin_mode_integer = sv_antilag_projectile_optin.integer;
+		float saved_stale_limit = sv_antilag_projectile_owner_stale.value;
+		float saved_nudge_window = sv_antilag_projectile_nudge.value;
+		sv_client_state_t saved_owner_state = owner_client->state;
+		int saved_owner_spectator = owner_client->spectator;
+		unsigned int saved_owner_laggedents_count = owner_client->laggedents_count;
+		float saved_owner_laggedents_frac = owner_client->laggedents_frac;
+		float saved_owner_laggedents_time = owner_client->laggedents_time;
+		qbool saved_owner_is_bot = owner_client->isBot;
+		char *saved_allow_list = sv_antilag_projectile_allow.string;
+		char *saved_deny_list = sv_antilag_projectile_deny.string;
+		char projectile_classname[] = "rocket";
+
+		memset(&projectile, 0, sizeof(projectile));
+		memset(&projectile_vars, 0, sizeof(projectile_vars));
+		projectile.v = &projectile_vars;
+		projectile.e.entnum = MAX_CLIENTS + 1;
+		projectile_vars.owner = EDICT_TO_PROG(owner_edict);
+		PR1_SetString(&projectile_vars.classname, projectile_classname);
+
+		sv.time = 100.0;
+		sv_antilag.value = 2.0f;
+		sv_antilag.integer = 2;
+		sv_antilag_rollout_stage.value = 3.0f;
+		sv_antilag_rollout_stage.integer = 3;
+		sv_antilag_projectile_playtest_signoff.value = 1.0f;
+		sv_antilag_projectile_playtest_signoff.integer = 1;
+		sv_antilag_projectile_full_admin.value = 1.0f;
+		sv_antilag_projectile_full_admin.integer = 1;
+		sv_antilag_projectile_mode.value = 2.0f;
+		sv_antilag_projectile_mode.integer = 2;
+		sv_antilag_projectile_optin.value = 0.0f;
+		sv_antilag_projectile_optin.integer = 0;
+		sv_antilag_projectile_owner_stale.value = 0.25f;
+		sv_antilag_projectile_nudge.value = 0.05f;
+		sv_antilag_projectile_allow.string = "";
+		sv_antilag_projectile_deny.string = "";
+		projectile_vars.flags = 0;
+		owner_client->state = cs_spawned;
+		owner_client->spectator = 0;
+		owner_client->laggedents_count = 1;
+		owner_client->laggedents_frac = 0.8f;
+		owner_client->laggedents_time = (float)(sv.time - 0.2);
+		owner_client->isBot = false;
+
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_mode2_full", policy_baseflags, &projectile, policy_baseflags | MOVE_LAGGED);
+
+		sv_antilag_projectile_mode.value = 1.0f;
+		sv_antilag_projectile_mode.integer = 1;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_mode1_limited", policy_baseflags, &projectile, policy_baseflags | MOVE_LAGGED);
+		failures += SV_AntilagReplayFloatScenario("policy_projectile_blend_mode1_nudged", SV_AntilagProjectileBlendFraction(owner_client), 0.20f, 0.001f);
+
+		sv_antilag_rollout_stage.value = 2.0f;
+		sv_antilag_rollout_stage.integer = 2;
+		sv_antilag_projectile_playtest_signoff.value = 0.0f;
+		sv_antilag_projectile_playtest_signoff.integer = 0;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_rollout_stage2_no_signoff", policy_baseflags, &projectile, policy_baseflags);
+		sv_antilag_projectile_playtest_signoff.value = 1.0f;
+		sv_antilag_projectile_playtest_signoff.integer = 1;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_rollout_stage2_signoff", policy_baseflags, &projectile, policy_baseflags | MOVE_LAGGED);
+
+		sv_antilag_rollout_stage.value = 0.0f;
+		sv_antilag_rollout_stage.integer = 0;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_rollout_stage0_off", policy_baseflags, &projectile, policy_baseflags);
+		sv_antilag_rollout_stage.value = 3.0f;
+		sv_antilag_rollout_stage.integer = 3;
+
+		sv_antilag_projectile_mode.value = 2.0f;
+		sv_antilag_projectile_mode.integer = 2;
+		sv_antilag_projectile_full_admin.value = 0.0f;
+		sv_antilag_projectile_full_admin.integer = 0;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_mode2_admin_gate", policy_baseflags, &projectile, policy_baseflags | MOVE_LAGGED);
+		failures += SV_AntilagReplayFloatScenario("policy_projectile_mode2_admin_gate_blend", SV_AntilagProjectileBlendFraction(owner_client), 0.20f, 0.001f);
+		sv_antilag_projectile_full_admin.value = 1.0f;
+		sv_antilag_projectile_full_admin.integer = 1;
+		failures += SV_AntilagReplayFloatScenario("policy_projectile_blend_mode2_full", SV_AntilagProjectileBlendFraction(owner_client), 0.80f, 0.001f);
+
+		sv_antilag_projectile_mode.value = 0.0f;
+		sv_antilag_projectile_mode.integer = 0;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_mode0_off", policy_baseflags | MOVE_LAGGED, &projectile, policy_baseflags);
+
+		sv_antilag_projectile_mode.value = 2.0f;
+		sv_antilag_projectile_mode.integer = 2;
+		owner_client->laggedents_time = (float)(sv.time - 1.0);
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_owner_stale", policy_baseflags, &projectile, policy_baseflags);
+
+		sv_antilag_projectile_owner_stale.value = 0.0f;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_owner_stale_unbounded", policy_baseflags, &projectile, policy_baseflags | MOVE_LAGGED);
+		sv_antilag_projectile_owner_stale.value = 0.25f;
+		owner_client->laggedents_time = (float)(sv.time - 0.2);
+
+		sv_antilag_projectile_optin.value = 1.0f;
+		sv_antilag_projectile_optin.integer = 1;
+		projectile_vars.flags = 0;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_optin1_requires_optin", policy_baseflags, &projectile, policy_baseflags);
+
+		projectile_vars.flags = FL_LAGGEDMOVE;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_optin1_flag", policy_baseflags, &projectile, policy_baseflags | MOVE_LAGGED);
+
+		projectile_vars.flags = 0;
+		sv_antilag_projectile_allow.string = "rocket";
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_optin1_allow", policy_baseflags, &projectile, policy_baseflags | MOVE_LAGGED);
+
+		sv_antilag_projectile_optin.value = 2.0f;
+		sv_antilag_projectile_optin.integer = 2;
+		sv_antilag_projectile_allow.string = "";
+		projectile_vars.flags = FL_LAGGEDMOVE;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_optin2_flag_only_off", policy_baseflags, &projectile, policy_baseflags);
+
+		projectile_vars.flags = 0;
+		sv_antilag_projectile_allow.string = "rocket";
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_optin2_allow", policy_baseflags, &projectile, policy_baseflags | MOVE_LAGGED);
+
+		sv_antilag_projectile_optin.value = 0.0f;
+		sv_antilag_projectile_optin.integer = 0;
+		sv_antilag_projectile_allow.string = "rocket";
+		sv_antilag_projectile_deny.string = "rocket";
+		projectile_vars.flags = FL_LAGGEDMOVE;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_deny_overrides_allow", policy_baseflags, &projectile, policy_baseflags);
+
+		projectile_vars.flags = 0;
+		sv_antilag_projectile_allow.string = "";
+		sv_antilag_projectile_deny.string = "";
+		owner_client->isBot = true;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_owner_bot_bypass", policy_baseflags, &projectile, policy_baseflags);
+
+		owner_client->isBot = false;
+		owner_client->state = cs_connected;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_owner_state_gate", policy_baseflags, &projectile, policy_baseflags);
+
+		owner_client->state = cs_spawned;
+		owner_client->spectator = 1;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_owner_spectator_gate", policy_baseflags, &projectile, policy_baseflags);
+
+		owner_client->spectator = 0;
+		owner_client->laggedents_count = 0;
+		failures += SV_AntilagReplayProjectilePolicyScenario("policy_projectile_owner_no_history", policy_baseflags, &projectile, policy_baseflags);
+
+		owner_client->laggedents_count = 1;
+		owner_client->laggedents_frac = 0.8f;
+		owner_client->laggedents_time = (float)sv.time;
+		sv_antilag_projectile_mode.value = 1.0f;
+		sv_antilag_projectile_mode.integer = 1;
+		sv_antilag_projectile_nudge.value = 0.0f;
+		failures += SV_AntilagReplayFloatScenario("policy_projectile_blend_mode1_zero_nudge", SV_AntilagProjectileBlendFraction(owner_client), 0.0f, 0.001f);
+		sv_antilag_projectile_nudge.value = 0.05f;
+		failures += SV_AntilagReplayFloatScenario("policy_projectile_blend_nonpositive_depth", SV_AntilagProjectileBlendFraction(owner_client), 0.8f, 0.001f);
+
+		sv.time = saved_sv_time;
+		sv_antilag.value = saved_antilag_mode;
+		sv_antilag.integer = saved_antilag_mode_integer;
+		sv_antilag_rollout_stage.value = saved_rollout_stage;
+		sv_antilag_rollout_stage.integer = saved_rollout_stage_integer;
+		sv_antilag_projectile_playtest_signoff.value = saved_playtest_signoff;
+		sv_antilag_projectile_playtest_signoff.integer = saved_playtest_signoff_integer;
+		sv_antilag_projectile_full_admin.value = saved_full_admin;
+		sv_antilag_projectile_full_admin.integer = saved_full_admin_integer;
+		sv_antilag_projectile_mode.value = saved_projectile_mode;
+		sv_antilag_projectile_mode.integer = saved_projectile_mode_integer;
+		sv_antilag_projectile_optin.value = saved_optin_mode;
+		sv_antilag_projectile_optin.integer = saved_optin_mode_integer;
+		sv_antilag_projectile_owner_stale.value = saved_stale_limit;
+		sv_antilag_projectile_nudge.value = saved_nudge_window;
+		sv_antilag_projectile_allow.string = saved_allow_list;
+		sv_antilag_projectile_deny.string = saved_deny_list;
+		owner_client->state = saved_owner_state;
+		owner_client->spectator = saved_owner_spectator;
+		owner_client->laggedents_count = saved_owner_laggedents_count;
+		owner_client->laggedents_frac = saved_owner_laggedents_frac;
+		owner_client->laggedents_time = saved_owner_laggedents_time;
+		owner_client->isBot = saved_owner_is_bot;
+	}
+	else {
+		Con_Printf("sv_antilag_replaytests: skipped phase7 projectile policy checks (server edicts unavailable)\n");
+	}
+
+	if (failures == 0) {
+		Con_Printf("sv_antilag_replaytests: all deterministic replay scenarios passed\n");
+	}
+
+	return failures;
+}
+
+static float SV_AntilagBoundsRadius(vec3_t mins, vec3_t maxs)
+{
+	vec3_t extent;
+
+	extent[0] = max(fabs(mins[0]), fabs(maxs[0]));
+	extent[1] = max(fabs(mins[1]), fabs(maxs[1]));
+	extent[2] = max(fabs(mins[2]), fabs(maxs[2]));
+
+	return VectorLength(extent);
+}
+
+static float SV_AntilagPointToSegmentDistanceSq(vec3_t point, vec3_t start, vec3_t end)
+{
+	vec3_t segment, to_point, closest, diff;
+	float segment_len_sq;
+	float t;
+
+	VectorSubtract(end, start, segment);
+	segment_len_sq = DotProduct(segment, segment);
+	if (segment_len_sq <= 0) {
+		VectorSubtract(point, start, diff);
+		return DotProduct(diff, diff);
+	}
+
+	VectorSubtract(point, start, to_point);
+	t = DotProduct(to_point, segment) / segment_len_sq;
+	t = bound(0, t, 1);
+	VectorMA(start, t, segment, closest);
+	VectorSubtract(point, closest, diff);
+	return DotProduct(diff, diff);
+}
+
+static qbool SV_AntilagPassesRayNarrow(moveclip_t *clip, edict_t *touch, vec3_t lagged_origin)
+{
+	vec3_t center_offset, center;
+	float target_radius;
+	float corridor_radius;
+	float distance_sq;
+
+	if (!w.ray_narrow) {
+		return true;
+	}
+
+	VectorAdd(touch->v->mins, touch->v->maxs, center_offset);
+	VectorScale(center_offset, 0.5f, center_offset);
+	VectorAdd(lagged_origin, center_offset, center);
+
+	target_radius = SV_AntilagBoundsRadius(touch->v->mins, touch->v->maxs);
+	corridor_radius = target_radius + w.move_radius + w.ray_narrow_pad;
+	distance_sq = SV_AntilagPointToSegmentDistanceSq(center, clip->start, clip->end);
+
+	return distance_sq <= corridor_radius * corridor_radius;
 }
 
 void SV_AntilagClipSetUp ( areanode_t *node, moveclip_t *clip )
@@ -630,6 +1529,10 @@ void SV_AntilagClipSetUp ( areanode_t *node, moveclip_t *clip )
 	int entnum = passedict->e.entnum;
 
 	clip->type &= ~MOVE_LAGGED;
+	w.owner = NULL;
+	w.ray_narrow = false;
+	w.ray_narrow_pad = max(0.0f, sv_antilag_ray_narrow_pad.value);
+	w.move_radius = SV_AntilagBoundsRadius(clip->mins2, clip->maxs2);
 
 	if (entnum && entnum <= MAX_CLIENTS && !svs.clients[entnum - 1].isBot)
 	{
@@ -637,23 +1540,32 @@ void SV_AntilagClipSetUp ( areanode_t *node, moveclip_t *clip )
 		w.lagents = svs.clients[entnum - 1].laggedents;
 		w.maxlagents = svs.clients[entnum - 1].laggedents_count;
 		w.lagentsfrac = svs.clients[entnum - 1].laggedents_frac;
+		w.owner = &svs.clients[entnum - 1];
 	}
-	else if (passedict->v->owner)
+	else
 	{
-		int owner = PROG_TO_EDICT(passedict->v->owner)->e.entnum;
+		client_t *owner = NULL;
 
-		if (owner && owner <= MAX_CLIENTS && !svs.clients[owner - 1].isBot)
+		if (SV_AntilagProjectileShouldUseLagged(passedict, &owner))
 		{
 			clip->type |= MOVE_LAGGED;
-			w.lagents = svs.clients[owner - 1].laggedents;
-			w.maxlagents = svs.clients[owner - 1].laggedents_count;
-			w.lagentsfrac = svs.clients[owner - 1].laggedents_frac;
+			w.lagents = owner->laggedents;
+			w.maxlagents = owner->laggedents_count;
+			w.lagentsfrac = SV_AntilagProjectileBlendFraction(owner);
+			w.owner = owner;
 		}
 	}
+
+	w.ray_narrow = (sv_antilag_ray_narrow.integer != 0);
 }
 
 void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 {
+	double perf_start = Sys_DoubleTime();
+	unsigned int candidates = 0;
+	unsigned int broadphase_rejects = 0;
+	unsigned int ray_rejects = 0;
+	unsigned int trace_tests = 0;
 	trace_t trace;
 	edict_t *touch;
 	vec3_t lp;
@@ -662,7 +1574,7 @@ void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 	for (i = 0; i < w.maxlagents; i++)
 	{
 		if (clip->trace.allsolid)
-			return; // return!!!
+			break;
 
 		if (!w.lagents[i].present)
 			continue;
@@ -678,6 +1590,7 @@ void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 		if ((clip->type & MOVE_NOMONSTERS) && touch->v->solid != SOLID_BSP)
 			continue;
 
+		candidates++;
 		VectorInterpolate(touch->v->origin, w.lagentsfrac, w.lagents[i].laggedpos, lp);
 
 		if (   clip->boxmins[0] > lp[0]+touch->v->maxs[0]
@@ -686,7 +1599,15 @@ void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 			|| clip->boxmaxs[0] < lp[0]+touch->v->mins[0]
 			|| clip->boxmaxs[1] < lp[1]+touch->v->mins[1]
 			|| clip->boxmaxs[2] < lp[2]+touch->v->mins[2] )
+		{
+			broadphase_rejects++;
 			continue;
+		}
+
+		if (!SV_AntilagPassesRayNarrow(clip, touch, lp)) {
+			ray_rejects++;
+			continue;
+		}
 
 		if (clip->passedict && clip->passedict->v->size[0] && !touch->v->size[0])
 			continue;	// points never interact
@@ -703,6 +1624,7 @@ void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 			trace = SV_ClipMoveToEntity (touch, &lp, clip->start, clip->mins2, clip->maxs2, clip->end);
 		else
 			trace = SV_ClipMoveToEntity (touch, &lp, clip->start, clip->mins, clip->maxs, clip->end);
+		trace_tests++;
 
 		// qqshka: I have NO idea why we keep startsolid but let do it.
 
@@ -719,6 +1641,14 @@ void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 			clip->trace = trace;
 		}
 	}
+
+	if (w.owner) {
+		w.owner->antilag_clip_candidates += candidates;
+		w.owner->antilag_clip_broadphase_rejects += broadphase_rejects;
+		w.owner->antilag_clip_ray_rejects += ray_rejects;
+		w.owner->antilag_clip_traces += trace_tests;
+	}
+	SV_AntilagPerfAddClip(Sys_DoubleTime() - perf_start, candidates, broadphase_rejects, ray_rejects, trace_tests);
 }
 
 /*

--- a/src/sv_world.h
+++ b/src/sv_world.h
@@ -28,6 +28,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define MOVE_LAGGED		64	//trace touches current last-known-state, instead of actual ents (just affects players for now)
 // }
 
+typedef enum {
+	antilag_trace_hitscan = 0,
+	antilag_trace_melee,
+	antilag_trace_projectile
+} antilag_trace_policy_t;
+
 typedef struct areanode_s
 {
 	int		axis;		// -1 = leaf node
@@ -81,5 +87,8 @@ trace_t SV_Trace (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int type, 
 int SV_AreaEdicts (vec3_t mins, vec3_t maxs, edict_t **edicts, int max_edicts, int area);
 
 void SV_AntilagReset (edict_t *ent);
+int SV_AntilagApplyTracePolicy(int traceflags, edict_t *passedict, antilag_trace_policy_t policy);
+trace_t SV_AntilagTrace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int traceflags, edict_t *passedict, antilag_trace_policy_t policy);
+int SV_AntilagRunReplayTests(void);
 
 #endif /* !__WORLD_H__ */

--- a/tests/antilag/phase9_golden.csv
+++ b/tests/antilag/phase9_golden.csv
@@ -1,0 +1,21 @@
+# Phase 9 anti-lag regression golden outcomes
+# Network format: network,name,target_time,reason_flags
+# Hitreg format: hitreg,name,mode,x,y,z
+network,steady_latency,9.900000,0
+network,jitter_spike,19.930000,0
+network,loss_burst,29.875000,0
+network,reorder_fallback,39.957000,8
+network,clamp_maxunlag,49.950000,24
+network,no_pred_baseline,59.933000,0
+network,msec_clamp_fallback,69.935000,8
+network,cmd_delta_guard_disabled,79.750000,16
+network,heavy_loss_window,89.759000,0
+network,high_jitter_no_fallback,99.925000,0
+hitreg,peek_shot,interpolate,48.0,0.0,0.0
+hitreg,crossing_strafe,interpolate,0.0,0.0,0.0
+hitreg,jitter_target,interpolate,24.0,0.0,0.0
+hitreg,discontinuity_snap,newest,50.0,0.0,0.0
+hitreg,discontinuity_snap_oldest,oldest,0.0,0.0,0.0
+hitreg,out_of_window_oldest,oldest,-10.0,0.0,0.0
+hitreg,out_of_window_newest,newest,55.0,0.0,0.0
+hitreg,single_sample,single,123.0,4.0,-7.0

--- a/tests/antilag/phase9_network_scenarios.csv
+++ b/tests/antilag/phase9_network_scenarios.csv
@@ -1,0 +1,11 @@
+# name,sv_time,frame_sv_time,ping_ms,net_drop,last_msec,oldest_msec,old_msec,new_msec,sv_maxfps,max_cmd_delta,max_unlag,no_pred
+steady_latency,10.000,9.900,100,0,13,13,13,13,77,0.20,0.25,0
+jitter_spike,20.000,19.910,80,0,15,15,15,40,77,0.20,0.25,0
+loss_burst,30.000,29.800,120,5,15,14,16,17,77,0.20,0.25,0
+reorder_fallback,40.000,39.200,60,0,13,13,13,13,77,0.20,0.25,0
+clamp_maxunlag,50.000,49.400,200,0,13,13,13,13,77,0.20,0.05,0
+no_pred_baseline,60.000,59.920,100,0,13,13,13,13,77,0.20,0.25,1
+msec_clamp_fallback,70.000,69.700,90,0,120,120,120,120,77,0.20,0.25,0
+cmd_delta_guard_disabled,80.000,79.200,60,0,13,13,13,13,77,0.00,0.25,0
+heavy_loss_window,90.000,89.600,140,10,16,14,17,18,77,0.20,0.25,0
+high_jitter_no_fallback,100.000,99.900,50,0,13,13,13,45,77,0.25,0.25,0

--- a/tests/antilag/phase9_regression.c
+++ b/tests/antilag/phase9_regression.c
@@ -1,0 +1,763 @@
+#include <ctype.h>
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_NETWORK_CASES 64
+#define MAX_NETWORK_RESULTS 64
+#define MAX_HITREG_RESULTS 24
+#define MAX_GOLDEN_ENTRIES 128
+#define LINE_BUFFER 1024
+
+#define MVD_PEXT1_ANTILAG_REASON_DISABLED      (1u << 0)
+#define MVD_PEXT1_ANTILAG_REASON_ENABLED       (1u << 1)
+#define MVD_PEXT1_ANTILAG_REASON_PING_REJECT   (1u << 2)
+#define MVD_PEXT1_ANTILAG_REASON_CMD_FALLBACK  (1u << 3)
+#define MVD_PEXT1_ANTILAG_REASON_CLAMP_MAXUNLAG (1u << 4)
+#define MVD_PEXT1_ANTILAG_REASON_CLAMP_FUTURE  (1u << 5)
+
+#define ANTILAG_POSITION_DISCONTINUITY (1u << 0)
+#define ANTILAG_POSITION_ALIVE         (1u << 1)
+
+typedef enum {
+	resolve_none = 0,
+	resolve_single,
+	resolve_oldest,
+	resolve_newest,
+	resolve_discontinuity,
+	resolve_interpolate,
+	resolve_bad_interval
+} resolve_mode_t;
+
+typedef struct {
+	char name[64];
+	double sv_time;
+	double frame_sv_time;
+	double ping_ms;
+	int net_drop;
+	int last_msec;
+	int oldest_msec;
+	int old_msec;
+	int new_msec;
+	double sv_maxfps;
+	double max_cmd_delta;
+	double max_unlag;
+	int no_pred;
+} network_case_t;
+
+typedef struct {
+	char name[64];
+	double target_time;
+	unsigned int reason_flags;
+} network_result_t;
+
+typedef struct {
+	double localtime;
+	double origin[3];
+	unsigned int flags;
+} hitreg_sample_t;
+
+typedef struct {
+	char name[64];
+	resolve_mode_t mode;
+	double origin[3];
+} hitreg_result_t;
+
+typedef struct {
+	char kind[16];
+	char name[64];
+	double target_time;
+	unsigned int reason_flags;
+	char mode[32];
+	double origin[3];
+} golden_entry_t;
+
+static int ieq(const char *a, const char *b);
+
+static int network_name_exists(const network_case_t *cases, int count, const char *name)
+{
+	int i;
+
+	for (i = 0; i < count; ++i) {
+		if (ieq(cases[i].name, name)) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static int golden_name_exists(const golden_entry_t *entries, int count, const char *kind, const char *name)
+{
+	int i;
+
+	for (i = 0; i < count; ++i) {
+		if (ieq(entries[i].kind, kind) && ieq(entries[i].name, name)) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static double clampd(double minv, double v, double maxv)
+{
+	if (v < minv) {
+		return minv;
+	}
+	if (v > maxv) {
+		return maxv;
+	}
+	return v;
+}
+
+static double maxd(double a, double b)
+{
+	return a > b ? a : b;
+}
+
+static double mind(double a, double b)
+{
+	return a < b ? a : b;
+}
+
+static int ieq(const char *a, const char *b)
+{
+	for (; *a && *b; ++a, ++b) {
+		if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) {
+			return 0;
+		}
+	}
+	return (*a == '\0' && *b == '\0');
+}
+
+static const char *mode_to_string(resolve_mode_t mode)
+{
+	switch (mode) {
+	case resolve_single:
+		return "single";
+	case resolve_oldest:
+		return "oldest";
+	case resolve_newest:
+		return "newest";
+	case resolve_discontinuity:
+		return "discontinuity";
+	case resolve_interpolate:
+		return "interpolate";
+	case resolve_bad_interval:
+		return "bad_interval";
+	default:
+		return "none";
+	}
+}
+
+static int parse_csv_line(char *line, char *fields[], int max_fields)
+{
+	int count = 0;
+	char *cursor = line;
+
+	while (*cursor && count < max_fields) {
+		char *start;
+
+		while (*cursor == ' ' || *cursor == '\t') {
+			++cursor;
+		}
+		start = cursor;
+		while (*cursor && *cursor != ',') {
+			++cursor;
+		}
+		if (*cursor == ',') {
+			*cursor = '\0';
+			++cursor;
+		}
+		while (*start && isspace((unsigned char)start[strlen(start) - 1])) {
+			start[strlen(start) - 1] = '\0';
+		}
+		fields[count++] = start;
+	}
+
+	return count;
+}
+
+static int load_network_cases(const char *path, network_case_t *cases, int max_cases)
+{
+	FILE *f;
+	char line[LINE_BUFFER];
+	int count = 0;
+
+	f = fopen(path, "rb");
+	if (!f) {
+		fprintf(stderr, "phase9: failed to open network scenario file %s (%s)\n", path, strerror(errno));
+		return -1;
+	}
+
+	while (fgets(line, sizeof(line), f)) {
+		char *fields[16];
+		int nfields;
+		network_case_t *out;
+
+		if (line[0] == '#' || line[0] == '\n' || line[0] == '\r') {
+			continue;
+		}
+
+		line[strcspn(line, "\r\n")] = '\0';
+		nfields = parse_csv_line(line, fields, 16);
+		if (nfields != 13) {
+			fprintf(stderr, "phase9: invalid network scenario row (need 13 fields): %s\n", line);
+			fclose(f);
+			return -1;
+		}
+		if (!fields[0][0]) {
+			fprintf(stderr, "phase9: network scenario name cannot be empty\n");
+			fclose(f);
+			return -1;
+		}
+		if (count >= max_cases) {
+			fprintf(stderr, "phase9: too many network scenarios (max %d)\n", max_cases);
+			fclose(f);
+			return -1;
+		}
+		if (network_name_exists(cases, count, fields[0])) {
+			fprintf(stderr, "phase9: duplicate network scenario name: %s\n", fields[0]);
+			fclose(f);
+			return -1;
+		}
+
+		out = &cases[count++];
+		memset(out, 0, sizeof(*out));
+		strncpy(out->name, fields[0], sizeof(out->name) - 1);
+		out->sv_time = atof(fields[1]);
+		out->frame_sv_time = atof(fields[2]);
+		out->ping_ms = atof(fields[3]);
+		out->net_drop = atoi(fields[4]);
+		out->last_msec = atoi(fields[5]);
+		out->oldest_msec = atoi(fields[6]);
+		out->old_msec = atoi(fields[7]);
+		out->new_msec = atoi(fields[8]);
+		out->sv_maxfps = atof(fields[9]);
+		out->max_cmd_delta = atof(fields[10]);
+		out->max_unlag = atof(fields[11]);
+		out->no_pred = atoi(fields[12]);
+	}
+
+	fclose(f);
+	return count;
+}
+
+static int load_golden_entries(const char *path, golden_entry_t *entries, int max_entries)
+{
+	FILE *f;
+	char line[LINE_BUFFER];
+	int count = 0;
+
+	f = fopen(path, "rb");
+	if (!f) {
+		fprintf(stderr, "phase9: failed to open golden file %s (%s)\n", path, strerror(errno));
+		return -1;
+	}
+
+	while (fgets(line, sizeof(line), f)) {
+		char *fields[8];
+		int nfields;
+		golden_entry_t *out;
+
+		if (line[0] == '#' || line[0] == '\n' || line[0] == '\r') {
+			continue;
+		}
+
+		line[strcspn(line, "\r\n")] = '\0';
+		nfields = parse_csv_line(line, fields, 8);
+		if (nfields < 4) {
+			fprintf(stderr, "phase9: invalid golden row: %s\n", line);
+			fclose(f);
+			return -1;
+		}
+		if (count >= max_entries) {
+			fprintf(stderr, "phase9: too many golden rows (max %d)\n", max_entries);
+			fclose(f);
+			return -1;
+		}
+
+		out = &entries[count++];
+		memset(out, 0, sizeof(*out));
+		strncpy(out->kind, fields[0], sizeof(out->kind) - 1);
+		strncpy(out->name, fields[1], sizeof(out->name) - 1);
+		if (!out->kind[0] || !out->name[0]) {
+			fprintf(stderr, "phase9: golden row requires non-empty kind and name: %s\n", line);
+			fclose(f);
+			return -1;
+		}
+		if (golden_name_exists(entries, count - 1, out->kind, out->name)) {
+			fprintf(stderr, "phase9: duplicate golden row for %s/%s\n", out->kind, out->name);
+			fclose(f);
+			return -1;
+		}
+
+		if (ieq(out->kind, "network")) {
+			if (nfields != 4) {
+				fprintf(stderr, "phase9: network golden row must have 4 fields: %s\n", line);
+				fclose(f);
+				return -1;
+			}
+			out->target_time = atof(fields[2]);
+			out->reason_flags = (unsigned int)strtoul(fields[3], NULL, 10);
+		}
+		else if (ieq(out->kind, "hitreg")) {
+			if (nfields != 6) {
+				fprintf(stderr, "phase9: hitreg golden row must have 6 fields: %s\n", line);
+				fclose(f);
+				return -1;
+			}
+			strncpy(out->mode, fields[2], sizeof(out->mode) - 1);
+			out->origin[0] = atof(fields[3]);
+			out->origin[1] = atof(fields[4]);
+			out->origin[2] = atof(fields[5]);
+		}
+		else {
+			fprintf(stderr, "phase9: unknown golden kind %s\n", out->kind);
+			fclose(f);
+			return -1;
+		}
+	}
+
+	fclose(f);
+	return count;
+}
+
+static double safe_cmd_msec(int msec)
+{
+	return clampd(0.0, (double)msec, 50.0);
+}
+
+static double command_window_seconds(const network_case_t *c)
+{
+	double command_window = 0.0;
+	int net_drop = c->net_drop;
+
+	if (net_drop < 20 && net_drop > 2) {
+		command_window += (net_drop - 2) * safe_cmd_msec(c->last_msec);
+	}
+	if (net_drop > 1) {
+		command_window += safe_cmd_msec(c->oldest_msec);
+	}
+	if (net_drop > 0) {
+		command_window += safe_cmd_msec(c->old_msec);
+	}
+	command_window += safe_cmd_msec(c->new_msec);
+
+	return command_window * 0.001;
+}
+
+static double interpolation_delay(const network_case_t *c)
+{
+	const double max_prediction = 0.02;
+	double max_physfps = c->sv_maxfps;
+	double cmd_interval = safe_cmd_msec(c->new_msec) * 0.001;
+
+	if (c->no_pred) {
+		return 0.0;
+	}
+
+	if (max_physfps < 20.0 || max_physfps > 1000.0) {
+		max_physfps = 77.0;
+	}
+	if (cmd_interval <= 0) {
+		cmd_interval = 1.0 / max_physfps;
+	}
+
+	return mind(max_prediction, maxd(1.0 / max_physfps, cmd_interval));
+}
+
+static void compute_network_result(const network_case_t *c, network_result_t *out)
+{
+	double rtt = maxd(0.0, c->ping_ms * 0.001);
+	double one_way = rtt * 0.5;
+	double interp = interpolation_delay(c);
+	double command_window = command_window_seconds(c);
+	double command_time = c->frame_sv_time + command_window;
+	double command_target = command_time - interp;
+	double latency_target = c->sv_time - one_way - interp;
+	double target_time = command_target;
+	unsigned int reason_flags = 0;
+
+	if (command_time > c->sv_time) {
+		command_time = c->sv_time;
+		command_target = command_time - interp;
+	}
+
+	if (c->max_cmd_delta > 0.0 && fabs(command_target - latency_target) > c->max_cmd_delta) {
+		target_time = latency_target;
+		reason_flags |= MVD_PEXT1_ANTILAG_REASON_CMD_FALLBACK;
+	}
+
+	if (c->max_unlag > 0.0 && target_time < c->sv_time - c->max_unlag) {
+		target_time = c->sv_time - c->max_unlag;
+		reason_flags |= MVD_PEXT1_ANTILAG_REASON_CLAMP_MAXUNLAG;
+	}
+	if (target_time > c->sv_time) {
+		target_time = c->sv_time;
+		reason_flags |= MVD_PEXT1_ANTILAG_REASON_CLAMP_FUTURE;
+	}
+
+	memset(out, 0, sizeof(*out));
+	strncpy(out->name, c->name, sizeof(out->name) - 1);
+	out->target_time = target_time;
+	out->reason_flags = reason_flags;
+}
+
+static int resolve_position(const hitreg_sample_t *samples, int count, double target_time, double out_origin[3], resolve_mode_t *mode)
+{
+	const hitreg_sample_t *base;
+	const hitreg_sample_t *interp;
+	const hitreg_sample_t *oldest;
+	const hitreg_sample_t *newest;
+	const hitreg_sample_t *previous;
+	int i;
+	double span;
+	double factor;
+
+	if (!samples || count <= 0) {
+		return 0;
+	}
+
+	oldest = &samples[0];
+	newest = &samples[count - 1];
+	base = oldest;
+	interp = oldest;
+	if (mode) {
+		*mode = resolve_none;
+	}
+
+	if (count == 1 || target_time <= oldest->localtime) {
+		base = interp = oldest;
+	}
+	else if (target_time >= newest->localtime) {
+		base = interp = newest;
+	}
+	else {
+		previous = oldest;
+		for (i = 1; i < count; ++i) {
+			const hitreg_sample_t *current = &samples[i];
+
+			if (target_time <= current->localtime) {
+				if ((previous->flags | current->flags) & ANTILAG_POSITION_DISCONTINUITY) {
+					if (fabs(target_time - previous->localtime) <= fabs(current->localtime - target_time)) {
+						base = interp = previous;
+					}
+					else {
+						base = interp = current;
+					}
+				}
+				else {
+					base = previous;
+					interp = current;
+				}
+				break;
+			}
+			previous = current;
+		}
+	}
+
+	if (base == interp) {
+		out_origin[0] = base->origin[0];
+		out_origin[1] = base->origin[1];
+		out_origin[2] = base->origin[2];
+		if (mode) {
+			if (count == 1) {
+				*mode = resolve_single;
+			}
+			else if (base == oldest) {
+				*mode = resolve_oldest;
+			}
+			else if (base == newest) {
+				*mode = resolve_newest;
+			}
+			else {
+				*mode = resolve_discontinuity;
+			}
+		}
+		return 1;
+	}
+
+	span = interp->localtime - base->localtime;
+	if (span <= 0.0 || isnan(span)) {
+		if (fabs(target_time - base->localtime) <= fabs(interp->localtime - target_time)) {
+			out_origin[0] = base->origin[0];
+			out_origin[1] = base->origin[1];
+			out_origin[2] = base->origin[2];
+		}
+		else {
+			out_origin[0] = interp->origin[0];
+			out_origin[1] = interp->origin[1];
+			out_origin[2] = interp->origin[2];
+		}
+		if (mode) {
+			*mode = resolve_bad_interval;
+		}
+		return 1;
+	}
+
+	factor = (target_time - base->localtime) / span;
+	if (isnan(factor)) {
+		factor = 0.0;
+	}
+	factor = clampd(0.0, factor, 1.0);
+	out_origin[0] = base->origin[0] + (interp->origin[0] - base->origin[0]) * factor;
+	out_origin[1] = base->origin[1] + (interp->origin[1] - base->origin[1]) * factor;
+	out_origin[2] = base->origin[2] + (interp->origin[2] - base->origin[2]) * factor;
+	if (mode) {
+		*mode = resolve_interpolate;
+	}
+	return 1;
+}
+
+static int run_hitreg_scenarios(hitreg_result_t *out, int max_out)
+{
+	hitreg_sample_t samples[4];
+	double resolved[3];
+	resolve_mode_t mode = resolve_none;
+	int count = 0;
+
+	if (max_out < 8) {
+		return -1;
+	}
+
+	memset(samples, 0, sizeof(samples));
+	samples[0].localtime = 10.000; samples[0].origin[0] = 0;  samples[0].flags = ANTILAG_POSITION_ALIVE;
+	samples[1].localtime = 10.050; samples[1].origin[0] = 32; samples[1].flags = ANTILAG_POSITION_ALIVE;
+	samples[2].localtime = 10.100; samples[2].origin[0] = 64; samples[2].flags = ANTILAG_POSITION_ALIVE;
+	resolve_position(samples, 3, 10.075, resolved, &mode);
+	strncpy(out[count].name, "peek_shot", sizeof(out[count].name) - 1);
+	out[count].mode = mode;
+	out[count].origin[0] = resolved[0];
+	out[count].origin[1] = resolved[1];
+	out[count].origin[2] = resolved[2];
+	count++;
+
+	memset(samples, 0, sizeof(samples));
+	samples[0].localtime = 20.000; samples[0].origin[0] = -80; samples[0].flags = ANTILAG_POSITION_ALIVE;
+	samples[1].localtime = 20.030; samples[1].origin[0] = -20; samples[1].flags = ANTILAG_POSITION_ALIVE;
+	samples[2].localtime = 20.060; samples[2].origin[0] = 20;  samples[2].flags = ANTILAG_POSITION_ALIVE;
+	samples[3].localtime = 20.090; samples[3].origin[0] = 80;  samples[3].flags = ANTILAG_POSITION_ALIVE;
+	resolve_position(samples, 4, 20.045, resolved, &mode);
+	strncpy(out[count].name, "crossing_strafe", sizeof(out[count].name) - 1);
+	out[count].mode = mode;
+	out[count].origin[0] = resolved[0];
+	out[count].origin[1] = resolved[1];
+	out[count].origin[2] = resolved[2];
+	count++;
+
+	memset(samples, 0, sizeof(samples));
+	samples[0].localtime = 30.000; samples[0].origin[0] = 0;  samples[0].flags = ANTILAG_POSITION_ALIVE;
+	samples[1].localtime = 30.008; samples[1].origin[0] = 8;  samples[1].flags = ANTILAG_POSITION_ALIVE;
+	samples[2].localtime = 30.041; samples[2].origin[0] = 41; samples[2].flags = ANTILAG_POSITION_ALIVE;
+	samples[3].localtime = 30.043; samples[3].origin[0] = 43; samples[3].flags = ANTILAG_POSITION_ALIVE;
+	resolve_position(samples, 4, 30.024, resolved, &mode);
+	strncpy(out[count].name, "jitter_target", sizeof(out[count].name) - 1);
+	out[count].mode = mode;
+	out[count].origin[0] = resolved[0];
+	out[count].origin[1] = resolved[1];
+	out[count].origin[2] = resolved[2];
+	count++;
+
+	memset(samples, 0, sizeof(samples));
+	samples[0].localtime = 31.000; samples[0].origin[0] = 0;  samples[0].flags = ANTILAG_POSITION_ALIVE;
+	samples[1].localtime = 31.050; samples[1].origin[0] = 50; samples[1].flags = ANTILAG_POSITION_ALIVE | ANTILAG_POSITION_DISCONTINUITY;
+	resolve_position(samples, 2, 31.030, resolved, &mode);
+	strncpy(out[count].name, "discontinuity_snap", sizeof(out[count].name) - 1);
+	out[count].mode = mode;
+	out[count].origin[0] = resolved[0];
+	out[count].origin[1] = resolved[1];
+	out[count].origin[2] = resolved[2];
+	count++;
+
+	memset(samples, 0, sizeof(samples));
+	samples[0].localtime = 31.000; samples[0].origin[0] = 0;  samples[0].flags = ANTILAG_POSITION_ALIVE;
+	samples[1].localtime = 31.050; samples[1].origin[0] = 50; samples[1].flags = ANTILAG_POSITION_ALIVE | ANTILAG_POSITION_DISCONTINUITY;
+	resolve_position(samples, 2, 31.010, resolved, &mode);
+	strncpy(out[count].name, "discontinuity_snap_oldest", sizeof(out[count].name) - 1);
+	out[count].mode = mode;
+	out[count].origin[0] = resolved[0];
+	out[count].origin[1] = resolved[1];
+	out[count].origin[2] = resolved[2];
+	count++;
+
+	memset(samples, 0, sizeof(samples));
+	samples[0].localtime = 40.000; samples[0].origin[0] = -10; samples[0].flags = ANTILAG_POSITION_ALIVE;
+	samples[1].localtime = 40.050; samples[1].origin[0] = 20;  samples[1].flags = ANTILAG_POSITION_ALIVE;
+	resolve_position(samples, 2, 39.500, resolved, &mode);
+	strncpy(out[count].name, "out_of_window_oldest", sizeof(out[count].name) - 1);
+	out[count].mode = mode;
+	out[count].origin[0] = resolved[0];
+	out[count].origin[1] = resolved[1];
+	out[count].origin[2] = resolved[2];
+	count++;
+
+	memset(samples, 0, sizeof(samples));
+	samples[0].localtime = 41.000; samples[0].origin[0] = -5; samples[0].flags = ANTILAG_POSITION_ALIVE;
+	samples[1].localtime = 41.050; samples[1].origin[0] = 55; samples[1].flags = ANTILAG_POSITION_ALIVE;
+	resolve_position(samples, 2, 41.500, resolved, &mode);
+	strncpy(out[count].name, "out_of_window_newest", sizeof(out[count].name) - 1);
+	out[count].mode = mode;
+	out[count].origin[0] = resolved[0];
+	out[count].origin[1] = resolved[1];
+	out[count].origin[2] = resolved[2];
+	count++;
+
+	memset(samples, 0, sizeof(samples));
+	samples[0].localtime = 42.000; samples[0].origin[0] = 123; samples[0].origin[1] = 4; samples[0].origin[2] = -7; samples[0].flags = ANTILAG_POSITION_ALIVE;
+	resolve_position(samples, 1, 42.500, resolved, &mode);
+	strncpy(out[count].name, "single_sample", sizeof(out[count].name) - 1);
+	out[count].mode = mode;
+	out[count].origin[0] = resolved[0];
+	out[count].origin[1] = resolved[1];
+	out[count].origin[2] = resolved[2];
+	count++;
+
+	return count;
+}
+
+static int find_golden_index(const golden_entry_t *entries, int count, const char *kind, const char *name)
+{
+	int i;
+
+	for (i = 0; i < count; ++i) {
+		if (ieq(entries[i].kind, kind) && ieq(entries[i].name, name)) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+int main(int argc, char **argv)
+{
+	const char *network_path = NULL;
+	const char *golden_path = NULL;
+	network_case_t network_cases[MAX_NETWORK_CASES];
+	network_result_t network_results[MAX_NETWORK_RESULTS];
+	hitreg_result_t hitreg_results[MAX_HITREG_RESULTS];
+	golden_entry_t golden_entries[MAX_GOLDEN_ENTRIES];
+	int golden_matched[MAX_GOLDEN_ENTRIES];
+	int network_case_count;
+	int hitreg_count;
+	int golden_count;
+	int failures = 0;
+	int i;
+
+	for (i = 1; i < argc; ++i) {
+		if (!strcmp(argv[i], "--network") && i + 1 < argc) {
+			network_path = argv[++i];
+		}
+		else if (!strcmp(argv[i], "--golden") && i + 1 < argc) {
+			golden_path = argv[++i];
+		}
+		else {
+			fprintf(stderr, "usage: %s --network <path> --golden <path>\n", argv[0]);
+			return 2;
+		}
+	}
+
+	if (!network_path || !golden_path) {
+		fprintf(stderr, "usage: %s --network <path> --golden <path>\n", argv[0]);
+		return 2;
+	}
+
+	network_case_count = load_network_cases(network_path, network_cases, MAX_NETWORK_CASES);
+	if (network_case_count < 0) {
+		return 2;
+	}
+	if (network_case_count > MAX_NETWORK_RESULTS) {
+		fprintf(stderr, "phase9: too many network cases for result buffer\n");
+		return 2;
+	}
+
+	for (i = 0; i < network_case_count; ++i) {
+		compute_network_result(&network_cases[i], &network_results[i]);
+	}
+
+	hitreg_count = run_hitreg_scenarios(hitreg_results, MAX_HITREG_RESULTS);
+	if (hitreg_count < 0) {
+		fprintf(stderr, "phase9: failed to build hitreg scenarios\n");
+		return 2;
+	}
+
+	golden_count = load_golden_entries(golden_path, golden_entries, MAX_GOLDEN_ENTRIES);
+	if (golden_count < 0) {
+		return 2;
+	}
+	memset(golden_matched, 0, sizeof(golden_matched));
+
+	for (i = 0; i < network_case_count; ++i) {
+		int g_index = find_golden_index(golden_entries, golden_count, "network", network_results[i].name);
+		const golden_entry_t *g = (g_index >= 0 ? &golden_entries[g_index] : NULL);
+
+		if (!g) {
+			fprintf(stderr, "phase9: missing golden network entry for %s\n", network_results[i].name);
+			failures++;
+			continue;
+		}
+		golden_matched[g_index] = 1;
+
+		if (fabs(network_results[i].target_time - g->target_time) > 0.0005 ||
+			network_results[i].reason_flags != g->reason_flags) {
+			fprintf(stderr, "phase9: network mismatch %s got(target=%0.6f flags=%u) expected(target=%0.6f flags=%u)\n",
+				network_results[i].name,
+				network_results[i].target_time,
+				network_results[i].reason_flags,
+				g->target_time,
+				g->reason_flags);
+			failures++;
+		}
+		else {
+			printf("phase9: network ok %s target=%0.6f flags=%u\n",
+				network_results[i].name, network_results[i].target_time, network_results[i].reason_flags);
+		}
+	}
+
+	for (i = 0; i < hitreg_count; ++i) {
+		int g_index = find_golden_index(golden_entries, golden_count, "hitreg", hitreg_results[i].name);
+		const golden_entry_t *g = (g_index >= 0 ? &golden_entries[g_index] : NULL);
+		const char *mode = mode_to_string(hitreg_results[i].mode);
+
+		if (!g) {
+			fprintf(stderr, "phase9: missing golden hitreg entry for %s\n", hitreg_results[i].name);
+			failures++;
+			continue;
+		}
+		golden_matched[g_index] = 1;
+
+		if (!ieq(mode, g->mode)
+			|| fabs(hitreg_results[i].origin[0] - g->origin[0]) > 0.05
+			|| fabs(hitreg_results[i].origin[1] - g->origin[1]) > 0.05
+			|| fabs(hitreg_results[i].origin[2] - g->origin[2]) > 0.05) {
+			fprintf(stderr, "phase9: hitreg mismatch %s got(mode=%s origin=%0.2f %0.2f %0.2f) expected(mode=%s origin=%0.2f %0.2f %0.2f)\n",
+				hitreg_results[i].name,
+				mode,
+				hitreg_results[i].origin[0], hitreg_results[i].origin[1], hitreg_results[i].origin[2],
+				g->mode,
+				g->origin[0], g->origin[1], g->origin[2]);
+			failures++;
+		}
+		else {
+			printf("phase9: hitreg ok %s mode=%s origin=%0.2f %0.2f %0.2f\n",
+				hitreg_results[i].name,
+				mode,
+				hitreg_results[i].origin[0], hitreg_results[i].origin[1], hitreg_results[i].origin[2]);
+		}
+	}
+
+	for (i = 0; i < golden_count; ++i) {
+		if (!golden_matched[i] && (ieq(golden_entries[i].kind, "network") || ieq(golden_entries[i].kind, "hitreg"))) {
+			fprintf(stderr, "phase9: unmatched golden entry %s/%s\n", golden_entries[i].kind, golden_entries[i].name);
+			failures++;
+		}
+	}
+
+	if (failures) {
+		fprintf(stderr, "PHASE9_REGRESSION_FAIL %d\n", failures);
+		return 1;
+	}
+
+	printf("PHASE9_REGRESSION_PASS network=%d hitreg=%d\n", network_case_count, hitreg_count);
+	return 0;
+}


### PR DESCRIPTION
Add comprehensive anti-lag documentation and tooling, including ANTI_LAG_REPORT.md and docs/ANTI_LAG_{ADMIN_TUNING,INVARIANTS,PLAYER_FAIRNESS,TROUBLESHOOTING}. Introduce a regression harness (tests/antilag/phase9_*) and a CMake option ENABLE_ANTILAG_REGRESSION_TESTS (ON) that builds/ registers antilag_phase9_regression with ctest checks against network/golden CSVs. Wire up README links and add help entries and cvars for rollout/debugging (help_commands.json and help_variables.json: sv_antilag_* rollout/projectile gates, sv_debug_antilag, cl_debug_antilag_hud, and related variables). Client-side changes: register cl_debug_antilag_hud, clear antilag_stats on view switch, and harden CL_ParseHiddenDataMessage against truncated/invalid hidden blocks. Misc: improve semver parsing/message in cmake/GitUtils.cmake. These changes provide docs, tests, and observability to support staged anti-lag rollout and validation.