### PR TITLE
RENDERER: Implement reverse-z infinite z-far

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -5564,6 +5564,13 @@
       ],
       "type": "integer"
     },
+    "gl_reverse_z": {
+      "default": "1",
+      "desc": "Enables reverse-z depth buffering with an infinite far plane suitable for maps of any size.",
+      "group-id": "35",
+      "remarks": "Takes effect on vid_restart. Only activates when a 32-bit float depth buffer is in use: requires vid_framebuffer 1, vid_framebuffer_depthformat 0 or 4, and OpenGL 4.5+ or the GL_ARB_clip_control extension. Falls back to conventional depth buffering otherwise.",
+      "type": "boolean"
+    },
     "gl_rl_globe": {
       "default": "0",
       "desc": "Helps customize rocket light independent of gl_flashblend.",

--- a/src/gl_framebuffer.c
+++ b/src/gl_framebuffer.c
@@ -279,13 +279,36 @@ void GL_InitialiseFramebufferHandling(void)
 		GL_LoadOptionalFunction(glNamedRenderbufferStorageMultisample);
 	}
 
-	// meag: disabled (classic needs glFrustum replaced, modern needs non-rubbish viewweapon
-	//                 depth hack, and near-plane clipping issues when the player is gibbed)
-	/*if (GL_VersionAtLeast(4, 5) || SDL_GL_ExtensionSupported("GL_ARB_clip_control")) {
+	if (GL_VersionAtLeast(4, 5) || SDL_GL_ExtensionSupported("GL_ARB_clip_control")) {
 		GL_LoadOptionalFunction(glClipControl);
-	}*/
+	}
 
 	memset(framebuffer_data, 0, sizeof(framebuffer_data));
+}
+
+void GL_InitialiseReversedDepth(void)
+{
+	extern cvar_t gl_reverse_z;
+	int depthformat = bound(0, vid_framebuffer_depthformat.integer, r_depthformat_count - 1);
+	qbool high_res_depth;
+
+	// reverse-z only pays off with a floating-point depth buffer, which requires
+	// rendering 3D to a framebuffer object (the default framebuffer is fixed-point)
+	high_res_depth = vid_framebuffer.integer && GL_Supported(R_SUPPORT_DEPTH32F) &&
+		(depthformat == r_depthformat_best || depthformat == r_depthformat_32bit_float);
+
+	glConfig.reversed_depth = (gl_reverse_z.integer && GL_Available(glClipControl) && high_res_depth);
+
+	if (glConfig.reversed_depth) {
+		// near plane maps to depth 1, infinity to 0, clear depth 0
+		GL_Procedure(glClipControl, GL_LOWER_LEFT, GL_ZERO_TO_ONE);
+		glClearDepth(0.0f);
+	}
+	else {
+		// fresh contexts default to GL_NEGATIVE_ONE_TO_ONE; don't call clipControl
+		// here as the pointer may be NULL
+		glClearDepth(1.0f);
+	}
 }
 
 void GL_FramebufferSetFiltering(qbool linear)
