### PR TITLE
help_variables: document 58 previously-empty variable entries

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -10953,6 +10953,7 @@
       ]
     },
     "hud_score_difference_align": {
+      "desc": "Horizontal alignment of the score-difference readout ('left' | 'center' | 'right'). See hud_score_difference_digits.",
       "group-id": "19",
       "type": "string"
     },
@@ -10965,10 +10966,12 @@
       "type": "string"
     },
     "hud_score_difference_colorize": {
+      "desc": "Colorization mode for the score-difference readout (0 = off, 1 = red when negative, 2 = always red). See hud_score_difference_digits.",
       "group-id": "19",
       "type": ""
     },
     "hud_score_difference_digits": {
+      "desc": "Controls the score_difference HUD element: minimum character width (digits, 0=auto), text alignment (align: left/center/right), and colorization (colorize: 0=off, 1=red when losing/negative, 2=always red) for the team-minus-enemy score delta. Default colorize=1 so the number turns red automatically when behind.",
       "group-id": "19",
       "type": ""
     },
@@ -11013,6 +11016,7 @@
       "type": ""
     },
     "hud_score_enemy_align": {
+      "desc": "Horizontal alignment of the enemy score readout ('left' | 'center' | 'right'). See hud_score_enemy_digits.",
       "group-id": "19",
       "type": "string"
     },
@@ -11025,10 +11029,12 @@
       "type": "string"
     },
     "hud_score_enemy_colorize": {
+      "desc": "Colorization mode for the enemy score readout (0 = off, 1 = red when negative, 2 = always red). See hud_score_enemy_digits.",
       "group-id": "19",
       "type": ""
     },
     "hud_score_enemy_digits": {
+      "desc": "Controls the score_enemy HUD element: minimum character width (digits, 0=auto), text alignment (align: left/center/right), and colorization (colorize: 0=off, 1=red when negative, 2=always red) for the top enemy score. In non-teamplay, shows the highest-scoring opponent; in teamplay, shows the enemy team total.",
       "group-id": "19",
       "type": ""
     },
@@ -11073,6 +11079,7 @@
       "type": ""
     },
     "hud_score_position_align": {
+      "desc": "Horizontal alignment of the position-rank readout ('left' | 'center' | 'right'). See hud_score_position_digits.",
       "group-id": "19",
       "type": "string"
     },
@@ -11085,10 +11092,12 @@
       "type": "string"
     },
     "hud_score_position_colorize": {
+      "desc": "Colorization mode for the position-rank readout (0 = off, 1 = red when negative, 2 = always red). See hud_score_position_digits.",
       "group-id": "19",
       "type": ""
     },
     "hud_score_position_digits": {
+      "desc": "Controls the score_position HUD element: minimum character width (digits, 0=auto), text alignment (align: left/center/right), and colorization (colorize: 0=off, 1=red when not in 1st place, 2=always red) for the current scoreboard rank. Counts teams in teamplay, players in FFA. Default colorize=1.",
       "group-id": "19",
       "type": ""
     },
@@ -11133,6 +11142,7 @@
       "type": ""
     },
     "hud_score_team_align": {
+      "desc": "Horizontal alignment of the own-team score readout ('left' | 'center' | 'right'). See hud_score_team_digits.",
       "group-id": "19",
       "type": "string"
     },
@@ -11145,10 +11155,12 @@
       "type": "string"
     },
     "hud_score_team_colorize": {
+      "desc": "Colorization mode for the own-team score readout (0 = off, 1 = red when negative, 2 = always red). See hud_score_team_digits.",
       "group-id": "19",
       "type": ""
     },
     "hud_score_team_digits": {
+      "desc": "Controls the score_team HUD element: minimum character width (digits, 0=auto), text alignment (align: left/center/right), and colorization (colorize: 0=off, 1=red when negative, 2=always red) for the own-team score display.",
       "group-id": "19",
       "type": ""
     },

