### PR TITLE
Add qizmo voice support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,6 +713,7 @@ set(client
         ${SOURCE_DIR}/snd_main.c
         ${SOURCE_DIR}/snd_mem.c
         ${SOURCE_DIR}/snd_mix.c
+        ${SOURCE_DIR}/snd_qizmo.c
         ${SOURCE_DIR}/snd_voip.c
         ${SOURCE_DIR}/stats_grid.c
         ${SOURCE_DIR}/sys_sdl2.c

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -3552,28 +3552,23 @@ void CL_MuzzleFlash (void)
 
 void CL_ParseQizmoVoice (void) 
 {
-	/* hifi: removed unused warnings, kept null logic */
-	int i;
-	MSG_ReadByte();
-	MSG_ReadByte();
+	byte frame_data[33];
+	byte sequence_low;
+	int sequence;
+	int voice_id;
 
-	for (i = 0; i < 32; i++)
-		MSG_ReadByte();
-	/*
-	   int i, seq, bits;
+	// Qizmo prefixes each frame with one low sequence byte. The next byte is
+	// mixed: bits 4-5 extend the sequence, bits 6-7 identify the voice burst,
+	// and the low nibble remains GSM data restored before decoding.
+	sequence_low = MSG_ReadByte();
 
-	// Read the two-byte header.
-	seq = MSG_ReadByte();
-	bits = MSG_ReadByte();
+	MSG_ReadData(frame_data, sizeof(frame_data));
+	sequence = sequence_low | ((frame_data[0] & 0x30) << 4);
+	voice_id = frame_data[0] >> 6;
 
-	seq |= (bits & 0x30) << 4;	// 10-bit block sequence number, strictly increasing
-	num = bits >> 6;			// 2-bit sample number, bumped at the start of a new sample
-	unknown = bits & 0x0f;		// mysterious 4 bits.  volume multiplier maybe?
-
-	// 32 bytes of voice data follow
-	for (i = 0; i < 32; i++)
-	MSG_ReadByte();
-	*/
+	if (!CL_Demo_SkipMessage(true)) {
+		S_QizmoVoice_PlayFrame(sequence, voice_id, frame_data, sizeof(frame_data));
+	}
 }
 
 #define SHOWNET(x) {if (cl_shownet.value == 2) Com_Printf ("%3i:%s\n", msg_readcount - 1, x);}

--- a/src/qsound.h
+++ b/src/qsound.h
@@ -73,7 +73,10 @@ typedef struct channel_s {
 	vec3_t		origin;			// origin of sound effect
 	vec_t		dist_mult;		// distance multiplier (attenuation/clipK)
 	int		master_vol;		// 0-255 master volume
+	int		flags;
 } channel_t;
+
+#define CHANNEL_FLAG_VOICE (1 << 0)
 
 typedef struct wavinfo_s {
 	int		rate;
@@ -98,6 +101,7 @@ void S_PaintChannels(int endtime);
 void S_LocalSound (char *s);
 void S_LocalSoundWithVol(char *sound, float volume);
 sfxcache_t *S_LoadSound (sfx_t *s);
+void S_RawAudio(int sourceid, byte *data, unsigned int speed, unsigned int samples, unsigned int channelsnum, unsigned int width);
 
 void SND_InitScaletable (void);
 int SND_Rate(int rate);
@@ -128,6 +132,7 @@ extern int		soundtime;
 extern cvar_t		s_loadas8bit;
 extern cvar_t		s_khz;
 extern cvar_t		s_volume;
+extern cvar_t		s_raw_volume;
 extern cvar_t		s_swapstereo;
 extern cvar_t		bgmvolume;
 

--- a/src/qsound.h
+++ b/src/qsound.h
@@ -101,7 +101,9 @@ void S_PaintChannels(int endtime);
 void S_LocalSound (char *s);
 void S_LocalSoundWithVol(char *sound, float volume);
 sfxcache_t *S_LoadSound (sfx_t *s);
+#define RAW_SOURCE_QIZMO_VOICE MAX_CLIENTS
 void S_RawAudio(int sourceid, byte *data, unsigned int speed, unsigned int samples, unsigned int channelsnum, unsigned int width);
+void S_QizmoVoice_PlayFrame(int sequence, int voice_id, const byte *data, int bytes);
 
 void SND_InitScaletable (void);
 int SND_Rate(int rate);

--- a/src/snd_main.c
+++ b/src/snd_main.c
@@ -1206,7 +1206,7 @@ void S_RawAudio(int sourceid, byte *data, unsigned int speed, unsigned int sampl
 
 	S_LockMixer();
 
-	raw_flags = (sourceid >= 0 && sourceid < MAX_CLIENTS) ? CHANNEL_FLAG_VOICE : 0;
+	raw_flags = (sourceid >= 0 && sourceid <= RAW_SOURCE_QIZMO_VOICE) ? CHANNEL_FLAG_VOICE : 0;
 	raw_volume = (raw_flags & CHANNEL_FLAG_VOICE) ? 1 : s_raw_volume.value;
 
 	// search for free slot or re-use previous one with the same sourceid.

--- a/src/snd_main.c
+++ b/src/snd_main.c
@@ -1198,11 +1198,16 @@ void S_RawAudio(int sourceid, byte *data, unsigned int speed, unsigned int sampl
 	int				prepadl;
 	int				spare;
 	int				outsamples;
+	int				raw_flags;
+	float			raw_volume;
 	double			speedfactor;
 	sfxcache_t *	currentcache;
 	streaming_t *	s;
 
 	S_LockMixer();
+
+	raw_flags = (sourceid >= 0 && sourceid < MAX_CLIENTS) ? CHANNEL_FLAG_VOICE : 0;
+	raw_volume = (raw_flags & CHANNEL_FLAG_VOICE) ? 1 : s_raw_volume.value;
 
 	// search for free slot or re-use previous one with the same sourceid.
 	s = S_RawGetFreeStream(sourceid);
@@ -1360,7 +1365,8 @@ void S_RawAudio(int sourceid, byte *data, unsigned int speed, unsigned int sampl
 #else
 			channels[i].pos -= prepadl; // * channels[i].rate;
 			channels[i].end += outsamples;
-			channels[i].master_vol = (int) (s_raw_volume.value * 255); // this should changed volume on alredy playing sound.
+			channels[i].master_vol = (int) (raw_volume * 255); // this should changed volume on alredy playing sound.
+			channels[i].flags = raw_flags;
 
 			if (channels[i].end < shw->paintedtime)
 			{
@@ -1374,7 +1380,13 @@ void S_RawAudio(int sourceid, byte *data, unsigned int speed, unsigned int sampl
 
 	//this one wasn't playing, lets start it then.
 	if (i == total_channels) {
-		S_StartSound(SELF_SOUND_ENTITY, 0, &s->sfx, r_origin, s_raw_volume.value, 0);
+		S_StartSound(SELF_SOUND_ENTITY, 0, &s->sfx, r_origin, raw_volume, 0);
+		for (i = 0; i < total_channels; i++) {
+			if (channels[i].sfx == &s->sfx) {
+				channels[i].flags = raw_flags;
+				break;
+			}
+		}
 	}
 
 	S_UnlockMixer();

--- a/src/snd_mix.c
+++ b/src/snd_mix.c
@@ -32,32 +32,35 @@ typedef struct portable_samplepair_s {
 	int right;
 } portable_samplepair_t;
 portable_samplepair_t paintbuffer[PAINTBUFFER_SIZE];
+static portable_samplepair_t voice_paintbuffer[PAINTBUFFER_SIZE];
+static portable_samplepair_t *painttarget = paintbuffer;
 int snd_scaletable[32][256];
 int snd_vol, *snd_p;
+static int *voice_snd_p;
 
 static int snd_linear_count;
 static short *snd_out;
 
-static void Snd_WriteLinearBlastStereo16 (int* input_buffer, short* output_buffer, int snd_vol)
+static void Snd_WriteLinearBlastStereo16 (int* input_buffer, int* voice_input_buffer, short* output_buffer, int snd_vol, int voice_vol)
 {
 	int val, i;
 
 	for (i = 0; i < snd_linear_count; i += 2) {
-		val = (input_buffer[i]*snd_vol)>>8;
+		val = ((input_buffer[i] * snd_vol) + (voice_input_buffer[i] * voice_vol)) >> 8;
 		output_buffer[i] = bound (-32768, val, 32767);
-		val = (input_buffer[i+1]*snd_vol)>>8;
+		val = ((input_buffer[i + 1] * snd_vol) + (voice_input_buffer[i + 1] * voice_vol)) >> 8;
 		output_buffer[i+1] = bound (-32768, val, 32767);
 	}
 }
 
-static void Snd_WriteLinearBlastStereo16_SwapStereo (int* input_buffer, short* output_buffer, int snd_vol)
+static void Snd_WriteLinearBlastStereo16_SwapStereo (int* input_buffer, int* voice_input_buffer, short* output_buffer, int snd_vol, int voice_vol)
 {
 	int val, i;
 
 	for (i = 0; i < snd_linear_count; i +=2 ) {
-		val = (input_buffer[i+1]*snd_vol)>>8;
+		val = ((input_buffer[i + 1] * snd_vol) + (voice_input_buffer[i + 1] * voice_vol)) >> 8;
 		output_buffer[i] = bound (-32768, val, 32767);
-		val = (input_buffer[i]*snd_vol)>>8;
+		val = ((input_buffer[i] * snd_vol) + (voice_input_buffer[i] * voice_vol)) >> 8;
 		output_buffer[i+1] = bound (-32768, val, 32767);
 	}
 }
@@ -65,11 +68,14 @@ static void Snd_WriteLinearBlastStereo16_SwapStereo (int* input_buffer, short* o
 static void S_TransferStereo16 (int endtime)
 {
 	int lpaintedtime, lpos, clientVolume;
+	int voiceVolume;
 	DWORD *pbuf;
 
 	clientVolume = snd_vol = (s_volume.value * S_VoipVoiceTransmitVolume()) * 256;
+	voiceVolume = max(0, s_raw_volume.value * 256);
 
 	snd_p = (int *) paintbuffer;
+	voice_snd_p = (int *) voice_paintbuffer;
 	lpaintedtime = shw->paintedtime;
 
 	pbuf = (DWORD *)shw->buffer;
@@ -87,15 +93,16 @@ static void S_TransferStereo16 (int endtime)
 
 		// write a linear blast of samples
 		if (s_swapstereo.value)
-			Snd_WriteLinearBlastStereo16_SwapStereo (snd_p, snd_out, clientVolume);
+			Snd_WriteLinearBlastStereo16_SwapStereo (snd_p, voice_snd_p, snd_out, clientVolume, voiceVolume);
 		else
-			Snd_WriteLinearBlastStereo16 (snd_p, snd_out, clientVolume);
+			Snd_WriteLinearBlastStereo16 (snd_p, voice_snd_p, snd_out, clientVolume, voiceVolume);
 
 		if (Movie_IsCapturing()) {
 			Movie_TransferSound (snd_out, snd_linear_count);
 		}
 
 		snd_p += snd_linear_count;
+		voice_snd_p += snd_linear_count;
 		lpaintedtime += (snd_linear_count>>1);
 	}
 }
@@ -110,6 +117,8 @@ static void S_TransferPaintBuffer(int endtime)
 	int step;
 	int val;
 	int snd_vol;
+	int voice_vol;
+	int *voice_p;
 
 	if (shw->samplebits == 16 && shw->numchannels == 2) {
 		S_TransferStereo16(endtime);
@@ -117,19 +126,22 @@ static void S_TransferPaintBuffer(int endtime)
 	}
 
 	p = (int *) paintbuffer;
+	voice_p = (int *) voice_paintbuffer;
 	count = (endtime - shw->paintedtime) * shw->numchannels;
 	out_mask = shw->samples - 1;
 	out_idx = shw->paintedtime * shw->numchannels & out_mask;
 	step = 3 - shw->numchannels;
 	snd_vol = (s_volume.value * S_VoipVoiceTransmitVolume()) * 256;
+	voice_vol = max(0, s_raw_volume.value * 256);
 
 	pbuf = (DWORD *)shw->buffer;
 
 	if (shw->samplebits == 16) {
 		short *out = (short *) pbuf;
 		while (count--) {
-			val = (*p * snd_vol) >> 8;
+			val = ((*p * snd_vol) + (*voice_p * voice_vol)) >> 8;
 			p+= step;
+			voice_p += step;
 			if (val > 0x7fff)
 				val = 0x7fff;
 			else if (val < (int)0x8000)
@@ -140,8 +152,9 @@ static void S_TransferPaintBuffer(int endtime)
 	} else if (shw->samplebits == 8) {
 		unsigned char *out = (unsigned char *) pbuf;
 		while (count--) {
-			val = (*p * snd_vol) >> 8;
+			val = ((*p * snd_vol) + (*voice_p * voice_vol)) >> 8;
 			p+= step;
+			voice_p += step;
 			if (val > 0x7fff)
 				val = 0x7fff;
 			else if (val < (int)0x8000)
@@ -176,8 +189,8 @@ static void SND_PaintChannelFrom8 (channel_t *ch, sfxcache_t *sc, int count)
 
 	for (i = 0; i < count ;i++) {
 		data = sfx[i];
-		paintbuffer[i].left += lscale[data];
-		paintbuffer[i].right += rscale[data];
+		painttarget[i].left += lscale[data];
+		painttarget[i].right += rscale[data];
 	}
 
 	ch->pos += count;
@@ -196,8 +209,8 @@ static void SND_PaintChannelFrom16 (channel_t *ch, sfxcache_t *sc, int count)
 		data = sfx[i];
 		left = (data * leftvol) >> 8;
 		right = (data * rightvol) >> 8;
-		paintbuffer[i].left += left;
-		paintbuffer[i].right += right;
+		painttarget[i].left += left;
+		painttarget[i].right += right;
 	}
 
 	ch->pos += count;
@@ -228,6 +241,7 @@ void S_PaintChannels(int endtime)
 
 		// clear the paint buffer
 		memset (paintbuffer, 0, (end - shw->paintedtime) * sizeof(portable_samplepair_t));
+		memset (voice_paintbuffer, 0, (end - shw->paintedtime) * sizeof(portable_samplepair_t));
 
 		// paint in the channels.
 		ch = channels;
@@ -256,6 +270,7 @@ void S_PaintChannels(int endtime)
 			if (!sc)
 				continue;
 
+			painttarget = (ch->flags & CHANNEL_FLAG_VOICE) ? voice_paintbuffer : paintbuffer;
 			ltime = shw->paintedtime;
 
 			while (ltime < end) { // paint up to end
@@ -282,6 +297,7 @@ void S_PaintChannels(int endtime)
 				}
 			}
 		}
+		painttarget = paintbuffer;
 
 		// transfer out according to DMA format
 		S_TransferPaintBuffer(end);

--- a/src/snd_qizmo.c
+++ b/src/snd_qizmo.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2026 Oscar Linderholm <osm@recv.se>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+#include "quakedef.h"
+#include "qsound.h"
+#include "sndfile.h"
+
+#define QIZMO_VOICE_GSM_BYTES	33
+#define QIZMO_VOICE_RATE	8000
+#define QIZMO_VOICE_PCM_SAMPLES	160
+
+// Keep a bounded GSM segment so libsndfile decodes with prior GSM state. Each
+// frame is 20 ms, at the cap, playback continues from a fresh segment.
+#define QIZMO_VOICE_MAX_FRAMES	1024
+
+// libsndfile decodes from file-like objects, so expose the accumulated GSM
+// bytes as a read-only in-memory file.
+typedef struct qizmo_voice_sfvio_s {
+	const byte *data;
+	sf_count_t size;
+	sf_count_t position;
+} qizmo_voice_sfvio_t;
+
+static sf_count_t S_QizmoVoice_GetFileLen(void *user_data)
+{
+	qizmo_voice_sfvio_t *vio = user_data;
+	return vio->size;
+}
+
+static sf_count_t S_QizmoVoice_Seek(sf_count_t offset, int whence, void *user_data)
+{
+	qizmo_voice_sfvio_t *vio = user_data;
+
+	if (whence == SEEK_CUR) {
+		vio->position += offset;
+	}
+	else if (whence == SEEK_SET) {
+		vio->position = offset;
+	}
+	else if (whence == SEEK_END) {
+		vio->position = vio->size + offset;
+	}
+
+	if (vio->position < 0) {
+		vio->position = 0;
+	}
+	else if (vio->position > vio->size) {
+		vio->position = vio->size;
+	}
+
+	return vio->position;
+}
+
+static sf_count_t S_QizmoVoice_Read(void *ptr, sf_count_t count, void *user_data)
+{
+	qizmo_voice_sfvio_t *vio = user_data;
+	sf_count_t available = vio->size - vio->position;
+
+	if (count > available) {
+		count = available;
+	}
+
+	memcpy(ptr, vio->data + vio->position, count);
+	vio->position += count;
+	return count;
+}
+
+static sf_count_t S_QizmoVoice_Tell(void *user_data)
+{
+	qizmo_voice_sfvio_t *vio = user_data;
+	return vio->position;
+}
+
+// Decode the segment from the beginning so the GSM decoder sees the prior
+// frame history it needs. The caller submits only the newest decoded frame.
+static sf_count_t S_QizmoVoice_DecodeSegment(const byte *gsm_segment,
+	int segment_frames, short *decoded_pcm)
+{
+	static SF_VIRTUAL_IO sfvio = {
+		S_QizmoVoice_GetFileLen,
+		S_QizmoVoice_Seek,
+		S_QizmoVoice_Read,
+		NULL,
+		S_QizmoVoice_Tell
+	};
+	SF_INFO sfinfo;
+	qizmo_voice_sfvio_t sfviodata;
+	SNDFILE *sndfile;
+	sf_count_t decoded_samples;
+
+	memset(&sfinfo, 0, sizeof(sfinfo));
+	sfinfo.samplerate = QIZMO_VOICE_RATE;
+	sfinfo.channels = 1;
+	sfinfo.format = SF_FORMAT_RAW | SF_FORMAT_GSM610;
+
+	sfviodata.data = gsm_segment;
+	sfviodata.size = segment_frames * QIZMO_VOICE_GSM_BYTES;
+	sfviodata.position = 0;
+
+	sndfile = sf_open_virtual(&sfvio, SFM_READ, &sfinfo, &sfviodata);
+	if (!sndfile) {
+		Com_DPrintf("Qizmo voice: could not open GSM frame: %s\n", sf_strerror(NULL));
+		return 0;
+	}
+
+	decoded_samples = sf_readf_short(sndfile, decoded_pcm,
+		segment_frames * QIZMO_VOICE_PCM_SAMPLES);
+	sf_close(sndfile);
+	return decoded_samples;
+}
+
+void S_QizmoVoice_PlayFrame(int sequence, int voice_id, const byte *frame_data, int bytes)
+{
+	static byte gsm_segment[QIZMO_VOICE_MAX_FRAMES * QIZMO_VOICE_GSM_BYTES];
+	static short decoded_pcm[QIZMO_VOICE_MAX_FRAMES * QIZMO_VOICE_PCM_SAMPLES];
+	static int last_sequence;
+	static int last_voice_id;
+	static int segment_frames;
+	static qbool have_sequence;
+	sf_count_t decoded_samples;
+	short *latest_pcm_frame;
+	byte *gsm_frame;
+
+	if (!snd_initialized || !snd_started) {
+		return;
+	}
+
+	if (bytes != QIZMO_VOICE_GSM_BYTES) {
+		Com_DPrintf("Qizmo voice: unexpected GSM frame size %d\n", bytes);
+		return;
+	}
+
+	// The Qizmo sequence groups packets into one voice transmission. A new
+	// voice id, sequence, gap, or the bounded history limit starts a fresh GSM
+	// decoder segment.
+	if (sequence == 0 || !have_sequence ||
+		last_voice_id != voice_id ||
+		((last_sequence + 1) & 0x3ff) != sequence ||
+		segment_frames >= QIZMO_VOICE_MAX_FRAMES) {
+		segment_frames = 0;
+	}
+
+	gsm_frame = gsm_segment + segment_frames * QIZMO_VOICE_GSM_BYTES;
+	memcpy(gsm_frame, frame_data, QIZMO_VOICE_GSM_BYTES);
+
+	// Qizmo stores GSM frames with a different high nibble than standard raw
+	// GSM 06.10. Preserve the low bits and normalize the magic nibble.
+	gsm_frame[0] = (gsm_frame[0] & 0x0f) | 0xd0;
+
+	segment_frames++;
+	last_sequence = sequence;
+	last_voice_id = voice_id;
+	have_sequence = true;
+
+	decoded_samples = S_QizmoVoice_DecodeSegment(gsm_segment, segment_frames, decoded_pcm);
+	if (decoded_samples < QIZMO_VOICE_PCM_SAMPLES) {
+		Com_DPrintf("Qizmo voice: decoded only %d PCM samples\n", (int)decoded_samples);
+		return;
+	}
+
+	latest_pcm_frame = decoded_pcm + decoded_samples - QIZMO_VOICE_PCM_SAMPLES;
+
+	S_RawAudio(RAW_SOURCE_QIZMO_VOICE,
+		(byte *)latest_pcm_frame,
+		QIZMO_VOICE_RATE,
+		QIZMO_VOICE_PCM_SAMPLES,
+		1,
+		sizeof(short));
+}

--- a/src/snd_voip.c
+++ b/src/snd_voip.c
@@ -41,7 +41,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 static void S_Voip_Play_Callback (cvar_t *var, char *string, qbool *cancel);
 void CL_SendClientCommand (qbool reliable, char *format, ...);
-void S_RawAudio (int sourceid, byte *data, unsigned int speed, unsigned int samples, unsigned int channelsnum, unsigned int width);
 
 static cvar_t s_inputdevice = { "s_inputdevice", "0" };                                // SDL device to use as microphone
 static cvar_t cl_voip_send = { "cl_voip_send", "0" };                                  // Sends voice-over-ip data to the server whenever it is set.


### PR DESCRIPTION
This PR adds playback support for qizmo voice packets and makes voice playback volume independent from regular game sound volume.

It introduces a separate voice mix path so VoIP/qizmo voice uses `s_raw_volume` at final mix time, while normal game audio continues to use volume. This allows configurations such as `volume 0` and `s_raw_volume 1`, where game sounds are muted but voice remains audible.

For qizmo voice, `svc_qizmovoice` packets are parsed as qizmo packed GSM 06.10 frames. The parser extracts the 10-bit frame sequence and 2-bit voice id, restores the standard GSM frame nibble, decodes the audio through libsndfiles GSM610 support, and submits the newest decoded PCM frame through the raw audio stream.

A sample demo that uses qizmo voice can be downloaded here: [voice.qwd.gz](https://github.com/user-attachments/files/26637588/voice.qwd.gz)