@@ -381,7 +404,7 @@ qbool GL_FramebufferCreate(framebuffer_id id, int width, int height)
 	if (framebuffer_depth_buffer[id]) {
 		GLenum depthFormat = glDepthFormats[bound(0, vid_framebuffer_depthformat.integer, r_depthformat_count - 1)];
 		if (depthFormat == 0) {
-			depthFormat = GL_Available(glClipControl) ? GL_DEPTH_COMPONENT32F : GL_DEPTH_COMPONENT32;
+			depthFormat = glConfig.reversed_depth ? GL_DEPTH_COMPONENT32F : GL_DEPTH_COMPONENT32;
 		}
 		if (depthFormat == GL_DEPTH_COMPONENT32F && !GL_Supported(R_SUPPORT_DEPTH32F)) {
 			depthFormat = GL_DEPTH_COMPONENT32;
@@ -411,23 +434,6 @@ qbool GL_FramebufferCreate(framebuffer_id id, int width, int height)
 
 		GL_FramebufferTexture(fb->glref, GL_DEPTH_ATTACHMENT, GL_TextureNameFromReference(fb->texture[fbtex_depth]), 0);
 #endif
-
-		if (GL_Available(glClipControl)) {
-			if (depthFormat == GL_DEPTH_COMPONENT32F) {
-				GL_Procedure(glClipControl, GL_LOWER_LEFT, GL_ZERO_TO_ONE);
-				glClearDepth(0.0f);
-				glConfig.reversed_depth = true;
-			}
-			else {
-				GL_Procedure(glClipControl, GL_LOWER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
-				glClearDepth(1.0f);
-				glConfig.reversed_depth = false;
-			}
-		}
-		else {
-			glConfig.reversed_depth = false;
-			glClearDepth(1.0f);
-		}
 	}
 
 	GL_FramebufferTexture(fb->glref, GL_COLOR_ATTACHMENT0, GL_TextureNameFromReference(fb->texture[fbtex_standard]), 0);

--- a/src/gl_framebuffer.h
+++ b/src/gl_framebuffer.h
@@ -43,6 +43,7 @@ typedef enum {
 } fbtex_id;
 
 void GL_InitialiseFramebufferHandling(void);
+void GL_InitialiseReversedDepth(void);
 qbool GL_FramebufferCreate(framebuffer_id id, int width, int height);
 void GL_FramebufferDelete(framebuffer_id id);
 void GL_FramebufferStartUsing(framebuffer_id id);

--- a/src/gl_program.c
+++ b/src/gl_program.c
@@ -1498,6 +1498,20 @@ static void GL_BuildCoreDefinitions(void)
 	memset(macro_definitions, 0, sizeof(macro_definitions));
 	strlcpy(macro_definitions, (R_UseModernOpenGL() ? "#define EZ_MODERN_GL\n" : "#define EZ_LEGACY_GL\n"), sizeof(macro_definitions));
 
+	// Reverse-z define + fog depth helper (reaches every GLM and GLC shader).
+	// gl_FragCoord.z/gl_FragCoord.w inverts under reverse-z (fog would vanish);
+	// 1.0/gl_FragCoord.w = w_clip = eye distance, depth-convention independent.
+	if (glConfig.reversed_depth) {
+		strlcat(macro_definitions, "#define EZQ_REVERSED_DEPTH\n", sizeof(macro_definitions));
+	}
+	strlcat(macro_definitions,
+		"#ifdef EZQ_REVERSED_DEPTH\n"
+		"#define fogFragDepth() (1.0 / gl_FragCoord.w)\n"
+		"#else\n"
+		"#define fogFragDepth() (gl_FragCoord.z / gl_FragCoord.w)\n"
+		"#endif\n",
+		sizeof(macro_definitions));
+
 #ifdef RENDERER_OPTION_MODERN_OPENGL
 	if (R_UseModernOpenGL()) {
 		if (GL_VersionAtLeast(4, 3)) {

--- a/src/gl_state.c
+++ b/src/gl_state.c
@@ -365,8 +365,8 @@ void GL_ApplyRenderingState(r_state_id id)
 	extern cvar_t gl_brush_polygonoffset;
 	rendering_state_t* current = &opengl.rendering_state;
 	float zRange[2] = {
-		glConfig.reversed_depth && false ? 1.0f - state->depth.nearRange : state->depth.nearRange,
-		glConfig.reversed_depth && false ? 1.0f - state->depth.farRange : state->depth.farRange,
+		glConfig.reversed_depth ? 1.0f - state->depth.farRange  : state->depth.nearRange,
+		glConfig.reversed_depth ? 1.0f - state->depth.nearRange : state->depth.farRange,
 	};
 
 	R_TraceEnterRegion(va("GL_ApplyRenderingState(%s)", state->name), true);
@@ -589,6 +589,17 @@ void GL_InitialiseState(void)
 {
 	R_InitRenderingState(r_state_default_opengl, false, "opengl", vao_none);
 	opengl.rendering_state = states[r_state_default_opengl];
+
+	// The state tracker seeds depth.func without issuing GL calls; GL's boot default
+	// is GL_LESS, so under reverse-z change-elision would strand the real state at
+	// GL_LESS. Force one explicit glDepthFunc for the seeded func.
+	if (glConfig.reversed_depth) {
+		glDepthFunc(glReversedDepthFunctions[opengl.rendering_state.depth.func]);
+	}
+	else {
+		glDepthFunc(glDepthFunctions[opengl.rendering_state.depth.func]);
+	}
+
 	R_InitialiseStates();
 
 	R_SetIdentityMatrix(R_ProjectionMatrix());
@@ -954,6 +965,12 @@ void R_CustomPolygonOffset(r_polygonoffset_t mode)
 		float factor = (mode == r_polygonoffset_standard ? bound(-1, gl_brush_polygonoffset_factor.value, 1) : 1);
 		float units = (mode == r_polygonoffset_standard ? bound(0, gl_brush_polygonoffset.value, 2) : 1);
 		qbool enabled = (mode == r_polygonoffset_standard || mode == r_polygonoffset_outlines) && units != 0;
+
+		if (glConfig.reversed_depth) {
+			// "farther" = smaller depth under reverse-z; negation preserves non-zero
+			factor = -factor;
+			units = -units;
+		}
 
 		if (enabled) {
 			if (!current->polygonOffset.fillEnabled) {

--- a/src/glm_aliasmodel.c
+++ b/src/glm_aliasmodel.c
@@ -108,7 +108,6 @@ extern float r_framelerp;
 
 #define DRAW_DETAIL_TEXTURES      (1 << 0)
 #define DRAW_CAUSTIC_TEXTURES     (1 << 1)
-#define DRAW_REVERSED_DEPTH       (1 << 2)
 #define DRAW_LERP_MUZZLEHACK      (1 << 3)
 #define DRAW_FLAT_SHADING         (1 << 4)
 #define DRAW_INSTANCED            (1 << 5)
@@ -153,7 +152,6 @@ qbool GLM_CompileAliasModelProgram(void)
 
 	unsigned int drawAlias_desiredOptions =
 		(r_refdef2.drawCaustics ? DRAW_CAUSTIC_TEXTURES : 0) |
-		(glConfig.reversed_depth ? DRAW_REVERSED_DEPTH : 0) |
 		(r_lerpmuzzlehack.integer ? DRAW_LERP_MUZZLEHACK : 0) |
 		(gl_smoothmodels.integer ? 0 : DRAW_FLAT_SHADING) |
 		(GL_Supported(R_SUPPORT_INSTANCED_RENDERING) ? DRAW_INSTANCED : 0);
@@ -179,9 +177,6 @@ qbool GLM_CompileAliasModelProgram(void)
 		}
 
 		strlcat(included_definitions, va("#define SAMPLER_COUNT %d\n", material_samplers_max), sizeof(included_definitions));
-		if (drawAlias_desiredOptions & DRAW_REVERSED_DEPTH) {
-			strlcat(included_definitions, "#define EZQ_REVERSED_DEPTH\n", sizeof(included_definitions));
-		}
 		if (drawAlias_desiredOptions & DRAW_LERP_MUZZLEHACK) {
 			strlcat(included_definitions, "#define EZQ_ALIASMODEL_MUZZLEHACK\n", sizeof(included_definitions));
 		}

--- a/src/glsl/draw_aliasmodel.fragment.glsl
+++ b/src/glsl/draw_aliasmodel.fragment.glsl
@@ -89,7 +89,7 @@ void main()
 
 			frag_colour = color1 * tex + color2 * altTex;
 #ifdef DRAW_FOG
-			frag_colour = applyFogBlend(frag_colour, gl_FragCoord.z / gl_FragCoord.w);
+			frag_colour = applyFogBlend(frag_colour, fogFragDepth());
 #endif
 			frag_colour *= shell_alpha;
 		}
@@ -105,13 +105,13 @@ void main()
 			}
 #endif
 #ifdef DRAW_FOG
-			frag_colour = applyFog(frag_colour, gl_FragCoord.z / gl_FragCoord.w);
+			frag_colour = applyFog(frag_colour, fogFragDepth());
 #endif
 			frag_colour *= fsBaseColor.a;
 		}
 	} else {
 #ifdef DRAW_FOG
-		frag_colour = applyFog(frag_colour, gl_FragCoord.z / gl_FragCoord.w);
+		frag_colour = applyFog(frag_colour, fogFragDepth());
 #endif
 	}
 }

--- a/src/glsl/draw_aliasmodel.vertex.glsl
+++ b/src/glsl/draw_aliasmodel.vertex.glsl
@@ -91,7 +91,10 @@ void main()
 
 	if ((fsFlags & AMF_WEAPONMODEL) != 0) {
 #ifdef EZQ_REVERSED_DEPTH
-		gl_Position.z *= 1 / 0.3;
+		// compress depth to the nearest 30% of the window range, equivalent to
+		// glDepthRange(0.7, 1.0): window z becomes 0.7 + 0.3 * z_ndc, and clip
+		// z stays within [0.7w, w] so the near plane can never clip it
+		gl_Position.z = 0.7 * gl_Position.w + 0.3 * gl_Position.z;
 #else
 		gl_Position.z *= 0.3;
 #endif

--- a/src/glsl/draw_sprites.fragment.glsl
+++ b/src/glsl/draw_sprites.fragment.glsl
@@ -19,6 +19,6 @@ void main()
 	}
 
 #ifdef DRAW_FOG
-	frag_color = applyFogBlend(frag_color, gl_FragCoord.z / gl_FragCoord.w);
+	frag_color = applyFogBlend(frag_color, fogFragDepth());
 #endif
 }