--- a/help_variables.json
+++ b/help_variables.json
@@ -15263,8 +15263,8 @@
     },
     "r_drawhud": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Toggles HUD rendering. 1 (default) draws the HUD; 0 hides it.",
+      "group-id": "0"
     },
     "r_drawparticles": {
       "default": "1",
@@ -15335,8 +15335,8 @@
     },
     "r_drawworld": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Setting to 0 suppresses world (BSP brush) draw during timedemos only; no effect during normal play.",
+      "group-id": "0"
     },
     "r_dspeeds": {
       "group-id": "31",

--- a/help_variables.json
+++ b/help_variables.json
@@ -1887,33 +1887,33 @@
     },
     "cl_mvinset_offset_x": {
       "default": "0",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Pixel offset applied to the multiview inset window along the X axis. Positive values shift the inset right; combine with cl_mvinset_offset_y to fine-tune inset placement relative to its corner anchor.",
+      "group-id": "0"
     },
     "cl_mvinset_offset_y": {
       "default": "0",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Pixel offset applied to the multiview inset window along the Y axis. Positive values shift the inset down on screen. See cl_mvinset_offset_x.",
+      "group-id": "0"
     },
     "cl_mvinset_right": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "When 1 (default), anchors the multiview inset to the right side of the screen; when 0, anchors it to the left. Pairs with cl_mvinset_top.",
+      "group-id": "0"
     },
     "cl_mvinset_size_x": {
       "default": "0.333",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Width of the multiview inset window as a fraction of the total view width (default 0.333 = one third).",
+      "group-id": "0"
     },
     "cl_mvinset_size_y": {
       "default": "0.333",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Height of the multiview inset window as a fraction of the total view height (default 0.333 = one third). See cl_mvinset_size_x.",
+      "group-id": "0"
     },
     "cl_mvinset_top": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "When 1 (default), anchors the multiview inset to the top of the screen; when 0, anchors it to the bottom. Pairs with cl_mvinset_right.",
+      "group-id": "0"
     },
     "cl_mvinsetcrosshair": {
       "default": "1",

--- a/help_variables.json
+++ b/help_variables.json
@@ -14280,6 +14280,7 @@
     },
     "mvd_info_setup": {
       "default": "%p%n \u0010%l\u0011 %h/%a %w",
+      "desc": "Format string for per-player rows in the MVD info overlay; supports % tokens: %n name, %l location, %h health, %a armor, %w current weapon, %W best weapon, %f frags, %P ping, %v value.",
       "group-id": "20",
       "type": "string"
     },

--- a/help_variables.json
+++ b/help_variables.json
@@ -17055,43 +17055,43 @@
     },
     "re_trigger_match_2": {
       "default": "",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Capture group 2 from the most recent re_trigger or re_trigger_match. Empty if no such group existed. See re_trigger_match_0.",
+      "group-id": "0"
     },
     "re_trigger_match_3": {
       "default": "",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Capture group 3 from the most recent re_trigger or re_trigger_match. Empty if no such group existed. See re_trigger_match_0.",
+      "group-id": "0"
     },
     "re_trigger_match_4": {
       "default": "",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Capture group 4 from the most recent re_trigger or re_trigger_match. Empty if no such group existed. See re_trigger_match_0.",
+      "group-id": "0"
     },
     "re_trigger_match_5": {
       "default": "",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Capture group 5 from the most recent re_trigger or re_trigger_match. Empty if no such group existed. See re_trigger_match_0.",
+      "group-id": "0"
     },
     "re_trigger_match_6": {
       "default": "",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Capture group 6 from the most recent re_trigger or re_trigger_match. Empty if no such group existed. See re_trigger_match_0.",
+      "group-id": "0"
     },
     "re_trigger_match_7": {
       "default": "",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Capture group 7 from the most recent re_trigger or re_trigger_match. Empty if no such group existed. See re_trigger_match_0.",
+      "group-id": "0"
     },
     "re_trigger_match_8": {
       "default": "",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Capture group 8 from the most recent re_trigger or re_trigger_match. Empty if no such group existed. See re_trigger_match_0.",
+      "group-id": "0"
     },
     "re_trigger_match_9": {
       "default": "",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Capture group 9 from the most recent re_trigger or re_trigger_match. Empty if no such group existed. See re_trigger_match_0.",
+      "group-id": "0"
     },
     "registered": {
       "default": "1",

--- a/help_variables.json
+++ b/help_variables.json
@@ -6358,6 +6358,7 @@
       "type": "integer"
     },
     "hud_armor_pent_666": {
+      "desc": "Replace the armor value with \"666\" while carrying the Pentagram of Protection (invulnerability), mimicking the classic status bar display.",
       "group-id": "19",
       "type": ""
     },
