### PR TITLE
Adds a few controls for colored frag messages

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -18865,7 +18865,7 @@
     },
     "scr_coloredfrags": {
       "default": "0",
-      "desc": "Frag messages will be colored according to your teamcolor/enemycolor settings.",
+      "desc": "Frag messages will be colored according to your teamcolor/enemycolor settings, unless scr_coloredfrags_team or scr_coloredfrags_enemy is set.",
       "group-id": "40",
       "remarks": "Needs scr_coloredText 1, cl_parsefrags 1, cl_loadfragfiles 1.",
       "type": "boolean",
@@ -18879,6 +18879,20 @@
           "name": "true"
         }
       ]
+    },
+    "scr_coloredfrags_enemy": {
+      "default": "",
+      "desc": "Overrides the enemy player name color used by scr_coloredfrags. Accepts an RGB value.",
+      "group-id": "40",
+      "remarks": "Use three values from 0 to 255, for example \"255 64 64\". Leave empty to use the enemy/player color from scr_coloredfrags.",
+      "type": "string"
+    },
+    "scr_coloredfrags_team": {
+      "default": "",
+      "desc": "Overrides the team player name color used by scr_coloredfrags. Accepts an RGB value.",
+      "group-id": "40",
+      "remarks": "Use three values from 0 to 255, for example \"64 255 64\". Leave empty to use the team/player color from scr_coloredfrags.",
+      "type": "string"
     },
     "scr_compactHud": {
       "default": "0",

--- a/help_variables.json
+++ b/help_variables.json
@@ -18887,6 +18887,22 @@
       "remarks": "Use three values from 0 to 255, for example \"255 64 64\". Leave empty to use the enemy/player color from scr_coloredfrags.",
       "type": "string"
     },
+    "scr_coloredfrags_normalize": {
+      "default": "0",
+      "desc": "Normalizes player names in colored frag messages by translating red chars to white chars.",
+      "group-id": "40",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Normalization off.",
+          "name": "false"
+        },
+        {
+          "description": "Normalization on.",
+          "name": "true"
+        }
+      ]
+    },
     "scr_coloredfrags_team": {
       "default": "",
       "desc": "Overrides the team player name color used by scr_coloredfrags. Accepts an RGB value.",

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -2582,6 +2582,28 @@ static char *CL_Color2ConColorOverride(int color)
 	return buf;
 }
 
+static void CL_CopyFragName(wchar *dest, const wchar *source, int len, int destlen)
+{
+	extern cvar_t scr_coloredfrags_normalize;
+
+	char name[MAX_SCOREBOARDNAME];
+	int i;
+
+	if (!scr_coloredfrags_normalize.integer) {
+		qwcslcpy(dest, source, bound(0, len + 1, destlen));
+		return;
+	}
+
+	len = bound(0, len, sizeof(name) - 1);
+	for (i = 0; i < len; i++) {
+		name[i] = source[i];
+	}
+	name[len] = 0;
+
+	Q_normalizetext(name);
+	qwcslcpy(dest, str2wcs(name), bound(0, len + 1, destlen));
+}
+
 // Will add colors to nicks in "ParadokS rides JohnNy_cz's rocket"
 // source - source frag message, dest - destination buffer, destlen - length of buffer
 // cff - see the cfrags_format definition 
@@ -2607,7 +2629,7 @@ static wchar* CL_ColorizeFragMessage (const wchar *source, cfrags_format *cff)
 	destlen -= (len = qwcslen(dest));
 	dest += len;
 	// 1st nick
-	qwcslcpy(dest, source + cff->p1pos, bound(0, cff->p1len + 1, destlen));
+	CL_CopyFragName(dest, source + cff->p1pos, cff->p1len, destlen);
 	destlen -= (len = qwcslen(dest));
 	dest += len;
 	// color off
@@ -2628,7 +2650,7 @@ static wchar* CL_ColorizeFragMessage (const wchar *source, cfrags_format *cff)
 		destlen -= (len = qwcslen(dest));
 		dest += len;
 		// 2nd nick
-		qwcslcpy(dest, source + cff->p2pos, bound(0, cff->p2len + 1, destlen));
+		CL_CopyFragName(dest, source + cff->p2pos, cff->p2len, destlen);
 		destlen -= (len = qwcslen(dest));
 		dest += len;
 		// color off

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -2553,6 +2553,35 @@ char *CL_Color2ConColor(int color)
 	return buf;
 }
 