--- a/src/glsl/draw_world.fragment.glsl
+++ b/src/glsl/draw_world.fragment.glsl
@@ -167,7 +167,7 @@ void main()
 				frag_colour = vec4(FlatColor, 1);
 			}
 #ifdef DRAW_FOG
-			frag_colour = applyFog(frag_colour, gl_FragCoord.z / gl_FragCoord.w);
+			frag_colour = applyFog(frag_colour, fogFragDepth());
 #endif
 #ifdef DRAW_ALPHATEST_ENABLED
 			frag_colour *= alpha;
@@ -212,7 +212,7 @@ void main()
 				frag_colour = vec4(lmColor.rgb, 1) * frag_colour;
 			}
 #ifdef DRAW_FOG
-			frag_colour = applyFog(frag_colour, gl_FragCoord.z / gl_FragCoord.w);
+			frag_colour = applyFog(frag_colour, fogFragDepth());
 #endif
 #ifdef DRAW_ALPHATEST_ENABLED
 			frag_colour *= alpha;
@@ -262,7 +262,7 @@ void main()
 #endif
 
 #ifdef DRAW_FOG
-		frag_colour = applyFog(frag_colour, gl_FragCoord.z / gl_FragCoord.w);
+		frag_colour = applyFog(frag_colour, fogFragDepth());
 #endif
 
 #ifdef DRAW_ALPHATEST_ENABLED