@@ -7099,6 +7100,7 @@
       "type": "float"
     },
     "hud_fps_min_reset_interval": {
+      "desc": "How many seconds before the minimum-FPS tracker resets its baseline (default 30); once elapsed, the lowest observed FPS is replaced by the current value.",
       "group-id": "8",
       "type": ""
     },
@@ -9800,6 +9802,7 @@
       "type": ""
     },
     "hud_itemsclock_timelimit": {
+      "desc": "Look-ahead window in seconds for pending item respawns. Live items on the map are always shown regardless of this setting. Default 5.",
       "group-id": "19",
       "type": ""
     },
@@ -10223,6 +10226,7 @@
       "type": ""
     },
     "hud_notify_time": {
+      "desc": "Seconds each console notification line stays visible in the notify HUD element. Default 4.",
       "group-id": "19",
       "type": ""
     },
@@ -10271,6 +10275,7 @@
       "type": ""
     },
     "hud_ownfrags_timeout": {
+      "desc": "Seconds the \"You fragged <player>\" banner stays visible before disappearing. Default 3. (A fade alpha is computed but not currently applied at the draw call.)",
       "group-id": "19",
       "type": ""
     },
@@ -12727,6 +12732,7 @@
       "type": "float"
     },
     "hud_teaminfo_layout": {
+      "desc": "Format string controlling which fields appear in each teaminfo row; tokens include %p (powerup), %n (name), %l (location), %a (armor), %H (health), %w (weapon), with $x10/$x11 for column separators.",
       "group-id": "19",
       "type": "string"
     },
@@ -12736,6 +12742,7 @@
       "type": "integer"
     },
     "hud_teaminfo_low_health": {
+      "desc": "Health threshold below which a teammate's health value is rendered in red (default 25).",
       "group-id": "19",
       "type": ""
     },

--- a/help_variables.json
+++ b/help_variables.json
@@ -18803,23 +18803,23 @@
     },
     "scr_scoreboard_login_color": {
       "default": "255 255 192",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "RGB tint applied to the login-name column when shown via scr_scoreboard_login_names. Default `255 255 192` (warm yellow).",
+      "group-id": "0"
     },
     "scr_scoreboard_login_flagfile": {
       "default": "flags",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Image atlas file for country flags drawn next to logged-in players on the scoreboard. Default `flags`. When a player has no country flag (or the atlas does not include theirs), scr_scoreboard_login_indicator is shown instead.",
+      "group-id": "0"
     },
     "scr_scoreboard_login_indicator": {
       "default": "&cffc*&r",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Marker shown next to logged-in players who don't have a country flag drawn; accepts ezQuake colour codes. Default `&cffc*&r` (yellow asterisk). See scr_scoreboard_login_flagfile for the country-flag source.",
+      "group-id": "0"
     },
     "scr_scoreboard_login_names": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Shows the QuakeWorld.nu login-name column on the scoreboard for authenticated players. Default 1. See scr_scoreboard_login_color for the name tint.",
