### PR TITLE
sys_posix: remove dead early return in Sys_Printf DEBUG branch (restores 2013 commit intent)

### DIFF
--- a/src/sys_posix.c
+++ b/src/sys_posix.c
@@ -74,8 +74,6 @@ void Sys_Printf (char *fmt, ...)
 	char text[2048];
 	unsigned char *p;
 
-	return;
-
 	va_start (argptr,fmt);
 	vsnprintf (text, sizeof(text), fmt, argptr);
 	va_end (argptr);


### PR DESCRIPTION
## Summary

One-line removal of an unconditional `return;` inside the `#ifdef DEBUG` block of `Sys_Printf` in `src/sys_posix.c`. The early return contradicts the same commit that introduced it.

## Bug

`Sys_Printf` body (current HEAD, `src/sys_posix.c:70-94`):

```c
void Sys_Printf (char *fmt, ...)
{
#ifdef DEBUG
    va_list argptr;
    char text[2048];
    unsigned char *p;

    return;                          // <-- the dead early return

    va_start (argptr,fmt);
    vsnprintf (text, sizeof(text), fmt, argptr);
    va_end (argptr);

    if (sys_nostdout.value)
        return;

    for (p = (unsigned char *) text; *p; p++)
        ...
#else
    return;
#endif
}
```

The `return;` immediately after the local declarations makes the DEBUG branch dead code: `argptr / text / p` are declared and never used, the `sys_nostdout` check is unreachable, and the actual stdout write path never runs. Net behavior: `Sys_Printf` is silent on POSIX in both DEBUG and non-DEBUG builds, and `sys_nostdout` is unobservable on the client.

## Why this is the actual bug (and not the `#else return;`)

The commit that introduced both early returns + the `#ifdef DEBUG` wrapping is [`9972c26c`](https://github.com/QW-Group/ezquake-source/commit/9972c26c6) (dimman, 2013-12-29):

> **Sys_Printf is DEBUG only (stdout) + Apply gamma to screenshots**

That message states the intent: `Sys_Printf` writes to stdout in DEBUG builds, silent otherwise. The non-DEBUG `#else return;` matches that intent and matches the equivalent Windows pattern in [`sys_win.c:503-507`](https://github.com/QW-Group/ezquake-source/blob/master/src/sys_win.c#L503-L507):

```c
void Sys_Printf (char *fmt, ...)
{
#ifndef _DEBUG
    return;
#endif
    ...
}
```

So the `#else return;` on POSIX is intentional. The DEBUG-branch early return is the one that contradicts the commit message: "DEBUG only (stdout)" cannot be true if the DEBUG branch returns before any output.

## Fix

Remove the unconditional `return;` (and its trailing blank line) so the DEBUG branch reaches the stdout-write path it was always supposed to use.

```diff
@@ -74,8 +74,6 @@ void Sys_Printf (char *fmt, ...)
        char text[2048];
        unsigned char *p;

-       return;
-
        va_start (argptr,fmt);
        vsnprintf (text, sizeof(text), fmt, argptr);
        va_end (argptr);
```

2 deletions, 0 insertions.

## Effect

- **POSIX DEBUG client builds**: `Sys_Printf` now writes to stdout and honors `sys_nostdout` / `-nostdout`, as intended.
- **Non-DEBUG / release client builds**: unchanged. The `#else return;` at line 90 remains; release builds stay silent by design.
- **Dedicated server**: unaffected. `sv_sys_unix.c` defines and honors `sys_nostdout` independently and already worked.

## Discovery context

Surfaced during the `help_cmdline_params.json` documentation audit in #1131. That PR ships a description-of-intent for `-nostdout`; after this merges a follow-up will sharpen the description to reflect the actual (DEBUG-build) effect on the client and the always-on effect on the dedicated server.