--- a/src/glsl/glc/glc_aliasmodel_shadow.fragment.glsl
+++ b/src/glsl/glc/glc_aliasmodel_shadow.fragment.glsl
@@ -7,6 +7,6 @@ void main()
 	gl_FragColor = vec4(0, 0, 0, 0.5);
 
 #ifdef DRAW_FOG
-	gl_FragColor = applyFog(gl_FragColor, gl_FragCoord.z / gl_FragCoord.w);
+	gl_FragColor = applyFog(gl_FragColor, fogFragDepth());
 #endif
 }

--- a/src/glsl/glc/glc_aliasmodel_shell.fragment.glsl
+++ b/src/glsl/glc/glc_aliasmodel_shell.fragment.glsl
@@ -17,6 +17,6 @@ void main()
 	gl_FragColor = tex * fsBaseColor1 + alt * fsBaseColor2;
 
 #ifdef DRAW_FOG
-	gl_FragColor = applyFog(gl_FragColor, gl_FragCoord.z / gl_FragCoord.w);
+	gl_FragColor = applyFog(gl_FragColor, fogFragDepth());
 #endif
 }

--- a/src/glsl/glc/glc_aliasmodel_std.fragment.glsl
+++ b/src/glsl/glc/glc_aliasmodel_std.fragment.glsl
@@ -54,6 +54,6 @@ void main()
 #endif // BACKFACE_PASS
 
 #ifdef DRAW_FOG
-	gl_FragColor = applyFog(gl_FragColor, gl_FragCoord.z / gl_FragCoord.w);
+	gl_FragColor = applyFog(gl_FragColor, fogFragDepth());
 #endif
 }

--- a/src/glsl/glc/glc_draw_sprites.fragment.glsl
+++ b/src/glsl/glc/glc_draw_sprites.fragment.glsl
@@ -13,6 +13,6 @@ void main()
 	gl_FragColor = texture2D(materialSampler, TextureCoord) * fsColor;
 
 #ifdef DRAW_FOG
-	gl_FragColor = applyFogBlend(gl_FragColor, gl_FragCoord.z / gl_FragCoord.w);
+	gl_FragColor = applyFogBlend(gl_FragColor, fogFragDepth());
 #endif
 }

--- a/src/glsl/glc/glc_turbsurface.fragment.glsl
+++ b/src/glsl/glc/glc_turbsurface.fragment.glsl
@@ -26,6 +26,6 @@ void main()
 #endif
 
 #ifdef DRAW_FOG
-	gl_FragColor = applyFog(gl_FragColor, gl_FragCoord.z / gl_FragCoord.w);
+	gl_FragColor = applyFog(gl_FragColor, fogFragDepth());
 #endif
 }