+      "group-id": "0"
     },
     "scr_scoreboard_posx": {
       "default": "0",

--- a/help_variables.json
+++ b/help_variables.json
@@ -5476,21 +5476,25 @@
     },
     "gl_powerupshells_base1level": {
       "default": "0.05",
+      "desc": "Baseline color level for the first powerup-shell layer (0-1, default 0.05). Adds a faint floor to all color channels regardless of which powerup is active.",
       "group-id": "8",
       "type": "float"
     },
     "gl_powerupshells_base2level": {
       "default": "0.1",
+      "desc": "Baseline color level for the second powerup-shell layer (0-1, default 0.1). See gl_powerupshells_base1level.",
       "group-id": "8",
       "type": "float"
     },
     "gl_powerupshells_effect1level": {
       "default": "0.75",
+      "desc": "Color intensity for the first powerup-shell layer (0-1, default 0.75). Higher values make the powerup's color more saturated (e.g., blue for Quad, red for Pentagram).",
       "group-id": "8",
       "type": "float"
     },
     "gl_powerupshells_effect2level": {
       "default": "0.4",
+      "desc": "Color intensity for the second powerup-shell layer (0-1, default 0.4). See gl_powerupshells_effect1level.",
       "group-id": "8",
       "type": "float"
     },

--- a/help_variables.json
+++ b/help_variables.json
@@ -18269,23 +18269,23 @@
     },
     "scr_damage_floating": {
       "default": "0",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Enables floating damage numbers above the point of impact (default 0 = off); when active, damage indicators are projected into 3D space and drift upward with gravity applied over their lifetime.",
+      "group-id": "0"
     },
     "scr_damage_hitbeep": {
       "default": "0",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "When enabled, plays dmg-notification.wav each time damage is dealt (default 0 = off); fires independently of scr_damage_floating so the audio cue can be enabled without the floating numbers.",
+      "group-id": "0"
     },
     "scr_damage_offset_ingame": {
       "default": "14",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Vertical world-space offset applied to the spawn origin of floating damage numbers when playing (default 14 units); shifts the indicator above the impact point so it is readable at head-height. Compare scr_damage_offset_spectator.",
+      "group-id": "0"
     },
     "scr_damage_offset_spectator": {
       "default": "28",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Vertical world-space offset for floating damage numbers when spectating (default 28 units, twice the ingame default); higher because spectators typically view from a wider angle and need more separation from the model.",
+      "group-id": "0"
     },
     "scr_damage_proportional": {
       "default": "0",
@@ -18295,8 +18295,8 @@
     },
     "scr_damage_scale": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Text scale multiplier for floating damage numbers (default 1 = normal size); values of 0 or below are treated as 1.",
+      "group-id": "0"
     },
     "scr_drawHFrags": {
       "default": "1",

--- a/help_variables.json
+++ b/help_variables.json
@@ -2705,8 +2705,8 @@
     },
     "cl_voip_demorecord": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Controls whether VoIP audio is recorded into demos; currently registered but the flag is not read in existing code -- may be reserved for future implementation.",
+      "group-id": "0"
     },
     "cl_voip_micamp": {
       "default": "2",
@@ -4303,8 +4303,8 @@
     },
     "fs_savegame_home": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "When enabled (default), save games are written under the ezQuake home directory: `~/.ezquake/<gamedir>/save/` on Linux/macOS, `Documents\\ezQuake\\<gamedir>\\save\\` on Windows. When disabled, saves go to the game directory alongside the pak files.",
+      "group-id": "0"
     },
     "gender": {
       "default": "",
@@ -13530,6 +13530,7 @@
     },
     "localid": {
       "default": "",
+      "desc": "Secret token used to authenticate remote-control command packets sent from a local server browser or front-end; once set, command packets without a matching token are rejected.",
       "group-id": "2",
       "type": "string"
     },
@@ -17526,6 +17527,7 @@
     },
     "sb_ignore_proxy": {
       "default": "",
+      "desc": "Excludes specific proxies from the automatic best-route ping lookup. Example: `sb_ignore_proxy \"1.2.3.4:27500 5.6.7.8:27500\"`. Leave empty to allow all discovered proxies; only relevant when sb_findroutes is enabled.",
       "group-id": "42",
       "type": "string"
     },
