### PR TITLE
rulesets: fix inverted strcasecmp in -ruleset cmdline dispatch + add smackdrive

### DIFF
--- a/src/rulesets.c
+++ b/src/rulesets.c
@@ -626,10 +626,13 @@ void Rulesets_Init(void)
 		} else if (!strcasecmp(COM_Argv(temp + 1), "mtfl")) {
 			Cvar_Set(&ruleset, "mtfl");
 			return;
-		} else if (strcasecmp(COM_Argv(temp + 1), "qcon")) {
+		} else if (!strcasecmp(COM_Argv(temp + 1), "qcon")) {
 			Cvar_Set(&ruleset, "qcon");
 			return;
-		} else if (strcasecmp(COM_Argv(temp + 1), "default")){
+		} else if (!strcasecmp(COM_Argv(temp + 1), "smackdrive")) {
+			Cvar_Set(&ruleset, "smackdrive");
+			return;
+		} else if (!strcasecmp(COM_Argv(temp + 1), "default")){
 			Cvar_Set(&ruleset, "default");
 			return;
 		} else {


### PR DESCRIPTION
## Summary

Two-line `!strcasecmp` inversion fix + a 4-line `smackdrive` cmdline-dispatch addition in `Rulesets_Init` (`src/rulesets.c:619-638`).

## Bug

Three branches (`smackdown` / `thunderdome` / `mtfl`) use `!strcasecmp(...)` correctly. Two (`qcon` / `default`) were missing the `!`, inverting the comparison:

```c
// before
} else if (strcasecmp(COM_Argv(temp + 1), "qcon")) {       // truthy when NOT "qcon"
    Cvar_Set(&ruleset, "qcon");
    return;
} else if (strcasecmp(COM_Argv(temp + 1), "default")){     // truthy when NOT "default"
    Cvar_Set(&ruleset, "default");
    return;
} else {
    Rulesets_Default();
    return;
}
```

As shipped:
- `-ruleset qcon` returns 0 from `strcasecmp` → falsy → branch NOT taken → falls through to inverted `default` branch and silently sets ruleset to `default`.
- `-ruleset default` likewise falsy on its own branch → falls through to final `else` and calls `Rulesets_Default()` (which happens to do the right thing by accident).
- `-ruleset somethingelse` is truthy on the inverted `qcon` branch → silently sets ruleset to `qcon`.

Blame shows the `default` inversion was the original sin (dimman, 2015-10-19, [`156b70d3`](https://github.com/QW-Group/ezquake-source/commit/156b70d37)) -- the same commit that wrote the three correct `!strcasecmp` branches above forgot the `!` on the fourth. `qcon` inherited the broken pattern when it was added in 2016 ([`be6109f3`](https://github.com/QW-Group/ezquake-source/commit/be6109f34)).

## Smackdrive addition

`rs_smackdrive` exists in the `rulesets.h:47` enum and is fully integrated at the runtime layer (8+ call sites, including the cvar OnChange dispatch at `rulesets.c:863` which already handles `Rulesets_Smackdrive(true)`). Only the cmdline dispatch in `Rulesets_Init` was missing it, so users could enable Smackdrive in-game via `ruleset smackdrive` but not via `+set ruleset smackdrive` / `-ruleset smackdrive` at launch. This PR adds the missing 4-line branch in the natural OnChange-matching order (qcon → smackdrive → default).

## Discovery context

Surfaced during the `help_cmdline_params.json` documentation audit in #1131. That PR ships a conservative `-ruleset` description listing only the three reliably-working values (`smackdown`, `thunderdome`, `mtfl`); after this PR merges a small follow-up will update the description to the full set.

## Diff

```diff
@@ -626,10 +626,13 @@ void Rulesets_Init(void)
                } else if (!strcasecmp(COM_Argv(temp + 1), "mtfl")) {
                        Cvar_Set(&ruleset, "mtfl");
                        return;
-               } else if (strcasecmp(COM_Argv(temp + 1), "qcon")) {
+               } else if (!strcasecmp(COM_Argv(temp + 1), "qcon")) {
                        Cvar_Set(&ruleset, "qcon");
                        return;
-               } else if (strcasecmp(COM_Argv(temp + 1), "default")){
+               } else if (!strcasecmp(COM_Argv(temp + 1), "smackdrive")) {
+                       Cvar_Set(&ruleset, "smackdrive");
+                       return;
+               } else if (!strcasecmp(COM_Argv(temp + 1), "default")){
                        Cvar_Set(&ruleset, "default");
                        return;
                } else {
```

5 insertions, 2 deletions.