--- a/src/glsl/glc/glc_world_drawflat.fragment.glsl
+++ b/src/glsl/glc/glc_world_drawflat.fragment.glsl
@@ -28,6 +28,6 @@ void main()
 	gl_FragColor = color * lightmap;
 
 #ifdef DRAW_FOG
-	gl_FragColor = applyFog(gl_FragColor, fogScale * gl_FragCoord.z / gl_FragCoord.w);
+	gl_FragColor = applyFog(gl_FragColor, fogScale * fogFragDepth());
 #endif
 }

--- a/src/glsl/glc/glc_world_textured.fragment.glsl
+++ b/src/glsl/glc/glc_world_textured.fragment.glsl
@@ -165,6 +165,6 @@ void main()
 #endif
 
 #ifdef DRAW_FOG
-	gl_FragColor = applyFog(gl_FragColor, gl_FragCoord.z / gl_FragCoord.w);
+	gl_FragColor = applyFog(gl_FragColor, fogFragDepth());
 #endif
 }

--- a/src/glsl/simple3d.fragment.glsl
+++ b/src/glsl/simple3d.fragment.glsl
@@ -8,6 +8,6 @@ void main(void)
 	frag_color = color;
 
 #ifdef DRAW_FOG
-	frag_color = applyFog(frag_color, gl_FragCoord.z / gl_FragCoord.w);
+	frag_color = applyFog(frag_color, fogFragDepth());
 #endif
 }