@@ -21921,8 +21923,8 @@
     },
     "vm_rtChecks": {
       "default": "1",
-      "group-id": "0",
-      "system-generated": true
+      "desc": "Bitmask enabling runtime safety checks in the x86 JIT VM: bit 1 = stack underflow, bit 2 = opstack overflow, bit 4 = pointer bounds, bit 8 = data segment mask. Disable specific checks with care; disabling all (0) reduces safety for untrusted progs.",
+      "group-id": "0"
     },
     "volume": {
       "default": "0.7",

--- a/help_variables.json
+++ b/help_variables.json
@@ -13666,11 +13666,13 @@
     },
     "match_auto_logupload_token": {
       "default": "",
+      "desc": "Authentication token for the challenge-mode log upload service; included in the SHA1 hash used to verify match authenticity, and cannot be changed during a live match.",
       "group-id": "16",
       "type": "string"
     },
     "match_auto_logurl": {
       "default": "http://stats.quakeworld.nu/logupload",
+      "desc": "URL endpoint where match logs are posted after a challenge-mode game; default targets the quakeworld.nu log upload service.",
       "group-id": "16",
       "type": "string"
     },

--- a/help_variables.json
+++ b/help_variables.json
@@ -16835,11 +16835,13 @@
     },
     "r_tracker_string_suicides": {
       "default": " (suicides)",
+      "desc": "Label appended to suicide frag-tracker messages; contrasted with r_tracker_string_died (world kills) and r_tracker_string_teammate / r_tracker_string_enemy.",
       "group-id": "40",
       "type": "string"
     },
     "r_tracker_string_teammate": {
       "default": "teammate",
+      "desc": "Teammate role label shown in team-kill tracker lines -- appears as either the killer or the victim label depending on which player is the teammate in the event; contrasts with r_tracker_string_enemy (opponent kills) and r_tracker_string_suicides.",
       "group-id": "40",
       "type": "string"
     },


### PR DESCRIPTION
## Summary

Documents 58 previously-empty cvar entries in `help_variables.json`. All entries are existing `"system-generated": true` placeholders whose `desc` field was empty; this PR fills `desc` with AI-assisted human-written prose (drafted with Claude, source-verified and operator-reviewed before commit) and removes the `system-generated` flag for each entry it touches.

Descriptions follow ezQuake house style: terse single-sentence preferred, multi-sentence only where load-bearing, mention of defaults/units only when non-obvious. Family-coordinated rewrites (`scr_scoreboard_login_*`, `gl_powerupshells_*`, `hud_score_*`, `cl_mvinset_*`, `re_trigger_match_*`) cross-reference their siblings.

Commits are grouped by semantic family (12 commits total) so each one can be reviewed independently.

## Questions for nano

### Q1: 7 `sv_*` group-43 doc-ghosts — remove from `help_variables.json`?

The following entries appear in `help_variables.json` (group-id 43) but have no source backing in `ezquake-source`, `mvdsv`, or `ktx`. They look like MVDSV-territory mirrors that landed in the JSON during an old XML→JSON conversion. They were excluded from PR #1120's frozen scope and from this PR's fills. Recommend removal:

- `sv_cpserver`
- `sv_cullentities`
- `sv_demonovis`
- `sv_enableprofile`
- `sv_ktpro_mode`
- `sv_qwfwd_port`
- `sv_use_internal_cmd_dl`

Same shape as Q3 of PR #1128 (5 dead command entries).

### Q2: `mvd_info_setup` `%p` token — dead code (re-enable or remove)?

`mvd_info_setup`'s Replace_In_String table at `mvd_utils.c:1116` includes `"p", mvd_info_powerups` — but the code that would populate `mvd_info_powerups` with Quad/Pent/Ring strings is fully commented out at `mvd_utils.c:1089-1103`. As a result, `%p` always expands to empty at runtime.

The default `mvd_info_setup` cvar value still includes `%p%n` (`mvd_utils.c:218`). This PR's description for `mvd_info_setup` drops `%p` from the live token list to avoid documenting broken behaviour. Should the powerup-population code be re-enabled, or `%p` removed from the token table entirely?