+static char *CL_Color2ConColorOverride(int color)
+{
+	cvar_t *override;
+	byte rgb[4];
+	static char buf[6];
+	extern cvar_t cl_teamtopcolor, cl_enemytopcolor;
+	extern cvar_t scr_coloredfrags_team, scr_coloredfrags_enemy;
+
+	if (scr_coloredfrags_team.string[0] && color == cl_teamtopcolor.integer) {
+		override = &scr_coloredfrags_team;
+	}
+	else if (scr_coloredfrags_enemy.string[0] && color == cl_enemytopcolor.integer) {
+		override = &scr_coloredfrags_enemy;
+	}
+	else {
+		return CL_Color2ConColor(color);
+	}
+
+	if (StringToRGB_W(override->string, rgb) < 3) {
+		return CL_Color2ConColor(color);
+	}
+	buf[0] = '&';
+	buf[1] = 'c';
+	RGBToString(rgb, buf + 2);
+	buf[5] = 0;
+
+	return buf;
+}
+
 // Will add colors to nicks in "ParadokS rides JohnNy_cz's rocket"
 // source - source frag message, dest - destination buffer, destlen - length of buffer
 // cff - see the cfrags_format definition 
@@ -2564,8 +2593,8 @@ static wchar* CL_ColorizeFragMessage (const wchar *source, cfrags_format *cff)
 
 	dest[0] = 0; // new string
 
-	qwcslcpy(col1, str2wcs(CL_Color2ConColor(cff->p1col)), sizeof(col1)/sizeof(wchar));
-	qwcslcpy(col2, str2wcs(CL_Color2ConColor(cff->p2col)), sizeof(col2)/sizeof(wchar));
+	qwcslcpy(col1, str2wcs(CL_Color2ConColorOverride(cff->p1col)), sizeof(col1)/sizeof(wchar));
+	qwcslcpy(col2, str2wcs(CL_Color2ConColorOverride(cff->p2col)), sizeof(col2)/sizeof(wchar));
 
 	// before 1st nick
 	qwcslcpy(dest, source, bound(0, cff->p1pos + 1, destlen));

--- a/src/cl_screen.c
+++ b/src/cl_screen.c
@@ -117,6 +117,7 @@ cvar_t  r_chaticons_alpha		= {"r_chaticons_alpha", "0.8"};
 cvar_t	scr_coloredfrags		= {"scr_coloredfrags", "0"};
 cvar_t	scr_coloredfrags_team		= {"scr_coloredfrags_team", ""};
 cvar_t	scr_coloredfrags_enemy		= {"scr_coloredfrags_enemy", ""};
+cvar_t	scr_coloredfrags_normalize	= {"scr_coloredfrags_normalize", "0"};
 
 cvar_t	scr_cursor_scale		= {"scr_cursor_scale", "0.2"};			// The mouse cursor scale.
 cvar_t	scr_cursor_iconoffset_x	= {"scr_cursor_iconoffset_x", "0"};	// How much the cursor icon should be offseted from the cursor.
@@ -1112,6 +1113,7 @@ void SCR_Init (void)
 		Cvar_Register(&scr_coloredfrags);
 		Cvar_Register(&scr_coloredfrags_team);
 		Cvar_Register(&scr_coloredfrags_enemy);
+		Cvar_Register(&scr_coloredfrags_normalize);
 
 		Cmd_AddCommand("calc_fov", tmp_calc_fov);
 

--- a/src/cl_screen.c
+++ b/src/cl_screen.c
@@ -115,6 +115,8 @@ cvar_t	cl_hud					= {"cl_hud", "1"};	// QW262 HUD.
 cvar_t	gl_triplebuffer			= {"gl_triplebuffer", "1"};
 cvar_t  r_chaticons_alpha		= {"r_chaticons_alpha", "0.8"};
 cvar_t	scr_coloredfrags		= {"scr_coloredfrags", "0"};
+cvar_t	scr_coloredfrags_team		= {"scr_coloredfrags_team", ""};
+cvar_t	scr_coloredfrags_enemy		= {"scr_coloredfrags_enemy", ""};
 
 cvar_t	scr_cursor_scale		= {"scr_cursor_scale", "0.2"};			// The mouse cursor scale.
 cvar_t	scr_cursor_iconoffset_x	= {"scr_cursor_iconoffset_x", "0"};	// How much the cursor icon should be offseted from the cursor.
@@ -1108,6 +1110,8 @@ void SCR_Init (void)
 		Cvar_Register(&show_velocity_3d_offset_down);
 
 		Cvar_Register(&scr_coloredfrags);
+		Cvar_Register(&scr_coloredfrags_team);
+		Cvar_Register(&scr_coloredfrags_enemy);
 
 		Cmd_AddCommand("calc_fov", tmp_calc_fov);
 


### PR DESCRIPTION
- `scr_coloredfrags_team` and `scr_coloredfrags_enemy` allow explicit RGB overrides for team/enemy name colors.
- `scr_coloredfrags_normalize` optionally normalizes colored frag names by translating red chars to white chars.

This makes colored frag output more configurable and easier to read across different name styles.

The screenshot is created with the following settings:
```
scr_coloredfrags                      "1"
scr_coloredfrags_enemy                "255 120 120"
scr_coloredfrags_normalize            "1"
scr_coloredfrags_team                 "120 255 120"
```
<img width="1920" height="1200" alt="scr_coloredfrags_normalize" src="https://github.com/user-attachments/assets/ce611167-f358-475c-9fcc-8bba938747e4" />