--- a/src/r_matrix.c
+++ b/src/r_matrix.c
@@ -338,8 +338,9 @@ void R_Frustum(double left, double right, double bottom, double top, double zNea
 	perspective[14] = -2 * (zFar * zNear) / (zFar - zNear);
 
 	if (glConfig.reversed_depth) {
-		perspective[10] = -zFar / (zNear - zFar) - 1;
-		perspective[14] = -(zNear * zFar) / (zNear - zFar);
+		// infinite far plane: z_ndc = zNear/dist, so near->1, infinity->0 (zFar unused)
+		perspective[10] = 0;
+		perspective[14] = zNear;
 	}
 
 	R_MultiplyMatrix(perspective, R_ProjectionMatrix(), new_projection);
@@ -347,7 +348,15 @@ void R_Frustum(double left, double right, double bottom, double top, double zNea
 
 #ifdef RENDERER_OPTION_CLASSIC_OPENGL
 	if (R_UseImmediateOpenGL()) {
-		GLC_Frustum(left, right, bottom, top, zNear, zFar);
+		// all callers run R_IdentityProjectionView() first, so loading the computed
+		// matrix is equivalent to multiplying here; glClipControl applies to the
+		// fixed-function pipeline so GLC needs nothing else
+		if (glConfig.reversed_depth) {
+			GLC_PopProjectionMatrix(R_ProjectionMatrix());
+		}
+		else {
+			GLC_Frustum(left, right, bottom, top, zNear, zFar);
+		}
 	}
 #endif
 }
@@ -396,6 +405,8 @@ qbool R_Project3DCoordinates(float objx, float objy, float objz, float* winx, fl
 	VectorScale(in, 1 / in[3], in);
 	*winx = view[0] + (1 + in[0]) * view[2] / 2;
 	*winy = view[1] + (1 + in[1]) * view[3] / 2;
+	// winz assumes [-1,1] NDC; under reverse-z this value is wrong, but it is
+	// computed-and-ignored by all callers
 	*winz = (1 + in[2]) / 2;
 
 	return true;

--- a/src/vid_common_gl.c
+++ b/src/vid_common_gl.c
@@ -53,6 +53,7 @@ static qbool GL_InitialiseRenderer(void)
 	glConfig.broken_features = 0;
 
 	GL_InitialiseFramebufferHandling();
+	GL_InitialiseReversedDepth();
 	GL_LoadProgramFunctions();
 	GL_LoadStateFunctions();
 	GL_LoadTextureManagementFunctions();
@@ -124,6 +125,20 @@ static qbool GL_InitialiseRenderer(void)
 	}
 	if (glConfig.supported_features & R_SUPPORT_FOG) {
 		R_TraceAPI("... fog");
+	}
+	if (glConfig.reversed_depth) {
+		R_TraceAPI("... reverse-z depth buffering (infinite far plane)");
+	}
+
+	{
+		extern cvar_t gl_reverse_z;
+
+		if (glConfig.reversed_depth) {
+			Com_Printf_State(PRINT_OK, "Reverse-Z depth buffering enabled (infinite far plane)\n");
+		}
+		else if (gl_reverse_z.integer) {
+			Com_Printf_State(PRINT_INFO, "Reverse-Z unavailable: requires vid_framebuffer 1, a 32-bit float depth buffer (vid_framebuffer_depthformat 0 or 4) and GL_ARB_clip_control\n");
+		}
 	}
 
 	if (glConfig.broken_features) {

--- a/src/vid_sdl2.c
+++ b/src/vid_sdl2.c
@@ -238,6 +238,7 @@ cvar_t vid_framebuffer_width       = {"vid_framebuffer_width",         "0",     
 cvar_t vid_framebuffer_height      = {"vid_framebuffer_height",        "0",       CVAR_NO_RESET | CVAR_AUTO, conres_changed_callback };
 cvar_t vid_framebuffer_scale       = {"vid_framebuffer_scale",         "1",       CVAR_NO_RESET, conres_changed_callback };
 cvar_t vid_framebuffer_depthformat = {"vid_framebuffer_depthformat",   "0",       CVAR_NO_RESET | CVAR_LATCH_GFX };
+cvar_t gl_reverse_z                = {"gl_reverse_z",                  "1",       CVAR_LATCH_GFX };
 cvar_t vid_framebuffer_hdr         = {"vid_framebuffer_hdr",           "0",       CVAR_NO_RESET | CVAR_LATCH_GFX };
 cvar_t vid_framebuffer_hdr_tonemap = {"vid_framebuffer_hdr_tonemap",   "0" };
 cvar_t vid_framebuffer_smooth      = {"vid_framebuffer_smooth",        "1",       CVAR_NO_RESET, framebuffer_smooth_changed_callback };
@@ -1030,6 +1031,7 @@ static void VID_RegisterLatchCvars(void)
 	Cvar_Register(&vid_framebuffer);
 	Cvar_Register(&vid_software_palette);
 	Cvar_Register(&vid_framebuffer_depthformat);
+	Cvar_Register(&gl_reverse_z);
 	Cvar_Register(&vid_framebuffer_hdr);
 
 #ifdef X11_GAMMA_WORKAROUND


### PR DESCRIPTION
Finish the dormant reverse-z support (glClipControl probing existed but was disabled) for both the classic (GLC) and modern (GLM) renderers, behind a new gl_reverse_z cvar (default on, applies on vid_restart, documented in help_variables.json).

Reverse-z with a 32-bit float depth buffer distributes depth precision evenly in view distance, eliminating z-fighting on distant geometry. The projection now also uses an infinite far plane, so r_farclip no longer clips geometry: useful for mappers placing detail far outside the playable area, and for very large maps (e.g. surf maps) that exceed the conventional far plane.

Reverse-z only activates when it actually pays off, i.e. when a float depth buffer will be used: requires vid_framebuffer 1 with vid_framebuffer_depthformat 0 (best) or 4 (32-bit float), plus GL 4.5 or GL_ARB_clip_control. Falls back to conventional depth otherwise (the default framebuffer only has fixed-point depth, where reverse-z brings no precision benefit), with a console notice explaining why.

Details:
- Clip control (GL_ZERO_TO_ONE) and glClearDepth(0) are now set once per context in GL_InitialiseReversedDepth() instead of per-framebuffer; FBO depth format prefers GL_DEPTH_COMPONENT32F when reversed.
- R_Frustum: reversed branch uses the infinite-far projection (m[10]=0, m[14]=zNear; near->1, infinity->0). GLC loads the computed matrix via glLoadMatrixf instead of rebuilding a conventional one with glFrustum.
- Depth range state translation fixed and enabled: logical [near,far] maps to window [1-far, 1-near], so the viewmodel range [0,0.3] becomes [0.7,1.0] (GLC path). Depth funcs were already inverted via the existing tables; also force-sync glDepthFunc at init so state-change elision can't leave the context at the GL default GL_LESS.
- GLM viewmodel: replace the old clip-space scale (z *= 1/0.3, which near-clipped the gun e.g. when gibbed) with z' = 0.7*w + 0.3*z, the clip-space equivalent of glDepthRange(0.7, 1.0); it can never near-clip and works within batched alias-model draws where per-draw depth range isn't possible.
- Fog: gl_FragCoord.z/gl_FragCoord.w inverts under reverse-z, so all fog call sites now use a fogFragDepth() macro that expands to 1.0/gl_FragCoord.w (exact eye distance) when reversed, legacy expression otherwise. EZQ_REVERSED_DEPTH is now injected globally into all shaders.
- Polygon offsets are negated when reversed ("farther" = smaller depth).