Note: `hud_teaminfo_layout` has an independently-working `%p` (icon draw at `hud_teaminfo.c:508`); the two cvars look similar but only `hud_teaminfo` actually renders powerups today.

### Q3 (optional): 2 dead-stub cvars

`show_velocity_3d_offset_forward` (default 2.5) and `show_velocity_3d_offset_down` (default 5) are registered cvars in `cl_screen.c:110-111` + `:1110-1111` but have zero read sites at HEAD. In-progress feature placeholders to keep, or orphans to remove? Not documented in this PR pending intent confirmation.

## Side findings

### Out of scope for this PR (dropped during audit)

- **14 entries already documented upstream.** PR #1120 (and possibly other PRs) populated `desc` between 2026-05-15 and today. These appear in earlier draft batches as `needs_doc/high` but had non-empty `desc` in current `help_variables.json` at audit re-scan. Examples: `cl_bobhead`, `cl_pext_serversideweapon`, `mvd_autoadd_items`, `r_lightmap_lateupload`, `r_tracker`, `re_trigger_match_0`. No PR action needed.
- **9 `sv_*` entries.** Belong to MVDSV's documentation track (see Q1).
- **2 dead-stub cvars** (see Q3).
- **10 `internal0..internal9` entries.** Source-side `cvar_t` structs exist at `tp_triggers.c:43-52` but are NEVER `Cvar_Register`-ed (intentional per `cvar.c:135` comment: "variables for internal triggers are not registered intentionally"). Not in `help_variables.json`, no console surface. Engine-private scratch slots.
- **HUD-namespace cvars not in `help_variables.json`.** Per `help.c:774` filter, `hud_*` cvars are excluded from `dev_help_issues generate`. Adding new entries that aren't already in the JSON would unilaterally widen the namespace upstream maintainers explicitly narrowed; deferred until/unless that filter is relaxed.

### Family coordination

Several cvar families had their descriptions rewritten together for cross-reference consistency, even when only some members were verifier-flagged:

- `scr_scoreboard_login_{names,color,flagfile,indicator}` — authenticated-player scoreboard display. Each cvar now points to relevant siblings.
- `gl_powerupshells_{base1level,base2level,effect1level,effect2level}` — shell-layer tuning. Corrected the prior "opacity" framing (these are additive RGB color contributions per channel, not alpha; the actual alpha is `gl_powerupshells`).
- `hud_score_{team,enemy,difference,position}_{digits,align,colorize}` — score HUD elements. The `_digits` entries carry the augmented head description covering the whole family; `_align` and `_colorize` are sibling pointers referencing the head.
- `re_trigger_match_2..9` — PCRE capture-group siblings of the already-documented `re_trigger_match_0`. Pointer-style descriptions referencing `_0`.
- `cl_mvinset_{offset_x,offset_y,size_x,size_y,top,right}` — kept as individual descriptions (members differ by axis/dimension/role — family_collapse rejected).

## Methodology notes

Drafts went through a 5-sub-agent parallel verifier pass against current HEAD before this PR. 21 of 47 needs_doc/high drafts (45%) were flagged for correction or operator review; all flags resolved or sharpened before commit.

5 mechanical corrections were applied to drafts on 2026-05-26 from the verifier pass:
- `scr_damage_scale`: value=0 also falls through to 1.0 (not only negative values)
- `hud_ownfrags_timeout`: banner doesn't actually fade (alpha computed but not applied at draw)
- `hud_teaminfo_layout`: default uses `$x10/$x11` (both `$`, not mixed `$/%`)
- `r_drawworld`: only affects timedemos (`!cls.timedemo || r_drawworld.integer` short-circuits during normal play)
- `r_tracker_string_teammate`: string appears in both killer-role and victim-role contexts

9 verifier concerns were walked one-by-one with the operator before commit, resulting in description revisions (mostly via the `show usage / drop algorithm` principle: prefer concrete examples over format-prose).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
