### PR TITLE
Antilag1 prototype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ set(common
         ${SOURCE_DIR}/net_chan.c
         ${SOURCE_DIR}/parser.c
         ${SOURCE_DIR}/pmove.c
+        ${SOURCE_DIR}/pmove_weapon.c
         ${SOURCE_DIR}/pmovetst.c
         ${SOURCE_DIR}/q_shared.c
         ${SOURCE_DIR}/sha1.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(USE_SYSTEM_LIBS          "Use system libraries instead of VCPKG"       ON
 option(RENDERER_MODERN_OPENGL   "Enable modern OpenGL renderer"               ON)
 option(RENDERER_CLASSIC_OPENGL  "Enable classic OpenGL renderer"              ON)
 option(DEBUG_MEMORY_ALLOCATIONS "Enable debug prints for memory allocations" OFF)
+option(ANTILAG                  "Enable antilag 1 prototype protocol extensions (client-side)" ON)
 option(ENABLE_SANDBOX           "Enables application sandboxing (macOS)"      ON)
 option(ENABLE_LTO               "Enable Link Time Optimization"               ON)
 
@@ -867,6 +868,13 @@ target_compile_definitions(ezquake PRIVATE
         $<$<BOOL:${HAVE_FREETYPE}>:EZ_FREETYPE_SUPPORT_STATIC>
 
         $<$<AND:$<BOOL:${HAVE_SPEEX}>,$<BOOL:${HAVE_SPEEXDSP}>>:WITH_SPEEX>
+
+        # antilag 1 prototype protocol extensions; values must match the
+        # commented-out defines in src/qwprot/src/protocol.h (shared with
+        # mvdsv, hence supplied from the compile command for client builds)
+        $<$<BOOL:${ANTILAG}>:MVD_PEXT1_WEAPONPREDICTION=128>
+        $<$<BOOL:${ANTILAG}>:MVD_PEXT1_SIMPLEPROJECTILE=256>
+        $<$<BOOL:${ANTILAG}>:FTE_PEXT_ACCURATETIMINGS=0x00000040>
 
         PCRE2_CODE_UNIT_WIDTH=8
 )

--- a/help_commands.json
+++ b/help_commands.json
@@ -1256,6 +1256,9 @@
   "penaltyremove": {
     "system-generated": true
   },
+  "pext_list": {
+    "description": "Prints the protocol extensions enabled by the client/server negotiation of the current connection (or the demo being played), grouped as FTE, FTE2 and MVD1 extensions with their hex masks. Extensions the server offered but the client declined (or vice versa) are not listed. Prints \"Not connected.\" when disconnected."
+  },
   "place": {
     "description": "`place <element> <area>` -- anchors the named HUD element to a named screen area or to another HUD element. Built-in area names are: `screen`, `top`, `view`, `sbar`, `ibar`, `hbar`, `sfree`, `ifree`, `hfree`. To anchor inside another element use `@elem`; to anchor outside it use the bare element name. Running `place <element>` with no area argument prints the element's current placement. An invalid area is rejected and the old value is restored. Example: `place fps view`, `place clock @ping`, `place ammo sbar`."
   },

--- a/help_variables.json
+++ b/help_variables.json
@@ -2067,6 +2067,12 @@
         }
       ]
     },
+    "cl_nopred_weapon": {
+      "default": "0",
+      "desc": "Disables the antilag 1 client-side weapon prediction (predicted weapon firing, sounds, projectiles and beams) even when the server supports it.",
+      "group-id": "21",
+      "type": "boolean"
+    },
     "cl_novweps": {
       "default": "0",
       "desc": "If set, disables support for zquake vwep extension.",
@@ -2185,6 +2191,12 @@
         }
       ]
     },
+    "cl_pext_accuratetimings": {
+      "default": "1",
+      "desc": "If set, requests FTE's accurate timings protocol extension during connect, giving millisecond-precision server time for entity interpolation. Used by the antilag 1 prototype.",
+      "group-id": "21",
+      "type": "boolean"
+    },
     "cl_pext_alpha": {
       "default": "1",
       "desc": "If set, enable support for FTE's alpha attribute protocol extension.",
@@ -2274,9 +2286,21 @@
       "group-id": "0",
       "type": "boolean"
     },
+    "cl_pext_simpleprojectiles": {
+      "default": "1",
+      "desc": "When 1, requests the MVD PEXT1 simple projectiles extension during connect. Supporting servers then send nails, grenades and rockets as lightweight stateless projectiles that the client flies locally, instead of interpolated entities. Part of the antilag 1 prototype.",
+      "group-id": "21",
+      "type": "boolean"
+    },
     "cl_pext_warndemos": {
       "default": "1",
       "desc": "If set, warning will be displayed when recording a demo that is not backwards compatible with old clients.",
+      "group-id": "21",
+      "type": "boolean"
+    },
+    "cl_pext_weaponprediction": {
+      "default": "1",
+      "desc": "When 1, requests the MVD PEXT1 weapon prediction extension during connect. Supporting servers then send the local player's weapon simulation state and the client predicts weapon firing, sounds, projectiles and beams ahead of the server. Part of the antilag 1 prototype.",
       "group-id": "21",
       "type": "boolean"
     },
@@ -2345,6 +2369,18 @@
         }
       ]
     },
+    "cl_predict_beam": {
+      "default": "1",
+      "desc": "With weapon prediction active, draws your own lightning beam immediately from the predicted state and suppresses the server-sent one.",
+      "group-id": "21",
+      "type": "boolean"
+    },
+    "cl_predict_buffer": {
+      "default": "1",
+      "desc": "Number of frames to delay predicted weapon effects, allowing mispredictions to be corrected before sounds and projectiles are shown. Higher values are safer but reduce the antilag benefit.",
+      "group-id": "21",
+      "type": "integer"
+    },
     "cl_predict_half": {
       "default": "0",
       "group-id": "21",
@@ -2361,6 +2397,12 @@
         }
       ]
     },
+    "cl_predict_jump": {
+      "default": "1",
+      "desc": "With weapon prediction active, plays your own jump sound immediately and ignores the server-sent one.",
+      "group-id": "21",
+      "type": "boolean"
+    },
     "cl_predict_players": {
       "default": "1",
       "desc": "This toggles the prediction for other players' movement. Unless you are having problems this variable should be left at \"1\".",
@@ -2376,6 +2418,24 @@
           "name": "true"
         }
       ]
+    },
+    "cl_predict_projectiles": {
+      "default": "1",
+      "desc": "With weapon prediction active, spawns your own nails, grenades and rockets immediately as locally simulated projectiles, which are merged with the server's projectiles when they arrive.",
+      "group-id": "21",
+      "type": "boolean"
+    },
+    "cl_predict_smoothview": {
+      "default": "1",
+      "desc": "With weapon prediction active, smooths out prediction error corrections of your view position instead of snapping. Values towards 2 decay the error faster, values towards 0.1 slower; 0 disables smoothing.",
+      "group-id": "21",
+      "type": "float"
+    },
+    "cl_predict_weaponsound": {
+      "default": "1",
+      "desc": "With weapon prediction active, plays your own weapon sounds immediately and ignores the server-sent ones. 0 disables, 1 predicts all weapon sounds, higher values are a bitmask excluding specific weapons from prediction: 2 axe, 4 shotgun/coilgun, 8 super shotgun, 16 nailgun, 32 super nailgun, 64 grenade launcher, 128 rocket launcher, 256 lightning gun.",
+      "group-id": "21",
+      "type": "integer"
     },
     "cl_proxyaddr": {
       "default": "",
@@ -2567,6 +2627,12 @@
     "cl_solid_players": {
       "default": "1",
       "desc": "If not set then client will not perform collision detection against other players.",
+      "group-id": "21",
+      "type": "boolean"
+    },
+    "cl_sproj_xerp": {
+      "default": "0",
+      "desc": "Extrapolates other players' simple projectiles by your latency (capped at 150 ms) so they are shown closer to where the server has them.",
       "group-id": "21",
       "type": "boolean"
     },

--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -1346,6 +1346,9 @@ void CL_ParsePlayerinfo (void)
 
 	player_state_t *prevstate, dummy;
 	int num, i;
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	int wep_predict = 0;
+#endif
 
 	extern void TP_ParsePlayerInfo(player_state_t *, player_state_t *, player_info_t *info);
 
@@ -1532,7 +1535,40 @@ void CL_ParsePlayerinfo (void)
 			state->effects = 0;
 
 		if (flags & PF_WEAPONFRAME)
+		{
 			state->weaponframe = MSG_ReadByte ();
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+			if (cls.mvdprotocolextensions1 & MVD_PEXT1_WEAPONPREDICTION)
+			{
+				wep_predict = MSG_ReadByte();
+				if (wep_predict)
+				{
+					state->impulse = MSG_ReadByte();
+
+					state->weapon = MSG_ReadShort();
+					state->items = cl.stats[STAT_ITEMS];
+
+					state->client_time = MSG_ReadFloat();
+					state->attack_finished = MSG_ReadFloat();
+					state->client_nextthink = MSG_ReadFloat();
+					state->client_thinkindex = MSG_ReadByte();
+					state->client_ping = MSG_ReadByte();
+					state->client_predflags = MSG_ReadByte();
+
+					state->ammo_shells = MSG_ReadByte();
+					state->ammo_nails = MSG_ReadByte();
+					state->ammo_rockets = MSG_ReadByte();
+					state->ammo_cells = MSG_ReadByte();
+				}
+			}
+			else
+			{
+				state->weapon = cl.stats[STAT_ACTIVEWEAPON];
+				state->items = cl.stats[STAT_ITEMS];
+			}
+#endif
+		}
 		else
 			state->weaponframe = 0;
 
@@ -1654,7 +1690,33 @@ guess_pm_type:
 			if (flags & PF_EFFECTS)
 				MSG_WriteByte(&cls.demomessage, state->effects);
 			if (flags & PF_WEAPONFRAME)
+			{
 				MSG_WriteByte(&cls.demomessage, state->weaponframe);
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+				if (cls.mvdprotocolextensions1 & MVD_PEXT1_WEAPONPREDICTION)
+				{
+					MSG_WriteByte(&cls.demomessage, wep_predict);
+					if (wep_predict)
+					{
+						MSG_WriteByte(&cls.demomessage, state->impulse);
+						MSG_WriteShort(&cls.demomessage, state->weapon);
+
+						MSG_WriteFloat(&cls.demomessage, state->client_time);
+						MSG_WriteFloat(&cls.demomessage, state->attack_finished);
+						MSG_WriteFloat(&cls.demomessage, state->client_nextthink);
+						MSG_WriteByte(&cls.demomessage, state->client_thinkindex);
+						MSG_WriteByte(&cls.demomessage, state->client_ping);
+						MSG_WriteByte(&cls.demomessage, state->client_predflags);
+
+						MSG_WriteByte(&cls.demomessage, state->ammo_shells);
+						MSG_WriteByte(&cls.demomessage, state->ammo_nails);
+						MSG_WriteByte(&cls.demomessage, state->ammo_rockets);
+						MSG_WriteByte(&cls.demomessage, state->ammo_cells);
+					}
+				}
+#endif
+			}
 #ifdef FTE_PEXT_TRANS
 			if (flags & PF_TRANS_Z && cls.fteprotocolextensions & FTE_PEXT_TRANS)
 				MSG_WriteByte(&cls.demomessage, state->alpha);		
@@ -1981,7 +2043,7 @@ static void CL_LinkPlayers(void)
 
 			oldphysent = pmove.numphysent;
 			CL_SetSolidPlayers(j);
-			CL_PredictUsercmd(state, &exact, &state->command);
+			CL_PredictUsercmd(state, &exact, &state->command, false);
 			pmove.numphysent = oldphysent;
 			VectorCopy(exact.origin, ent.origin);
 			VectorCopy(exact.origin, predicted_players[j].drawn_origin);
@@ -2220,7 +2282,7 @@ void CL_SetUpPlayerPrediction(qbool dopred)
 					msec = 255;
 				state->command.msec = msec;
 
-				CL_PredictUsercmd (state, &exact, &state->command);
+				CL_PredictUsercmd (state, &exact, &state->command, false);
 				VectorCopy (exact.origin, pplayer->origin);
 			}
 		}
@@ -2520,6 +2582,12 @@ void MVD_Interpolate(void)
 void CL_ClearPredict(void) {
 	memset(predicted_players, 0, sizeof(predicted_players));
 	mvd_fixangle = 0;
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	pmove.effect_frame = 0;
+	pmove.t_width = 0;
+	pmove.impulse = 0;
+	pmove.client_predflags = 0; // don't carry PRDFL_* over to the next server
+#endif
 }
 
 void CL_CalcPlayerFPS(player_info_t *info, int msec)

--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "qmb_particles.h"
 #include "rulesets.h"
 #include "teamplay.h"
+#include "cl_tent.h"
 
 static int MVD_TranslateFlags(int src);
 void TP_ParsePlayerInfo(player_state_t *, player_state_t *, player_info_t *info);	
@@ -62,6 +63,7 @@ void CL_InitEnts(void) {
 	memset(cl_modelnames, 0, sizeof(cl_modelnames));
 
 	cl_modelnames[mi_spike] = "progs/spike.mdl";
+	cl_modelnames[mi_s_spike] = "progs/s_spike.mdl";
 	cl_modelnames[mi_player] = "progs/player.mdl";
 	cl_modelnames[mi_eyes] = "progs/eyes.mdl";
 	cl_modelnames[mi_flag] = "progs/flag.mdl";
@@ -97,6 +99,8 @@ void CL_InitEnts(void) {
 	cl_modelnames[mi_weapon6] = "progs/v_rock.mdl";
 	cl_modelnames[mi_weapon7] = "progs/v_rock2.mdl";
 	cl_modelnames[mi_weapon8] = "progs/v_light.mdl";
+	cl_modelnames[mi_coilgun] = "progs/v_coil.mdl";
+	cl_modelnames[mi_hook] = "progs/v_star.mdl";
 
 	cl_modelnames[mi_vaxe] = "progs/v_axe.mdl";
 	cl_modelnames[mi_vbio] = "progs/v_bio.mdl";
@@ -1009,10 +1013,17 @@ void CL_LinkPacketEntities(void)
 
 		ent.model = model;
 
-		if (state->modelindex == cl_modelindices[mi_rocket]) 
+		if (state->modelindex == cl_modelindices[mi_rocket])
 		{
 			if (cl_rocket2grenade.value && cl_modelindices[mi_grenade] != -1)
 				ent.model = cl.model_precache[cl_modelindices[mi_grenade]];
+#ifdef EZQ_FAKEPROJ
+			CL_MatchFakeProjectile(cent);
+		}
+		else if (state->modelindex == cl_modelindices[mi_grenade])
+		{
+			CL_MatchFakeProjectile(cent);
+#endif
 		}
 
 		ent.skinnum = state->skinnum;

--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -856,6 +856,210 @@ void CL_ParsePacketEntities (qbool delta)
 	}
 }
 
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+
+static cs_sprojectile_t cs_sprojectiles[CL_MAX_EDICTS];
+
+// Called from CL_ClearTEnts so no projectile state survives a map change
+// or reconnect.
+void CL_ClearSimpleProjectiles(void)
+{
+	memset(cs_sprojectiles, 0, sizeof(cs_sprojectiles));
+}
+
+// Find the fake projectile a server-sent simple projectile corresponds to:
+// either the one it was matched to before, or (with weapon prediction) a
+// locally predicted projectile from the same owner close to its position.
+static int CL_SimpleProjectile_MatchFakeProj(cs_sprojectile_t *sproj, int entnum)
+{
+	fproj_t *prj;
+	int i;
+
+	for (i = 0, prj = cl_fakeprojectiles; i < MAX_FAKEPROJ; i++, prj++)
+	{
+		if (prj->endtime == 0)
+			continue;
+
+		if (prj->owner != sproj->owner)
+			continue;
+
+		if (cl.time > prj->endtime + 0.1)
+			continue;
+
+		if (prj->entnum == sproj->fproj_number)
+		{
+			return i;
+		}
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+		else if (cls.mvdprotocolextensions1 & MVD_PEXT1_WEAPONPREDICTION && prj->entnum == 0)
+		{
+			if (VectorDistance(sproj->origin, prj->org) > 24)
+				continue;
+
+			prj->entnum = entnum;
+			prj->endtime = prj->starttime + 5;
+			return i;
+		}
+#endif
+	}
+
+	return -1;
+}
+
+// An svc_packetsprojectiles message has just been parsed, deal with the rest
+// of the data stream: a frame number followed by (entnum, sendflags, fields)
+// triples, terminated by entnum 0. Entnum bit 0x8000 means removal.
+void CL_ParsePacketSimpleProjectiles(void)
+{
+	int word, sendflags;
+
+	MSG_ReadLong(); // frame number, used only by the disabled clc_ackframe path
+
+	while (true)
+	{
+		word = (unsigned short)MSG_ReadShort();
+
+		if (msg_badread) // something didn't parse right...
+			Host_Error("msg_badread in packetsprojectiles");
+
+		if (word == 0)
+			break;
+
+		if (word & 0x8000)
+		{
+			fproj_t *mis;
+
+			word &= ~0x8000;
+			word = bound(0, word, CL_MAX_EDICTS - 1);
+
+			mis = &cl_fakeprojectiles[cs_sprojectiles[word].fproj_number];
+			if (mis->entnum == word)
+			{
+				memset(mis, 0, sizeof(fproj_t));
+				mis->endtime = -1;
+				mis->index = 0;
+			}
+			memset(&cs_sprojectiles[word], 0, sizeof(cs_sprojectile_t));
+
+			continue;
+		}
+
+		word = bound(0, word, CL_MAX_EDICTS - 1);
+
+		fproj_t *mis;
+		int mis_new = 0;
+		if (cs_sprojectiles[word].active == false)
+			mis_new = 1;
+
+		cs_sprojectiles[word].active = true;
+		cs_sprojectile_t *cs_sproj = &cs_sprojectiles[word];
+		cs_sproj->fproj_number = bound(0, cs_sproj->fproj_number, MAX_FAKEPROJ - 1);
+		mis = &cl_fakeprojectiles[cs_sproj->fproj_number];
+
+		sendflags = (unsigned short)MSG_ReadShort();
+
+		if (sendflags & U_ORIGIN1)
+		{
+			cs_sproj->origin[0] = MSG_ReadFloat();
+			cs_sproj->origin[1] = MSG_ReadFloat();
+			cs_sproj->origin[2] = MSG_ReadFloat();
+
+			cs_sproj->velocity[0] = MSG_ReadFloat();
+			cs_sproj->velocity[1] = MSG_ReadFloat();
+			cs_sproj->velocity[2] = MSG_ReadFloat();
+		}
+
+		if (sendflags & U_ANGLE1)
+		{
+			cs_sproj->angles[0] = MSG_ReadAngle();
+			cs_sproj->angles[1] = MSG_ReadAngle();
+			cs_sproj->angles[2] = MSG_ReadAngle();
+		}
+
+		if (sendflags & U_MODEL)
+		{
+			cs_sproj->modelindex = MSG_ReadShort();
+			cs_sproj->owner = MSG_ReadShort();
+		}
+
+		if (sendflags & U_ORIGIN3)
+		{
+			cs_sproj->time_offset = -(float)MSG_ReadByte() / 255;
+		}
+
+		if (mis_new)
+		{
+			cs_sproj->fproj_number = -1;
+			cs_sproj->fproj_number = CL_SimpleProjectile_MatchFakeProj(cs_sproj, word);
+			if (cs_sproj->fproj_number < 0)
+			{
+				mis_new = 2;
+				mis = CL_AllocFakeProjectile();
+				cs_sproj->fproj_number = mis->index;
+			}
+
+			mis = &cl_fakeprojectiles[cs_sproj->fproj_number];
+
+			mis->starttime = cl.time;
+			VectorCopy(cs_sproj->origin, mis->start);
+		}
+
+		if (sendflags & U_ORIGIN1)
+		{
+			VectorCopy(cs_sproj->origin, mis->org);
+			VectorCopy(cs_sproj->velocity, mis->vel);
+
+			mis->starttime = cl.time;
+			VectorCopy(mis->org, mis->start);
+		}
+
+		if (sendflags & U_ANGLE1)
+		{
+			VectorCopy(cs_sproj->angles, mis->angs);
+		}
+
+		if (sendflags & U_MODEL)
+		{
+			mis->modelindex = cs_sproj->modelindex;
+			mis->owner = cs_sproj->owner;
+
+			if (mis->modelindex != 0 && cl.model_precache[mis->modelindex])
+			{
+				// apply the model's effect flags
+				mis->effects = cl.model_precache[mis->modelindex]->flags;
+
+				// a yucky hack to add nail trails
+				if (mis->modelindex == cl_modelindices[mi_spike] || mis->modelindex == cl_modelindices[mi_s_spike])
+				{
+					mis->effects |= 256;
+				}
+			}
+		}
+
+		mis->endtime = cl.time + 20;
+		if (mis_new)
+		{
+			mis->entnum = word;
+			if (mis_new == 2)
+			{
+				memset(&cl_entities[mis->entnum], 0, sizeof(centity_t));
+
+				VectorCopy(mis->org, mis->partorg);
+				if (cs_sproj->time_offset)
+				{
+					VectorMA(mis->partorg, cs_sproj->time_offset, cs_sproj->velocity, mis->partorg);
+				}
+			}
+			else
+			{
+				cl_entities[mis->entnum] = mis->cent;
+			}
+		}
+	}
+}
+
+#endif // MVD_PEXT1_SIMPLEPROJECTILE
+
 static qbool CL_SetAlphaByDistance(entity_t* ent)
 {
 	vec3_t diff;

--- a/src/cl_input.c
+++ b/src/cl_input.c
@@ -946,9 +946,15 @@ void CL_FinishMove(usercmd_t* cmd)
 		)
 		) {
 		cmd->impulse = 0;
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+		cmd->impulse_pred = 0;
+#endif
 	}
 	else {
 		cmd->impulse = in_impulse;
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+		cmd->impulse_pred = in_impulse;
+#endif
 	}
 	// } shaman RFE 1030281
 	in_impulse = 0;

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -596,6 +596,134 @@ unsigned int CL_SupportedMVDExtensions1(void)
 }
 #endif
 
+#if defined(PROTOCOL_VERSION_FTE) || defined(PROTOCOL_VERSION_FTE2) || defined(PROTOCOL_VERSION_MVD1)
+typedef struct pext_info_s {
+	unsigned int bit;
+	const char *name;
+} pext_info_t;
+
+static void CL_PrintPextGroup(const char *group, unsigned int active, const pext_info_t *info)
+{
+	unsigned int known = 0;
+
+	Com_Printf("%s: 0x%08x\n", group, active);
+	for (; info->name; info++) {
+		known |= info->bit;
+		if (active & info->bit) {
+			Com_Printf("  %s\n", info->name);
+		}
+	}
+	if (active & ~known) {
+		Com_Printf("  unknown bits: 0x%08x\n", active & ~known);
+	}
+}
+
+// Prints the protocol extensions that were enabled by the client/server
+// negotiation of the current connection (or the demo being played).
+static void CL_PextList_f(void)
+{
+#ifdef PROTOCOL_VERSION_FTE
+	static const pext_info_t fte_pexts[] = {
+#ifdef FTE_PEXT_TRANS
+		{ FTE_PEXT_TRANS, "FTE_PEXT_TRANS" },
+#endif
+#ifdef FTE_PEXT_ACCURATETIMINGS
+		{ FTE_PEXT_ACCURATETIMINGS, "FTE_PEXT_ACCURATETIMINGS" },
+#endif
+#ifdef FTE_PEXT_HLBSP
+		{ FTE_PEXT_HLBSP, "FTE_PEXT_HLBSP" },
+#endif
+#ifdef FTE_PEXT_MODELDBL
+		{ FTE_PEXT_MODELDBL, "FTE_PEXT_MODELDBL" },
+#endif
+#ifdef FTE_PEXT_ENTITYDBL
+		{ FTE_PEXT_ENTITYDBL, "FTE_PEXT_ENTITYDBL" },
+#endif
+#ifdef FTE_PEXT_ENTITYDBL2
+		{ FTE_PEXT_ENTITYDBL2, "FTE_PEXT_ENTITYDBL2" },
+#endif
+#ifdef FTE_PEXT_FLOATCOORDS
+		{ FTE_PEXT_FLOATCOORDS, "FTE_PEXT_FLOATCOORDS" },
+#endif
+#ifdef FTE_PEXT_SPAWNSTATIC2
+		{ FTE_PEXT_SPAWNSTATIC2, "FTE_PEXT_SPAWNSTATIC2" },
+#endif
+#ifdef FTE_PEXT_COLOURMOD
+		{ FTE_PEXT_COLOURMOD, "FTE_PEXT_COLOURMOD" },
+#endif
+#ifdef FTE_PEXT_256PACKETENTITIES
+		{ FTE_PEXT_256PACKETENTITIES, "FTE_PEXT_256PACKETENTITIES" },
+#endif
+#ifdef FTE_PEXT_CHUNKEDDOWNLOADS
+		{ FTE_PEXT_CHUNKEDDOWNLOADS, "FTE_PEXT_CHUNKEDDOWNLOADS" },
+#endif
+#ifdef FTE_PEXT_CSQC
+		{ FTE_PEXT_CSQC, "FTE_PEXT_CSQC" },
+#endif
+#ifdef FTE_PEXT_DPFLAGS
+		{ FTE_PEXT_DPFLAGS, "FTE_PEXT_DPFLAGS" },
+#endif
+		{ 0, NULL }
+	};
+#endif
+#ifdef PROTOCOL_VERSION_FTE2
+	static const pext_info_t fte2_pexts[] = {
+#ifdef FTE_PEXT2_VOICECHAT
+		{ FTE_PEXT2_VOICECHAT, "FTE_PEXT2_VOICECHAT" },
+#endif
+		{ 0, NULL }
+	};
+#endif
+#ifdef PROTOCOL_VERSION_MVD1
+	static const pext_info_t mvd1_pexts[] = {
+#ifdef MVD_PEXT1_FLOATCOORDS
+		{ MVD_PEXT1_FLOATCOORDS, "MVD_PEXT1_FLOATCOORDS" },
+#endif
+#ifdef MVD_PEXT1_HIGHLAGTELEPORT
+		{ MVD_PEXT1_HIGHLAGTELEPORT, "MVD_PEXT1_HIGHLAGTELEPORT" },
+#endif
+#ifdef MVD_PEXT1_SERVERSIDEWEAPON
+		{ MVD_PEXT1_SERVERSIDEWEAPON, "MVD_PEXT1_SERVERSIDEWEAPON" },
+#endif
+#ifdef MVD_PEXT1_DEBUG_WEAPON
+		{ MVD_PEXT1_DEBUG_WEAPON, "MVD_PEXT1_DEBUG_WEAPON" },
+#endif
+#ifdef MVD_PEXT1_DEBUG_ANTILAG
+		{ MVD_PEXT1_DEBUG_ANTILAG, "MVD_PEXT1_DEBUG_ANTILAG" },
+#endif
+#ifdef MVD_PEXT1_HIDDEN_MESSAGES
+		{ MVD_PEXT1_HIDDEN_MESSAGES, "MVD_PEXT1_HIDDEN_MESSAGES" },
+#endif
+#ifdef MVD_PEXT1_SERVERSIDEWEAPON2
+		{ MVD_PEXT1_SERVERSIDEWEAPON2, "MVD_PEXT1_SERVERSIDEWEAPON2" },
+#endif
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+		{ MVD_PEXT1_WEAPONPREDICTION, "MVD_PEXT1_WEAPONPREDICTION" },
+#endif
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+		{ MVD_PEXT1_SIMPLEPROJECTILE, "MVD_PEXT1_SIMPLEPROJECTILE" },
+#endif
+		{ 0, NULL }
+	};
+#endif
+
+	if (cls.state == ca_disconnected) {
+		Com_Printf("Not connected.\n");
+		return;
+	}
+
+#ifdef PROTOCOL_VERSION_FTE
+	CL_PrintPextGroup("FTE extensions", cls.fteprotocolextensions, fte_pexts);
+#endif
+#ifdef PROTOCOL_VERSION_FTE2
+	CL_PrintPextGroup("FTE2 extensions", cls.fteprotocolextensions2, fte2_pexts);
+#endif
+#ifdef PROTOCOL_VERSION_MVD1
+	CL_PrintPextGroup("MVD1 extensions", cls.mvdprotocolextensions1, mvd1_pexts);
+#endif
+}
+#endif
+
 // Called by CL_Connect_f and CL_CheckResend
 static void CL_SendConnectPacket(
 #ifdef PROTOCOL_VERSION_FTE
@@ -2057,6 +2185,9 @@ static void CL_InitLocal(void)
 	Cmd_AddCommand ("dns", CL_DNS_f);
 	Cmd_AddCommand ("hash", CL_Hash_f);
 	Cmd_AddCommand ("reconnect", CL_Reconnect_f);
+#if defined(PROTOCOL_VERSION_FTE) || defined(PROTOCOL_VERSION_FTE2) || defined(PROTOCOL_VERSION_MVD1)
+	Cmd_AddCommand ("pext_list", CL_PextList_f);
+#endif
 
 	Cmd_AddMacro(macro_connectiontype, CL_Macro_ConnectionType);
 	Cmd_AddMacro(macro_demoplayback, CL_Macro_Demoplayback);

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -138,6 +138,10 @@ cvar_t cl_pext_alpha = {"cl_pext_alpha", "1"};
 cvar_t cl_pext_colourmod = {"cl_pext_colourmod", "1"};
 #endif
 
+#ifdef FTE_PEXT_ACCURATETIMINGS
+cvar_t cl_pext_accuratetimings = {"cl_pext_accuratetimings", "1"};
+#endif
+
 #ifdef CLIENTONLY
 #define PROCESS_SERVERPACKETS_IMMEDIATELY (0)
 #else
@@ -504,11 +508,13 @@ unsigned int CL_SupportedFTEExtensions (void)
 #endif
 	}
 
-	if (cl_pext_other.value)
-	{
 #ifdef FTE_PEXT_ACCURATETIMINGS
+	if (cl_pext_accuratetimings.value)
 		fteprotextsupported |= FTE_PEXT_ACCURATETIMINGS;
 #endif
+
+	if (cl_pext_other.value)
+	{
 #ifdef FTE_PEXT_HLBSP
 		fteprotextsupported |= FTE_PEXT_HLBSP;
 #endif
@@ -1946,6 +1952,9 @@ static void CL_InitLocal(void)
 #endif
 #ifdef FTE_PEXT_COLOURMOD
 	Cvar_Register(&cl_pext_colourmod);
+#endif
+#ifdef FTE_PEXT_ACCURATETIMINGS
+	Cvar_Register(&cl_pext_accuratetimings);
 #endif
 
 	Cvar_SetCurrentGroup(CVAR_GROUP_INPUT_KEYBOARD);

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -117,6 +117,9 @@ cvar_t  cl_pext_lagteleport = { "cl_pext_lagteleport", "1" }; // server-side adj
 #ifdef MVD_PEXT1_SERVERSIDEWEAPON
 cvar_t  cl_pext_serversideweapon = { "cl_pext_serversideweapon", "0", 0, onchange_pext_serversideweapon }; // server-side weapon selection
 #endif
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+cvar_t  cl_pext_weaponprediction = { "cl_pext_weaponprediction", "1" }; // client-side weapon prediction
+#endif
 #endif
 #ifdef FTE_PEXT_256PACKETENTITIES
 cvar_t	cl_pext_256packetentities = {"cl_pext_256packetentities", "1"};
@@ -564,6 +567,12 @@ unsigned int CL_SupportedMVDExtensions1(void)
 #ifdef MVD_PEXT1_SERVERSIDEWEAPON
 	if (cl_pext_serversideweapon.integer) {
 		extensions_supported |= MVD_PEXT1_SERVERSIDEWEAPON;
+	}
+#endif
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	if (cl_pext_weaponprediction.integer) {
+		extensions_supported |= MVD_PEXT1_WEAPONPREDICTION;
 	}
 #endif
 
@@ -1933,6 +1942,9 @@ static void CL_InitLocal(void)
 #endif
 #ifdef MVD_PEXT1_SERVERSIDEWEAPON
 	Cvar_Register(&cl_pext_serversideweapon);
+#endif
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	Cvar_Register(&cl_pext_weaponprediction);
 #endif
 #endif // PROTOCOL_VERSION_FTE
 #ifdef FTE_PEXT_256PACKETENTITIES

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -120,6 +120,10 @@ cvar_t  cl_pext_serversideweapon = { "cl_pext_serversideweapon", "0", 0, onchang
 #ifdef MVD_PEXT1_WEAPONPREDICTION
 cvar_t  cl_pext_weaponprediction = { "cl_pext_weaponprediction", "1" }; // client-side weapon prediction
 #endif
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+cvar_t  cl_pext_simpleprojectiles = { "cl_pext_simpleprojectiles", "1" }; // send simple stateless projectiles
+cvar_t  cl_sproj_xerp = { "cl_sproj_xerp", "0" }; // extrapolate projectiles based on ping
+#endif
 #endif
 #ifdef FTE_PEXT_256PACKETENTITIES
 cvar_t	cl_pext_256packetentities = {"cl_pext_256packetentities", "1"};
@@ -573,6 +577,12 @@ unsigned int CL_SupportedMVDExtensions1(void)
 #ifdef MVD_PEXT1_WEAPONPREDICTION
 	if (cl_pext_weaponprediction.integer) {
 		extensions_supported |= MVD_PEXT1_WEAPONPREDICTION;
+	}
+#endif
+
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+	if (cl_pext_simpleprojectiles.integer) {
+		extensions_supported |= MVD_PEXT1_SIMPLEPROJECTILE;
 	}
 #endif
 
@@ -1945,6 +1955,10 @@ static void CL_InitLocal(void)
 #endif
 #ifdef MVD_PEXT1_WEAPONPREDICTION
 	Cvar_Register(&cl_pext_weaponprediction);
+#endif
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+	Cvar_Register(&cl_pext_simpleprojectiles);
+	Cvar_Register(&cl_sproj_xerp);
 #endif
 #endif // PROTOCOL_VERSION_FTE
 #ifdef FTE_PEXT_256PACKETENTITIES

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -4211,6 +4211,13 @@ void CL_ParseServerMessage (void)
 					CL_ParseQizmoVoice();
 					break;
 				}
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+			case svc_packetsprojectiles:
+				{
+					CL_ParsePacketSimpleProjectiles();
+					break;
+				}
+#endif
 		}
 
 		// cl_messages, update size

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -1969,6 +1969,53 @@ void CL_ParseStartSoundPacket(void)
 	if (ent > CL_MAX_EDICTS)
 		Host_Error ("CL_ParseStartSoundPacket: ent = %i", ent);
 
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	// skip our own weapon/jump sounds if we are predicting them
+	if (ent == cl.playernum + 1 && PM_WeaponPredictionActive())
+	{
+		extern cvar_t cl_nopred;
+
+		if (cl_predict_weaponsound.integer != 0)
+		{
+			if (channel == 1)
+			{
+				int predict_sound = true;
+
+				if (cl_predict_weaponsound.integer > 1)
+				{
+					predict_sound = PM_FilterWeaponSound(sound_num);
+				}
+				else if (strcmp(cl.sound_precache[sound_num]->name, "player/axhit2.wav") == 0)
+				{
+					predict_sound = false;
+				}
+
+				if (predict_sound)
+					return;
+			}
+
+			// the lightning start sound is played on channel 0, not the weapon channel
+			if (channel == 0)
+			{
+				if (!(cl_predict_weaponsound.integer & 256))
+				{
+					if (strcmp(cl.sound_precache[sound_num]->name, "weapons/lstart.wav") == 0)
+						return;
+				}
+			}
+		}
+
+		if (cl_predict_jump.integer && !cl_nopred.integer)
+		{
+			if (channel == 4)
+			{
+				if (strcmp(cl.sound_precache[sound_num]->name, "player/plyrjmp8.wav") == 0)
+					return;
+			}
+		}
+	}
+#endif
+
 	// MVD Playback
     if (cls.mvdplayback)
 	{

--- a/src/cl_pred.c
+++ b/src/cl_pred.c
@@ -19,9 +19,28 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 #include "quakedef.h"
 #include "pmove.h"
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+#include "qsound.h"
+#include "cl_tent.h"
+#endif
 
 
 cvar_t	cl_nopred	= {"cl_nopred", "0"};
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+cvar_t	cl_nopred_weapon = { "cl_nopred_weapon", "0" };
+cvar_t	cl_predict_weaponsound = { "cl_predict_weaponsound", "1" };
+cvar_t	cl_predict_smoothview = { "cl_predict_smoothview", "1" };
+cvar_t	cl_predict_beam = { "cl_predict_beam", "1" };
+cvar_t	cl_predict_projectiles = { "cl_predict_projectiles", "1" };
+cvar_t	cl_predict_jump = { "cl_predict_jump", "1" };
+cvar_t	cl_predict_buffer = { "cl_predict_buffer", "1" };
+
+prediction_event_fakeproj_t	*p_event_fakeproj;
+prediction_event_sound_t	*p_event_sound;
+
+sfx_t *cl_sfx_jump, *cl_sfx_ax1, *cl_sfx_sg, *cl_sfx_ssg, *cl_sfx_ng, *cl_sfx_sng,
+	*cl_sfx_gl, *cl_sfx_rl, *cl_sfx_lg, *cl_sfx_lghit, *cl_sfx_coil;
+#endif
 
 extern cvar_t cl_independentPhysics;
 
@@ -37,7 +56,24 @@ qbool clpred_newpos = false;
 static qbool nolerp[2];
 static qbool nolerp_nextpos;
 
-void CL_PredictUsercmd (player_state_t *from, player_state_t *to, usercmd_t *u) {
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+void CL_InitWepSounds(void)
+{
+	cl_sfx_jump = S_PrecacheSound("player/plyrjmp8.wav");
+	cl_sfx_ax1 = S_PrecacheSound("weapons/ax1.wav");
+	cl_sfx_sg = S_PrecacheSound("weapons/guncock.wav");
+	cl_sfx_ssg = S_PrecacheSound("weapons/shotgn2.wav");
+	cl_sfx_ng = S_PrecacheSound("weapons/rocket1i.wav");
+	cl_sfx_sng = S_PrecacheSound("weapons/spike2.wav");
+	cl_sfx_gl = S_PrecacheSound("weapons/grenade.wav");
+	cl_sfx_rl = S_PrecacheSound("weapons/sgun1.wav");
+	cl_sfx_lg = S_PrecacheSound("weapons/lstart.wav");
+	cl_sfx_lghit = S_PrecacheSound("weapons/lhit.wav");
+	cl_sfx_coil = S_PrecacheSound("weapons/coilgun.wav");
+}
+#endif
+
+void CL_PredictUsercmd (player_state_t *from, player_state_t *to, usercmd_t *u, qbool local) {
 	// split up very long moves
 	if (u->msec > 50) {
 		player_state_t temp;
@@ -46,14 +82,39 @@ void CL_PredictUsercmd (player_state_t *from, player_state_t *to, usercmd_t *u) 
 		split = *u;
 		split.msec /= 2;
 
-		CL_PredictUsercmd (from, &temp, &split);
-		CL_PredictUsercmd (&temp, to, &split);
+		CL_PredictUsercmd (from, &temp, &split, local);
+		CL_PredictUsercmd (&temp, to, &split, local);
 		return;
 	}
 
 	VectorCopy (from->origin, pmove.origin);
 	VectorCopy (u->angles, pmove.angles);
 	VectorCopy (from->velocity, pmove.velocity);
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	// we only care about these values for our local player
+	if (local)
+	{
+		pmove.client_time = from->client_time;
+		pmove.attack_finished = from->attack_finished;
+		pmove.client_nextthink = from->client_nextthink;
+		pmove.client_thinkindex = from->client_thinkindex;
+		pmove.client_ping = from->client_ping;
+		pmove.client_predflags = from->client_predflags;
+
+		pmove.ammo_shells = from->ammo_shells;
+		pmove.ammo_nails = from->ammo_nails;
+		pmove.ammo_rockets = from->ammo_rockets;
+		pmove.ammo_cells = from->ammo_cells;
+
+		pmove.weapon_index = from->weapon_index;
+		pmove.weaponframe = from->weaponframe;
+		pmove.weapon = from->weapon;
+		pmove.items = from->items;
+
+		pmove.impulse = from->impulse;
+	}
+#endif
 
 	pmove.jump_msec = (cl.z_ext & Z_EXT_PM_TYPE) ? 0 : from->jump_msec;
 	pmove.jump_held = from->jump_held;
@@ -77,6 +138,35 @@ void CL_PredictUsercmd (player_state_t *from, player_state_t *to, usercmd_t *u) 
 
 	PM_PlayerMove();
 
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	if (local)
+	{
+		if (PM_WeaponPredictionActive())
+			PM_PlayerWeapon();
+		else
+			pmove.impulse = 0;
+
+		to->client_time = pmove.client_time;
+		to->attack_finished = pmove.attack_finished;
+		to->client_nextthink = pmove.client_nextthink;
+		to->client_thinkindex = pmove.client_thinkindex;
+		to->client_ping = from->client_ping;
+		to->client_predflags = from->client_predflags;
+
+		to->ammo_shells = pmove.ammo_shells;
+		to->ammo_nails = pmove.ammo_nails;
+		to->ammo_rockets = pmove.ammo_rockets;
+		to->ammo_cells = pmove.ammo_cells;
+
+		to->weapon_index = pmove.weapon_index;
+		to->weaponframe = pmove.weaponframe;
+		to->weapon = pmove.weapon;
+		to->items = pmove.items;
+
+		to->impulse = pmove.impulse;
+	}
+#endif
+
 	to->waterjumptime = pmove.waterjumptime;
 	to->pm_type = pmove.pm_type;
 	to->jump_held = pmove.jump_held;
@@ -88,7 +178,13 @@ void CL_PredictUsercmd (player_state_t *from, player_state_t *to, usercmd_t *u) 
 	VectorCopy (pmove.velocity, to->velocity);
 	to->onground = pmove.onground;
 
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	// for the local player the weapon prediction block above set weaponframe
+	if (!local)
+		to->weaponframe = from->weaponframe;
+#else
 	to->weaponframe = from->weaponframe;
+#endif
 }
 
 //Used when cl_nopred is 1 to determine whether we are on ground, otherwise stepup smoothing code produces ugly jump physics
@@ -300,6 +396,143 @@ static void check_standing_on_entity(void)
         cl_independentPhysics.value);
 }
 
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+static void CL_ClearPredictionEvents(void)
+{
+	while (p_event_sound != NULL)
+	{
+		prediction_event_sound_t *s_event = p_event_sound;
+		p_event_sound = s_event->next;
+		Q_free(s_event);
+	}
+
+	while (p_event_fakeproj != NULL)
+	{
+		prediction_event_fakeproj_t *p_event = p_event_fakeproj;
+		p_event_fakeproj = p_event->next;
+		Q_free(p_event);
+	}
+}
+
+// Play the sounds and spawn the fake projectiles queued up by weapon
+// prediction. Events are delayed by up to cl_predict_buffer frames so a
+// mispredicted attack can be corrected before its effects are shown.
+static void CL_PlayEvents(void)
+{
+	int threshold = bound(min(cl.validsequence + 2, cls.netchan.outgoing_sequence - 1),
+	                      cls.netchan.outgoing_sequence - (cl_predict_buffer.integer + 1),
+	                      cls.netchan.outgoing_sequence - 1);
+	player_state_t *new_state, *state;
+	prediction_event_sound_t *s_event;
+	prediction_event_fakeproj_t *p_event;
+
+	if (pmove.effect_frame >= threshold)
+		return;
+
+	new_state = &cl.frames[(cls.netchan.outgoing_sequence - 1) & UPDATE_MASK].playerstate[cl.playernum];
+	state = &cl.frames[threshold & UPDATE_MASK].playerstate[cl.playernum];
+
+	for (s_event = p_event_sound; s_event != NULL; s_event = s_event->next)
+	{
+		if (s_event->frame_num > pmove.effect_frame && s_event->frame_num <= threshold)
+		{
+			S_StartSound(cl.playernum + 1, s_event->chan, s_event->sample, pmove.origin, s_event->vol, 0);
+		}
+	}
+
+	for (p_event = p_event_fakeproj; p_event != NULL; p_event = p_event->next)
+	{
+		if (p_event->frame_num > pmove.effect_frame && p_event->frame_num <= threshold)
+		{
+			player_state_t *this_state = &cl.frames[p_event->frame_num & UPDATE_MASK].playerstate[cl.playernum];
+			float ms_diff = max((new_state->state_time - this_state->state_time), 0);
+
+			if (p_event->type == IT_LIGHTNING)
+			{
+				vec3_t start, end, forward;
+				trace_t hittrace;
+
+				if (pmove.client_time >= pmove.t_width)
+				{
+					pmove.t_width = pmove.client_time + 0.6;
+
+					if (!((cl_predict_weaponsound.integer == 0) || (cl_predict_weaponsound.integer & 256)))
+					{
+						S_StartSound(cl.playernum + 1, 1, cl_sfx_lghit, pmove.origin, 1, 0);
+					}
+				}
+
+				if (!cl_predict_beam.integer)
+					continue;
+
+				VectorCopy(p_event->origin, start);
+				VectorCopy(start, end);
+
+				AngleVectors(p_event->angles, forward, NULL, NULL);
+				VectorScale(forward, 600, forward);
+				VectorAdd(end, forward, end);
+
+				hittrace = PM_TraceLine(start, end);
+				CL_CreateBeam(2, cl.playernum + 1, start, hittrace.endpos);
+			}
+			else
+			{
+				fproj_t *newmis;
+
+				if (!cl_predict_projectiles.integer)
+					continue;
+
+				switch (p_event->type)
+				{
+				case IT_NAILGUN:
+					newmis = CL_CreateFakeNail();
+					break;
+				case IT_SUPER_NAILGUN:
+					newmis = CL_CreateFakeSuperNail();
+					break;
+				case IT_GRENADE_LAUNCHER:
+					newmis = CL_CreateFakeGrenade();
+					break;
+				default:
+					newmis = CL_CreateFakeRocket();
+					break;
+				}
+
+				if (newmis == NULL)
+					continue;
+
+				VectorCopy(p_event->angles, newmis->angs);
+				VectorCopy(p_event->origin, newmis->org);
+				VectorCopy(p_event->origin, newmis->start);
+				VectorCopy(p_event->velocity, newmis->vel);
+				VectorCopy(p_event->avelocity, newmis->avel);
+				VectorMA(p_event->origin, 0.05, p_event->velocity, newmis->partorg);
+
+				// back-date the projectile by how long ago the firing frame was predicted
+				newmis->parttime -= max(ms_diff + 0.013, 0);
+				newmis->starttime -= max(ms_diff + 0.025, 0);
+				newmis->endtime -= max(ms_diff - 0.013, 0);
+
+				if (p_event->type == IT_GRENADE_LAUNCHER)
+				{
+					Fproj_Physics_Bounce(newmis, 0.02);
+					Fproj_Physics_Bounce(newmis, max(ms_diff - 0.013, 0));
+				}
+				else
+				{
+					VectorMA(newmis->org, ms_diff, newmis->vel, newmis->org);
+				}
+			}
+		}
+	}
+
+	cl.simwepframe = state->weaponframe;
+	cl.simwep = state->weapon_index;
+
+	pmove.effect_frame = threshold;
+}
+#endif // MVD_PEXT1_WEAPONPREDICTION
+
 void CL_PredictMove (qbool physframe) {
 	int i, oldphysent;
 	frame_t *from = NULL, *to;
@@ -364,18 +597,104 @@ void CL_PredictMove (qbool physframe) {
 		oldphysent = pmove.numphysent;
 		CL_SetSolidPlayers (cl.playernum);
 
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+		pmove_nopred_weapon = (cl_nopred_weapon.integer || pmove.client_predflags == PRDFL_FORCEOFF || cl.spectator);
+
+		CL_ClearPredictionEvents();
+#endif
+
 		// run frames
 		for (i = 1; i < UPDATE_BACKUP - 1 && cl.validsequence + i < cls.netchan.outgoing_sequence; i++) {
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+			pmove.frame_current = cl.validsequence + i;
+#endif
+
 			from = to;
 			to = &cl.frames[(cl.validsequence + i) & UPDATE_MASK];
-			CL_PredictUsercmd (&from->playerstate[cl.playernum], &to->playerstate[cl.playernum], &to->cmd);
+			CL_PredictUsercmd (&from->playerstate[cl.playernum], &to->playerstate[cl.playernum], &to->cmd, true);
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+			if ((cl.validsequence + i) == cl.simerr_frame)
+			{
+				// if our origin is significantly wrong, add it to our nudge vector
+				vec3_t diff;
+				float error;
+
+				VectorSubtract(cl.simerr_org, to->playerstate[cl.playernum].origin, diff);
+				error = VectorLength(diff);
+				if (error > 4 && error < 64)
+				{
+					float mult;
+					mult = 1 - min(0.013 / cls.latency, 1);
+					VectorScale(diff, mult, diff);
+					VectorAdd(diff, cl.simerr_nudge, cl.simerr_nudge);
+				}
+
+				// we missed some weapon state change, replay all the sounds since then
+				if (cl.simerr_wep != pmove.weapon || cl.simerr_wepframe != pmove.weaponframe)
+					pmove.effect_frame = cl.validsequence;
+			}
+#endif
 		}
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+		CL_PlayEvents();
+#endif
 
 		pmove.numphysent = oldphysent;
 
 		// save results
 		VectorCopy (to->playerstate[cl.playernum].velocity, cl.simvel);
 		VectorCopy (to->playerstate[cl.playernum].origin, cl.simorg);
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+		// prediction error smoothing: instead of snapping to the corrected
+		// origin, decay the correction over a few frames
+		if (cl_predict_smoothview.value >= 0.1 && !cl.spectator
+			&& (cls.mvdprotocolextensions1 & MVD_PEXT1_WEAPONPREDICTION))
+		{
+			float nudge, nudge_mult, check_deltatime;
+			vec3_t nudge_norm, goal;
+			trace_t checktrace;
+
+			// update and smooth our position
+			cl.simerr_frame = cl.validsequence + i - 1;
+			VectorCopy(to->playerstate[cl.playernum].origin, cl.simerr_org);
+			nudge = VectorLength(cl.simerr_nudge);
+			VectorCopy(cl.simerr_nudge, nudge_norm);
+			VectorNormalize(nudge_norm);
+
+			check_deltatime = cl.time - cl.simerr_lastcheck;
+			cl.simerr_lastcheck = cl.time;
+
+			nudge_mult = bound(0.1, 2 - cl_predict_smoothview.value, 2);
+
+			nudge = min(nudge, 64);
+			if (nudge < 220 * nudge_mult * check_deltatime)
+				nudge = 0;
+			else if (nudge < 8)
+				nudge -= 200 * nudge_mult * check_deltatime;
+			else if (nudge < 16)
+				nudge -= 500 * nudge_mult * check_deltatime;
+			else if (nudge < 32)
+				nudge -= 800 * nudge_mult * check_deltatime;
+			else
+				nudge -= 1400 * nudge_mult * check_deltatime;
+			nudge = max(0, nudge); // in case we overshot due to low framerate or something
+
+			VectorScale(nudge_norm, nudge, cl.simerr_nudge);
+
+			VectorAdd(cl.simorg, cl.simerr_nudge, goal);
+			checktrace = PM_PlayerTrace(cl.simorg, goal);
+			VectorSubtract(checktrace.endpos, cl.simorg, cl.simerr_nudge);
+			VectorCopy(checktrace.endpos, cl.simorg);
+
+			// update our expected weapon state as well
+			cl.simerr_wep = pmove.weapon;
+			cl.simerr_wepframe = pmove.weaponframe;
+		}
+#endif
+
 		cl.onground = pmove.onground;
 		cl.waterlevel = pmove.waterlevel;
 		check_standing_on_entity();
@@ -419,7 +738,20 @@ void CL_InitPrediction(void)
 {
 	Cvar_SetCurrentGroup(CVAR_GROUP_NETWORK);
 	Cvar_Register(&cl_nopred);
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	Cvar_Register(&cl_nopred_weapon);
+	Cvar_Register(&cl_predict_weaponsound);
+	Cvar_Register(&cl_predict_smoothview);
+	Cvar_Register(&cl_predict_beam);
+	Cvar_Register(&cl_predict_projectiles);
+	Cvar_Register(&cl_predict_jump);
+	Cvar_Register(&cl_predict_buffer);
+#endif
 	Cvar_ResetCurrentGroup();
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	CL_InitWepSounds();
+#endif
 
 #ifdef JSS_CAM
 	Cvar_SetCurrentGroup(CVAR_GROUP_SPECTATOR);

--- a/src/cl_tent.c
+++ b/src/cl_tent.c
@@ -28,8 +28,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "utils.h"
 #include "qsound.h"
 #include "qmb_particles.h"
+#include "cl_tent.h"
 
 extern cvar_t gl_no24bit;
+#ifdef EZQ_FAKEPROJ
+extern cvar_t cl_rocket2grenade;
+#endif
 
 temp_entity_list_t temp_entities;
 
@@ -60,6 +64,10 @@ typedef struct explosion_s
 // cl_free_explosions = linear linked list of free explosions
 explosion_t	cl_explosions[MAX_EXPLOSIONS];
 explosion_t cl_explosions_headnode, *cl_free_explosions;
+
+#ifdef EZQ_FAKEPROJ
+fproj_t cl_fakeprojectiles[MAX_FAKEPROJ];
+#endif
 
 static model_t	*cl_explo_mod, *cl_bolt1_mod, *cl_bolt2_mod, *cl_bolt3_mod, *cl_beam_mod;
 
@@ -101,6 +109,9 @@ void CL_ClearTEnts(void)
 
 	memset (&cl_beams, 0, sizeof(cl_beams));
 	memset (&cl_explosions, 0, sizeof(cl_explosions));
+#ifdef EZQ_FAKEPROJ
+	memset (&cl_fakeprojectiles, 0, sizeof(cl_fakeprojectiles));
+#endif
 
 	// link explosions 
 	cl_free_explosions = cl_explosions; 
@@ -148,12 +159,195 @@ void CL_FreeExplosion(explosion_t *ex)
 	cl_free_explosions = ex;
 }
 
+#ifdef EZQ_FAKEPROJ
+
+// Removes the dynamic light owned by a fake projectile, if any.
+static void CL_FakeProjectile_KillDlight(fproj_t *prj)
+{
+	dlight_t *dl;
+	int i;
+
+	if (!prj->dl_key)
+		return;
+
+	for (i = 0, dl = cl_dlights; i < MAX_DLIGHTS; i++, dl++) {
+		if (dl->key == prj->dl_key) {
+			memset(dl, 0, sizeof(*dl));
+			cl_dlight_active[i / 32] &= ~(1 << (i % 32));
+		}
+	}
+
+	prj->dl_key = 0;
+}
+
+static void CL_SetTrailStops(centity_t *cent, const vec3_t stop)
+{
+	int i;
+
+	for (i = 0; i < sizeof(cent->trails) / sizeof(cent->trails[0]); i++) {
+		VectorCopy(stop, cent->trails[i].stop);
+	}
+}
+
+// Merge an incoming server projectile entity with a fake projectile that is
+// about to expire, so trails continue smoothly instead of restarting.
+void CL_MatchFakeProjectile(centity_t *cent)
+{
+	fproj_t *prj;
+	int i;
+
+	for (i = 0, prj = cl_fakeprojectiles; i < MAX_FAKEPROJ; i++, prj++)
+	{
+		// only consider fake projectiles that ended recently (or end soon)
+		if (prj->endtime >= cl.time && prj->endtime <= cl.time + 0.08)
+		{
+			if (VectorDistance(cent->lerp_origin, prj->org) < 24)
+			{
+				if (prj->partcount)
+				{
+					CL_SetTrailStops(cent, prj->partorg);
+				}
+
+				CL_FakeProjectile_KillDlight(prj);
+
+				memset(prj, 0, sizeof(fproj_t));
+				return;
+			}
+		}
+	}
+}
+
+fproj_t *CL_AllocFakeProjectile(void)
+{
+	fproj_t *prj;
+	int i;
+	float cull_distance;
+	int cull_index;
+
+	for (i = 0, prj = cl_fakeprojectiles; i < MAX_FAKEPROJ; i++, prj++)
+	{
+		if (prj->endtime < cl.time)
+		{
+			memset(prj, 0, sizeof(fproj_t));
+			prj->dl_key = MAX_EDICTS + i; // make sure not to collide with entity dlight keys
+			prj->index = i;
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+			prj->owner = cl.viewplayernum + 1;
+			prj->entnum = 0;
+#endif
+			return prj;
+		}
+	}
+
+	// out of free slots, cull the projectile furthest away from the player
+	cull_distance = 1;
+	cull_index = 0;
+	for (i = 0, prj = cl_fakeprojectiles; i < MAX_FAKEPROJ; i++, prj++)
+	{
+		float temp_dist;
+
+		temp_dist = VectorDistance(prj->org, cl.simorg);
+		if (temp_dist > cull_distance)
+		{
+			if (temp_dist > 2048) // it's so far away, just use this and hope for the best
+				break;
+
+			cull_distance = temp_dist;
+			cull_index = i;
+		}
+	}
+
+	prj = &cl_fakeprojectiles[cull_index];
+	memset(prj, 0, sizeof(fproj_t));
+	prj->index = cull_index;
+	prj->dl_key = MAX_EDICTS + cull_index;
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+	prj->owner = cl.viewplayernum + 1;
+	prj->entnum = 0;
+#endif
+	return prj;
+}
+
+#define MAX_CLIP_PLANES 5
+
+static void Fproj_Physics_ClipVelocity(vec3_t vel, vec3_t norm, float f)
+{
+	vec3_t vel2;
+
+	VectorScale(norm, DotProduct(vel, norm), vel2);
+	VectorScale(vel2, f, vel2);
+	VectorSubtract(vel, vel2, vel);
+
+	if (vel[0] > -0.1 && vel[0] < 0.1) vel[0] = 0;
+	if (vel[1] > -0.1 && vel[1] < 0.1) vel[1] = 0;
+	if (vel[2] > -0.1 && vel[2] < 0.1) vel[2] = 0;
+}
+
+// Grenade-style movement: gravity plus bouncing against world geometry.
+// Flag 512 marks a projectile that has come to rest.
+void Fproj_Physics_Bounce(fproj_t *proj, float dt)
+{
+	float gravity_value = movevars.gravity;
+	float movetime, bump;
+
+	if (proj->flags & 512)
+	{
+		if (proj->vel[2] >= 1 / 32)
+			proj->flags &= ~512;
+	}
+
+	proj->vel[2] -= 0.5 * dt * gravity_value;
+
+	VectorMA(proj->angs, dt, proj->avel, proj->angs);
+
+	movetime = dt;
+	for (bump = 0; bump < MAX_CLIP_PLANES && movetime > 0; ++bump)
+	{
+		float d, bouncefac, bouncestp;
+		vec3_t move, to;
+		trace_t phytrace;
+
+		VectorScale(proj->vel, movetime, move);
+		VectorAdd(proj->org, move, to);
+		phytrace = PM_TraceLine(proj->org, to);
+		VectorCopy(phytrace.endpos, proj->org);
+
+		if (phytrace.fraction == 1)
+			break;
+
+		movetime *= 1 - min(1, phytrace.fraction);
+
+		bouncefac = 0.5;
+		bouncestp = 60 / 800;
+		bouncestp *= gravity_value;
+
+		Fproj_Physics_ClipVelocity(proj->vel, phytrace.plane.normal, 1 + bouncefac);
+
+		d = DotProduct(phytrace.plane.normal, proj->vel);
+		if (phytrace.plane.normal[2] > 0.7 && d < bouncestp && d > -bouncestp)
+		{
+			proj->flags |= 512;
+			VectorClear(proj->vel);
+			VectorClear(proj->avel);
+		}
+		else
+		{
+			proj->flags &= ~512;
+		}
+	}
+
+	if (!(proj->flags & 512))
+	{
+		proj->vel[2] -= 0.5 * dt * gravity_value;
+	}
+}
+
+#endif // EZQ_FAKEPROJ
+
 static void CL_ParseBeam(int type, vec3_t end)
 {
-	int ent, i;
+	int ent;
 	vec3_t start;
-	beam_t *b;
-	struct model_s *m;
 
 	ent = MSG_ReadShort();
 
@@ -164,6 +358,15 @@ static void CL_ParseBeam(int type, vec3_t end)
 	end[0] = MSG_ReadCoord();
 	end[1] = MSG_ReadCoord();
 	end[2] = MSG_ReadCoord();
+
+	CL_CreateBeam(type, ent, start, end);
+}
+
+void CL_CreateBeam(int type, int ent, vec3_t start, vec3_t end)
+{
+	int i;
+	beam_t *b;
+	struct model_s *m;
 
 	if (CL_Demo_SkipMessage(true))
 		return;
@@ -954,9 +1157,132 @@ static void CL_UpdateExplosions(void)
 	}
 }
 
+#ifdef EZQ_FAKEPROJ
+// Run physics for and draw all live fake projectiles.
+static void CL_UpdateFakeProjectiles(void)
+{
+	int i;
+	fproj_t *prj;
+	centity_t *cent;
+	entity_t ent;
+	entity_state_t centstate;
+	customlight_t cst_lt = { 0 };
+
+	memset(&centstate, 0, sizeof(entity_state_t));
+	memset(&ent, 0, sizeof(entity_t));
+	ent.colormap = vid.colormap;
+
+	for (i = 0; i < MAX_FAKEPROJ; i++) {
+		prj = &cl_fakeprojectiles[i];
+		cent = &prj->cent;
+
+		if (cl.time <= prj->starttime)
+		{
+			continue;
+		}
+		else if (cl.time >= prj->endtime)
+		{
+			CL_FakeProjectile_KillDlight(prj);
+			continue;
+		}
+
+		cent->current = centstate;
+
+		if (!prj->modelindex || !cl.model_precache[prj->modelindex] || prj->modelindex >= MAX_MODELS)
+			continue;
+
+		ent.model = cl.model_precache[prj->modelindex];
+		centstate.modelindex = prj->modelindex;
+		centstate.number = prj->dl_key;
+
+		if (prj->type == 1)
+		{
+			// grenade: bounce physics
+			Fproj_Physics_Bounce(prj, cls.frametime);
+
+			VectorCopy(prj->org, ent.origin);
+			VectorCopy(prj->angs, ent.angles);
+		}
+		else
+		{
+			// linear flight, extrapolated from start position
+			vec3_t traveled;
+			trace_t trace;
+
+			VectorCopy(prj->start, ent.origin);
+			VectorScale(prj->vel, (cl.time - prj->starttime) + 0.02, traveled);
+			VectorAdd(ent.origin, traveled, ent.origin);
+			VectorCopy(prj->angs, ent.angles);
+			VectorCopy(ent.origin, prj->org);
+
+			trace = PM_TraceLine(prj->start, ent.origin);
+			if (trace.fraction < 1)
+			{
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+				if (prj->parttime)
+					continue;
+				else
+					VectorCopy(trace.endpos, prj->org);
+#else
+				continue;
+#endif
+			}
+		}
+
+		if (prj->effects)
+		{
+			if (cl.time >= prj->parttime)
+			{
+				prj->parttime = cl.time + 0.013;
+				if (!VectorLength(prj->partorg))
+				{
+					VectorCopy(prj->org, prj->partorg);
+					CL_SetTrailStops(cent, prj->partorg);
+				}
+
+				prj->partcount++;
+				VectorCopy(prj->partorg, cent->old_origin);
+				CL_SetTrailStops(cent, prj->partorg);
+				VectorCopy(ent.origin, cent->current.origin);
+				VectorCopy(ent.origin, cent->lerp_origin);
+				VectorCopy(ent.origin, prj->partorg);
+
+				if (prj->effects & 256)
+				{
+					// nail trail
+					if (amf_nailtrail.integer && !gl_no24bit.integer && amf_nailtrail_plasma.integer) {
+						byte color[3];
+						color[0] = 0; color[1] = 70; color[2] = 255;
+						FireballTrail(cent, color, 0.6, 0.3);
+					}
+				}
+				else
+				{
+					CL_AddParticleTrail(&ent, cent, &cst_lt, &centstate);
+				}
+			}
+		}
+
+		// hacky fix for cl_r2g, we have to change the model after the particles have been handled
+		if (prj->effects & EF_ROCKET)
+		{
+			if (cl_rocket2grenade.integer)
+			{
+				ent.model = cl.model_precache[cl_modelindices[mi_grenade]];
+			}
+		}
+
+		CL_AddEntity(&ent);
+	}
+}
+#endif // EZQ_FAKEPROJ
+
 void CL_UpdateTEnts (void)
 {
 	CL_UpdateBeams();
 	CL_UpdateExplosions();
+#ifdef EZQ_FAKEPROJ
+	CL_UpdateFakeProjectiles();
+#endif
 }
 

--- a/src/cl_tent.c
+++ b/src/cl_tent.c
@@ -342,6 +342,65 @@ void Fproj_Physics_Bounce(fproj_t *proj, float dt)
 	}
 }
 
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+
+// Constructor for locally predicted projectiles. Lifetimes are derived
+// from the connection latency: the fake projectile only covers the gap
+// until the server's own projectile entity is expected to arrive.
+static fproj_t *CL_CreateFakeProjectile(cl_modelindex_t model, float lifetime, int effects)
+{
+	fproj_t *newmis;
+	float latency = cls.latency;
+
+	if (pmove.client_ping == 0)
+		return NULL;
+
+	newmis = CL_AllocFakeProjectile();
+	newmis->modelindex = cl_modelindices[model];
+	newmis->starttime = cl.time + max((latency - 0.013) - ((float)pmove.client_ping / 1000), 0);
+	newmis->endtime = cl.time + latency + lifetime;
+	newmis->effects = effects;
+
+	return newmis;
+}
+
+fproj_t *CL_CreateFakeNail(void)
+{
+	return CL_CreateFakeProjectile(mi_spike, 0.013, 256);
+}
+
+fproj_t *CL_CreateFakeSuperNail(void)
+{
+	return CL_CreateFakeProjectile(mi_s_spike, 0.013, 256);
+}
+
+fproj_t *CL_CreateFakeGrenade(void)
+{
+	fproj_t *newmis = CL_CreateFakeProjectile(mi_grenade, 0, EF_GRENADE);
+
+	if (newmis)
+	{
+		newmis->parttime = newmis->starttime + 0.013;
+		newmis->type = 1; // bounce physics
+	}
+
+	return newmis;
+}
+
+fproj_t *CL_CreateFakeRocket(void)
+{
+	fproj_t *newmis = CL_CreateFakeProjectile(mi_rocket, 0.013, EF_ROCKET);
+
+	if (newmis)
+	{
+		newmis->parttime = newmis->starttime + 0.013; // delay trail a tiny bit, otherwise it looks funny
+	}
+
+	return newmis;
+}
+
+#endif // MVD_PEXT1_WEAPONPREDICTION
+
 #endif // EZQ_FAKEPROJ
 
 static void CL_ParseBeam(int type, vec3_t end)
@@ -358,6 +417,15 @@ static void CL_ParseBeam(int type, vec3_t end)
 	end[0] = MSG_ReadCoord();
 	end[1] = MSG_ReadCoord();
 	end[2] = MSG_ReadCoord();
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	if (ent == cl.playernum + 1)
+	{
+		// the local beam is already drawn by prediction
+		if (PM_WeaponPredictionActive() && cl_predict_beam.integer)
+			return;
+	}
+#endif
 
 	CL_CreateBeam(type, ent, start, end);
 }

--- a/src/cl_tent.c
+++ b/src/cl_tent.c
@@ -34,6 +34,9 @@ extern cvar_t gl_no24bit;
 #ifdef EZQ_FAKEPROJ
 extern cvar_t cl_rocket2grenade;
 #endif
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+extern cvar_t cl_sproj_xerp;
+#endif
 
 temp_entity_list_t temp_entities;
 
@@ -111,6 +114,9 @@ void CL_ClearTEnts(void)
 	memset (&cl_explosions, 0, sizeof(cl_explosions));
 #ifdef EZQ_FAKEPROJ
 	memset (&cl_fakeprojectiles, 0, sizeof(cl_fakeprojectiles));
+#endif
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+	CL_ClearSimpleProjectiles();
 #endif
 
 	// link explosions 
@@ -1276,9 +1282,21 @@ static void CL_UpdateFakeProjectiles(void)
 			// linear flight, extrapolated from start position
 			vec3_t traveled;
 			trace_t trace;
+			float modified_time = cl.time;
+
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+			if (cl_sproj_xerp.value)
+			{
+				// extrapolate other players' projectiles over our latency
+				if (prj->owner != (cl.viewplayernum + 1))
+				{
+					modified_time += min(150, cls.latency);
+				}
+			}
+#endif
 
 			VectorCopy(prj->start, ent.origin);
-			VectorScale(prj->vel, (cl.time - prj->starttime) + 0.02, traveled);
+			VectorScale(prj->vel, (modified_time - prj->starttime) + 0.02, traveled);
 			VectorAdd(ent.origin, traveled, ent.origin);
 			VectorCopy(prj->angs, ent.angles);
 			VectorCopy(ent.origin, prj->org);

--- a/src/cl_tent.h
+++ b/src/cl_tent.h
@@ -1,0 +1,78 @@
+/*
+Copyright (C) 1996-1997 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+// cl_tent.h -- client side temporary entities, antilag 1 fake projectiles
+
+#ifndef __CL_TENT_H__
+#define __CL_TENT_H__
+
+void CL_CreateBeam(int type, int ent, vec3_t start, vec3_t end);
+
+// client-side "fake" projectiles: spawned locally by weapon prediction
+// and/or driven by server-sent simple projectile states
+#if defined(MVD_PEXT1_WEAPONPREDICTION) || defined(MVD_PEXT1_SIMPLEPROJECTILE)
+#define EZQ_FAKEPROJ
+#endif
+
+#ifdef EZQ_FAKEPROJ
+
+#define MAX_FAKEPROJ 96
+
+typedef struct fproj_s {
+	int modelindex, dl_key;
+	int type, effects, flags, partcount, index;
+	float starttime, endtime, parttime;
+	vec3_t start, vel, avel, angs, org, partorg;
+	centity_t cent;
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+	int entnum;
+	int owner;
+#endif
+} fproj_t;
+
+extern fproj_t cl_fakeprojectiles[MAX_FAKEPROJ];
+
+void Fproj_Physics_Bounce(fproj_t *proj, float dt);
+void CL_MatchFakeProjectile(centity_t *cent);
+fproj_t *CL_AllocFakeProjectile(void);
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+fproj_t *CL_CreateFakeNail(void);
+fproj_t *CL_CreateFakeSuperNail(void);
+fproj_t *CL_CreateFakeGrenade(void);
+fproj_t *CL_CreateFakeRocket(void);
+#endif
+
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+// per-edict mirror of the server's simple projectile state
+typedef struct cs_sprojectile_s {
+	int active;
+
+	int fproj_number;
+	int owner;
+	vec3_t origin;
+	vec3_t velocity;
+	vec3_t angles;
+	int modelindex;
+	float time_offset;
+} cs_sprojectile_t;
+#endif
+
+#endif // EZQ_FAKEPROJ
+
+#endif // __CL_TENT_H__

--- a/src/cl_view.c
+++ b/src/cl_view.c
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "hud_common.h"
 #include "mvd_utils.h"
 #include "r_matrix.h"
+#include "pmove.h"
 
 #ifdef X11_GAMMA_WORKAROUND
 #include "tr_types.h"
@@ -850,9 +851,22 @@ static int V_CurrentWeaponModel(void)
 				return cl_modelindices[mi_vaxe];
 			}
 			if (bestgun > 1 && bestgun <= 8) {
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+				if (!pmove_nopred_weapon && pmove.client_predflags & PRDFL_COILGUN)
+					if (bestgun == 2) { bestgun = 9; }
+#endif
 				return cl_modelindices[mi_weapon1 - 1 + bestgun];
 			}
 		}
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+		else if (PM_WeaponPredictionActive()) {
+			// show the predicted weapon (weapon_index 9 maps to mi_coilgun)
+			if (cl.simwep == 1)
+				return cl_modelindices[mi_vaxe];
+			else if (cl.simwep > 1 && cl.simwep <= 9)
+				return cl_modelindices[mi_weapon1 - 1 + cl.simwep];
+		}
+#endif
 		return cl.stats[STAT_WEAPON];
 	}
 }
@@ -911,6 +925,11 @@ static void V_AddViewWeapon(float bob)
 		else if (scr_viewsize.value == 80)
 			cent->current.origin[2] += 0.5;
 	}
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	if (PM_WeaponPredictionActive())
+		view_message.weaponframe = cl.simwepframe;
+#endif
 
 	if (cent->current.modelindex != gunmodel) {
 		cent->frametime = -1;

--- a/src/client.h
+++ b/src/client.h
@@ -1051,13 +1051,13 @@ void CL_UpdateTEnts(void);
 
 // cl_ents.c
 typedef enum cl_modelindex_s {
-	mi_spike, mi_player, mi_eyes, mi_flag, mi_tf_flag, mi_tf_stan, mi_stag, mi_basrkey, mi_basbkey, mi_w_s_key, mi_w_g_key, mi_b_g_key, mi_b_s_key, mi_ff_flag, mi_harbflag, mi_princess, mi_explod1, mi_explod2, mi_h_player,
+	mi_spike, mi_s_spike, mi_player, mi_eyes, mi_flag, mi_tf_flag, mi_tf_stan, mi_stag, mi_basrkey, mi_basbkey, mi_w_s_key, mi_w_g_key, mi_b_g_key, mi_b_s_key, mi_ff_flag, mi_harbflag, mi_princess, mi_explod1, mi_explod2, mi_h_player,
 	mi_gib1, mi_gib2, mi_gib3, mi_rocket, mi_grenade, mi_bubble,
 	mi_vaxe, mi_vbio, mi_vgrap, mi_vknife, mi_vknife2, mi_vmedi, mi_vspan,
 	mi_flame,	//joe: for changing flame/flame0 models
 	mi_monster1,mi_m2,mi_m3,mi_m4,mi_m5,mi_m6,mi_m7,mi_m8,mi_m9,mi_m10,mi_m11,mi_m12,
 	mi_m13, mi_m14, mi_m15, mi_m16, mi_m17,
-	mi_weapon1, mi_weapon2, mi_weapon3, mi_weapon4, mi_weapon5, mi_weapon6, mi_weapon7, mi_weapon8,
+	mi_weapon1, mi_weapon2, mi_weapon3, mi_weapon4, mi_weapon5, mi_weapon6, mi_weapon7, mi_weapon8, mi_coilgun, mi_hook,
 	cl_num_modelindices,
 } cl_modelindex_t;
 

--- a/src/client.h
+++ b/src/client.h
@@ -83,9 +83,40 @@ enum {
 	dbg_antilag_position_set   = 4
 };
 
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+// events generated during weapon prediction; played back slightly delayed
+// depending on cl_predict_buffer (see CL_PlayEvents)
+typedef struct prediction_event_sound_s
+{
+	int				frame_num;
+
+	int				chan;
+	struct sfx_s	*sample;
+	float			vol;
+
+	struct prediction_event_sound_s *next;
+} prediction_event_sound_t;
+
+typedef struct prediction_event_fakeproj_s
+{
+	int			frame_num;
+
+	int			type;		// IT_* weapon that fired
+	vec3_t		origin;
+	vec3_t		angles;
+	vec3_t		velocity;
+	vec3_t		avelocity;
+
+	struct prediction_event_fakeproj_s *next;
+} prediction_event_fakeproj_t;
+
+extern prediction_event_fakeproj_t	*p_event_fakeproj;
+extern prediction_event_sound_t		*p_event_sound;
+#endif // MVD_PEXT1_WEAPONPREDICTION
+
 // player_state_t is the information needed by a player entity
 // to do move prediction and to generate a drawable entity
-typedef struct 
+typedef struct
 {
 	int			messagenum;		// All players won't be updated each frame.
 
@@ -97,6 +128,27 @@ typedef struct
 	vec3_t		viewangles;		// Only for demos, not from server.
 	vec3_t		velocity;
 	int			weaponframe;
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	// weapon prediction state for the local player, sent by the server
+	// under PF_WEAPONFRAME (see CL_ParsePlayerinfo)
+	int			weapon_index;
+	int			weapon;
+	int			items;
+	int			impulse;
+
+	byte		ammo_shells;
+	byte		ammo_nails;
+	byte		ammo_rockets;
+	byte		ammo_cells;
+
+	float		attack_finished;
+	float		client_time;
+	float		client_nextthink;
+	int			client_thinkindex;
+	int			client_ping;
+	int			client_predflags;
+#endif
 
 	int			modelindex;
 	int			frame;
@@ -633,6 +685,17 @@ typedef struct {
 	vec3_t		simorg;
 	vec3_t		simvel;
 	vec3_t		simangles;
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	int			simwep;			// predicted weapon (weapon_index) to display
+	int			simwepframe;	// predicted weapon animation frame
+	// prediction error smoothing (cl_predict_smoothview)
+	float		simerr_lastcheck;
+	int			simerr_frame;
+	int			simerr_wepframe;
+	int			simerr_wep;
+	vec3_t		simerr_nudge;
+	vec3_t		simerr_org;
+#endif
 
 	// pitch drifting vars
 	float		pitchvel;
@@ -1094,8 +1157,11 @@ void CL_ParseProjectiles(qbool indexed);
 
 // cl_pred.c
 void CL_InitPrediction(void);
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+void CL_InitWepSounds(void);
+#endif
 void CL_PredictMove(qbool physframe);
-void CL_PredictUsercmd(player_state_t *from, player_state_t *to, usercmd_t *u);
+void CL_PredictUsercmd(player_state_t *from, player_state_t *to, usercmd_t *u, qbool local);
 void CL_DisableLerpMove(void);
 
 // cl_cam.c

--- a/src/client.h
+++ b/src/client.h
@@ -1145,6 +1145,10 @@ void CL_SetUpPlayerPrediction(qbool dopred);
 void CL_EmitEntities (void);
 void CL_ClearProjectiles (void);
 void CL_ParsePacketEntities (qbool delta);
+#ifdef MVD_PEXT1_SIMPLEPROJECTILE
+void CL_ParsePacketSimpleProjectiles(void);
+void CL_ClearSimpleProjectiles(void);
+#endif
 void CL_SetSolidEntities (void);
 void CL_ParsePlayerinfo (void);
 void CL_StorePausePredictionLocations(void);

--- a/src/pmove.c
+++ b/src/pmove.c
@@ -712,6 +712,13 @@ static void PM_CheckJump (void)
 	if (pmove.jump_held && !pmove.jump_msec)
 		return; // don't pogo stick
 
+#if defined(MVD_PEXT1_WEAPONPREDICTION) && !defined(SERVERONLY)
+	if (cl_predict_jump.integer && PM_WeaponPredictionActive())
+	{
+		PM_SoundEffect(cl_sfx_jump, 4);
+	}
+#endif
+
 	if (!movevars.pground) {
 		// check for jump bug
 		// groundplane normal was set in the call to PM_CategorizePosition

--- a/src/pmove.h
+++ b/src/pmove.h
@@ -54,6 +54,33 @@ typedef struct {
 	float		waterjumptime;
 	int			pm_type;
 
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	// weapon prediction state, mirrored from/into player_state_t for the
+	// local player only (see CL_PredictUsercmd)
+	int			weapon;
+	int			weapon_index;
+	int			weaponframe;
+
+	int			current_ammo;
+	int			items;
+	int			impulse;
+	float		client_time;
+	float		attack_finished;
+	float		client_nextthink;
+	byte		client_thinkindex;
+	byte		client_ping;
+	byte		client_predflags;
+	int			frame_current;	// outgoing sequence number of the frame being predicted
+	int			effect_frame;	// last frame whose prediction events have been played
+
+	short		ammo_shells;
+	short		ammo_nails;
+	short		ammo_rockets;
+	short		ammo_cells;
+
+	float		t_width;		// re-trigger time for the predicted lightning hit sound
+#endif
+
 	// world state
 	int			numphysent;
 	physent_t	physents[MAX_PHYSENTS]; // 0 should be the world
@@ -94,6 +121,38 @@ typedef struct {
 
 extern movevars_t movevars;
 extern playermove_t pmove;
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+#include "qsound.h"
+
+// client_predflags values sent by the server
+#define PRDFL_MIDAIR	1
+#define PRDFL_COILGUN	2
+#define PRDFL_FORCEOFF	255
+
+extern int pmove_nopred_weapon;
+
+// true when the negotiated extension is in effect and weapon prediction has
+// not been disabled by the user, the server (PRDFL_FORCEOFF) or spectating
+#define PM_WeaponPredictionActive() \
+	(!pmove_nopred_weapon && (cls.mvdprotocolextensions1 & MVD_PEXT1_WEAPONPREDICTION))
+
+// predicted weapon sounds, precached by CL_InitWepSounds (cl_pred.c)
+extern sfx_t *cl_sfx_jump, *cl_sfx_ax1, *cl_sfx_sg, *cl_sfx_ssg, *cl_sfx_ng,
+	*cl_sfx_sng, *cl_sfx_gl, *cl_sfx_rl, *cl_sfx_lg, *cl_sfx_lghit, *cl_sfx_coil;
+
+extern cvar_t cl_nopred_weapon;
+extern cvar_t cl_predict_weaponsound;
+extern cvar_t cl_predict_smoothview;
+extern cvar_t cl_predict_beam;
+extern cvar_t cl_predict_projectiles;
+extern cvar_t cl_predict_jump;
+extern cvar_t cl_predict_buffer;
+
+void PM_PlayerWeapon (void);
+int PM_FilterWeaponSound (byte sound_num);
+void PM_SoundEffect (sfx_t *sample, int chan);
+#endif
 
 int PM_PlayerMove (void);
 

--- a/src/pmove_weapon.c
+++ b/src/pmove_weapon.c
@@ -1,0 +1,867 @@
+/*
+Copyright (C) 1996-1997 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+// pmove_weapon.c -- antilag 1 client-side weapon prediction
+//
+// A QuakeC-style re-implementation of the standard QW weapon logic
+// (attack timing, ammo, weapon switching, view weapon animation), driven
+// from CL_PredictUsercmd for the local player when the server supports
+// MVD_PEXT1_WEAPONPREDICTION. Effects are not applied directly; they are
+// queued as prediction events and played back by CL_PlayEvents.
+
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+
+#include "quakedef.h"
+#include "pmove.h"
+#include "qsound.h"
+#include "keys.h"
+
+#define IT_HOOK 32768
+
+int pmove_nopred_weapon;
+
+// Queue a predicted sound
+void PM_SoundEffect(sfx_t *sample, int chan)
+{
+	prediction_event_sound_t *s_event = Q_malloc(sizeof(prediction_event_sound_t));
+
+	s_event->chan = chan;
+	s_event->sample = sample;
+	s_event->vol = 1;
+	s_event->frame_num = pmove.frame_current;
+	s_event->next = p_event_sound;
+	p_event_sound = s_event;
+}
+
+// Queue a predicted weapon sound unless filtered out by the
+// cl_predict_weaponsound bitmask (weap is the weapon's filter bit)
+static void PM_SoundEffect_Weapon(sfx_t *sample, int chan, int weap)
+{
+	if (cl_predict_weaponsound.integer == 0)
+		return;
+	if (cl_predict_weaponsound.integer & weap)
+		return;
+
+	PM_SoundEffect(sample, chan);
+}
+
+static prediction_event_fakeproj_t *PM_AddEvent_FakeProj(int type)
+{
+	prediction_event_fakeproj_t *proj;
+
+	if (type == IT_LIGHTNING) {
+		if (!cl_predict_beam.integer)
+			return NULL;
+	}
+	else {
+		if (!cl_predict_projectiles.integer)
+			return NULL;
+	}
+
+	proj = Q_malloc(sizeof(prediction_event_fakeproj_t));
+	proj->type = type;
+	proj->frame_num = pmove.frame_current;
+	proj->next = p_event_fakeproj;
+	p_event_fakeproj = proj;
+	return proj;
+}
+
+// Should the server sound be replaced by its predicted counterpart,
+// given the cl_predict_weaponsound bitmask?
+int PM_FilterWeaponSound(byte sound_num)
+{
+	const char *name = cl.sound_precache[sound_num]->name;
+
+	if (cl_predict_weaponsound.integer & 2)
+		if (strcmp(name, "weapons/ax1.wav") == 0)
+			return false;
+	if (cl_predict_weaponsound.integer & 4)
+		if (strcmp(name, "weapons/guncock.wav") == 0)
+			return false;
+	if (cl_predict_weaponsound.integer & 8)
+		if (strcmp(name, "weapons/shotgn2.wav") == 0)
+			return false;
+	if (cl_predict_weaponsound.integer & 16)
+		if (strcmp(name, "weapons/rocket1i.wav") == 0)
+			return false;
+	if (cl_predict_weaponsound.integer & 32)
+		if (strcmp(name, "weapons/spike2.wav") == 0)
+			return false;
+	if (cl_predict_weaponsound.integer & 64)
+		if (strcmp(name, "weapons/grenade.wav") == 0)
+			return false;
+	if (cl_predict_weaponsound.integer & 128)
+		if (strcmp(name, "weapons/sgun1.wav") == 0)
+			return false;
+	if (cl_predict_weaponsound.integer & 256)
+	{
+		if (strcmp(name, "weapons/lstart.wav") == 0)
+			return false;
+		if (strcmp(name, "weapons/lhit.wav") == 0)
+			return false;
+	}
+
+	return true;
+}
+
+static void W_SetCurrentAmmo(void)
+{
+	switch (pmove.weapon)
+	{
+		case IT_AXE: {
+			pmove.current_ammo = 0;
+			pmove.weapon_index = 1;
+		} break;
+		case IT_SHOTGUN: {
+			pmove.current_ammo = pmove.ammo_shells;
+			if (pmove.client_predflags & PRDFL_COILGUN)
+				pmove.weapon_index = 9;
+			else
+				pmove.weapon_index = 2;
+		} break;
+		case IT_SUPER_SHOTGUN: {
+			pmove.current_ammo = pmove.ammo_shells;
+			pmove.weapon_index = 3;
+		} break;
+		case IT_NAILGUN: {
+			pmove.current_ammo = pmove.ammo_nails;
+			pmove.weapon_index = 4;
+		} break;
+		case IT_SUPER_NAILGUN: {
+			pmove.current_ammo = pmove.ammo_nails;
+			pmove.weapon_index = 5;
+		} break;
+		case IT_GRENADE_LAUNCHER: {
+			pmove.current_ammo = pmove.ammo_rockets;
+			pmove.weapon_index = 6;
+		} break;
+		case IT_ROCKET_LAUNCHER: {
+			pmove.current_ammo = pmove.ammo_rockets;
+			pmove.weapon_index = 7;
+		} break;
+		case IT_LIGHTNING: {
+			pmove.current_ammo = pmove.ammo_cells;
+			pmove.weapon_index = 8;
+		} break;
+		case IT_HOOK: {
+			pmove.current_ammo = 0;
+			pmove.weapon_index = 10;
+		} break;
+	}
+}
+
+static int W_BestWeapon(void)
+{
+	int it = pmove.items;
+	char *w_rank = Info_ValueForKey(cls.userinfo, "w_rank");
+
+	if (w_rank != NULL)
+	{
+		while (*w_rank)
+		{
+			int weapon = (*w_rank - '0');
+
+			if ((weapon == 8) && (it & IT_LIGHTNING) && (pmove.ammo_cells >= 1))
+				return IT_LIGHTNING;
+			if ((weapon == 7) && (it & IT_ROCKET_LAUNCHER) && (pmove.ammo_rockets >= 1))
+				return IT_ROCKET_LAUNCHER;
+			if ((weapon == 6) && (it & IT_GRENADE_LAUNCHER) && (pmove.ammo_rockets >= 1))
+				return IT_GRENADE_LAUNCHER;
+			if ((weapon == 5) && (it & IT_SUPER_NAILGUN) && (pmove.ammo_nails >= 2))
+				return IT_SUPER_NAILGUN;
+			if ((weapon == 4) && (it & IT_NAILGUN) && (pmove.ammo_nails >= 1))
+				return IT_NAILGUN;
+			if ((weapon == 3) && (it & IT_SUPER_SHOTGUN) && (pmove.ammo_shells >= 2))
+				return IT_SUPER_SHOTGUN;
+			if ((weapon == 2) && (it & IT_SHOTGUN) && (pmove.ammo_shells >= 1))
+				return IT_SHOTGUN;
+			if ((weapon == 1) && (it & IT_AXE))
+				return IT_AXE;
+
+			++w_rank;
+		}
+
+		if (it & IT_AXE)
+			return IT_AXE;
+
+		return 0;
+	}
+
+	// standard behaviour
+	if ((pmove.waterlevel <= 1) && (pmove.ammo_cells >= 1) && (it & IT_LIGHTNING))
+		return IT_LIGHTNING;
+	else if ((pmove.ammo_nails >= 2) && (it & IT_SUPER_NAILGUN))
+		return IT_SUPER_NAILGUN;
+	else if ((pmove.ammo_shells >= 2) && (it & IT_SUPER_SHOTGUN))
+		return IT_SUPER_SHOTGUN;
+	else if ((pmove.ammo_nails >= 1) && (it & IT_NAILGUN))
+		return IT_NAILGUN;
+	else if ((pmove.ammo_shells >= 1) && (it & IT_SHOTGUN))
+		return IT_SHOTGUN;
+
+	return (it & IT_AXE ? IT_AXE : 0);
+}
+
+static int W_CheckNoAmmo(void)
+{
+	if (pmove.current_ammo > 0)
+		return true;
+
+	if ((pmove.weapon == IT_AXE) || (pmove.weapon == IT_HOOK))
+		return true;
+
+	// drop the weapon down
+	pmove.weapon = W_BestWeapon();
+	W_SetCurrentAmmo();
+
+	return false;
+}
+
+// Go to the next weapon with ammo
+static int CycleWeaponCommand(void)
+{
+	int i, it, am;
+
+	if (pmove.client_time < pmove.attack_finished)
+		return false;
+
+	it = pmove.items;
+
+	for (i = 0; i < 20; i++) // qqshka, 20 is just from head, but prevent infinite loop
+	{
+		am = 0;
+		switch (pmove.weapon)
+		{
+		case IT_LIGHTNING:
+			pmove.weapon = IT_AXE;
+			break;
+
+		case IT_AXE:
+			pmove.weapon = IT_HOOK;
+			break;
+
+		case IT_HOOK:
+			pmove.weapon = IT_SHOTGUN;
+			if (pmove.ammo_shells < 1)
+				am = 1;
+			break;
+
+		case IT_SHOTGUN:
+			pmove.weapon = IT_SUPER_SHOTGUN;
+			if (pmove.ammo_shells < 2)
+				am = 1;
+			break;
+
+		case IT_SUPER_SHOTGUN:
+			pmove.weapon = IT_NAILGUN;
+			if (pmove.ammo_nails < 1)
+				am = 1;
+			break;
+
+		case IT_NAILGUN:
+			pmove.weapon = IT_SUPER_NAILGUN;
+			if (pmove.ammo_nails < 2)
+				am = 1;
+			break;
+
+		case IT_SUPER_NAILGUN:
+			pmove.weapon = IT_GRENADE_LAUNCHER;
+			if (pmove.ammo_rockets < 1)
+				am = 1;
+			break;
+
+		case IT_GRENADE_LAUNCHER:
+			pmove.weapon = IT_ROCKET_LAUNCHER;
+			if (pmove.ammo_rockets < 1)
+				am = 1;
+			break;
+
+		case IT_ROCKET_LAUNCHER:
+			pmove.weapon = IT_LIGHTNING;
+			if (pmove.ammo_cells < 1)
+				am = 1;
+			break;
+		}
+
+		if ((it & pmove.weapon) && (am == 0))
+		{
+			W_SetCurrentAmmo();
+			return true;
+		}
+	}
+
+	return true;
+}
+
+// Go to the prev weapon with ammo
+static int CycleWeaponReverseCommand(void)
+{
+	int i, it, am;
+
+	if (pmove.client_time < pmove.attack_finished)
+		return false;
+
+	it = pmove.items;
+
+	for (i = 0; i < 20; i++) // qqshka, 20 is just from head, but prevent infinite loop
+	{
+		am = 0;
+		switch (pmove.weapon)
+		{
+		case IT_LIGHTNING:
+			pmove.weapon = IT_ROCKET_LAUNCHER;
+			if (pmove.ammo_rockets < 1)
+				am = 1;
+			break;
+
+		case IT_ROCKET_LAUNCHER:
+			pmove.weapon = IT_GRENADE_LAUNCHER;
+			if (pmove.ammo_rockets < 1)
+				am = 1;
+			break;
+
+		case IT_GRENADE_LAUNCHER:
+			pmove.weapon = IT_SUPER_NAILGUN;
+			if (pmove.ammo_nails < 2)
+				am = 1;
+			break;
+
+		case IT_SUPER_NAILGUN:
+			pmove.weapon = IT_NAILGUN;
+			if (pmove.ammo_nails < 1)
+				am = 1;
+			break;
+
+		case IT_NAILGUN:
+			pmove.weapon = IT_SUPER_SHOTGUN;
+			if (pmove.ammo_shells < 2)
+				am = 1;
+			break;
+
+		case IT_SUPER_SHOTGUN:
+			pmove.weapon = IT_SHOTGUN;
+			if (pmove.ammo_shells < 1)
+				am = 1;
+			break;
+
+		case IT_SHOTGUN:
+			pmove.weapon = IT_HOOK;
+			break;
+
+		case IT_HOOK:
+			pmove.weapon = IT_AXE;
+			break;
+
+		case IT_AXE:
+			pmove.weapon = IT_LIGHTNING;
+			if (pmove.ammo_cells < 1)
+				am = 1;
+			break;
+		}
+
+		if ((it & pmove.weapon) && (am == 0))
+		{
+			W_SetCurrentAmmo();
+			return true;
+		}
+	}
+
+	return true;
+}
+
+static int W_ChangeWeapon(int impulse)
+{
+	int fl = 0;
+	int am = 0;
+
+	switch (impulse)
+	{
+		case 1: {
+			fl = IT_AXE;
+			if (pmove.items & IT_HOOK && pmove.weapon == IT_AXE)
+				fl = IT_HOOK;
+
+			am = 1;
+		} break;
+
+		case 2: {
+			fl = IT_SHOTGUN;
+			if (pmove.ammo_shells >= 1)
+				am = 1;
+		} break;
+
+		case 3: {
+			fl = IT_SUPER_SHOTGUN;
+			if (pmove.ammo_shells >= 2)
+				am = 1;
+		} break;
+
+		case 4: {
+			fl = IT_NAILGUN;
+			if (pmove.ammo_nails >= 1)
+				am = 1;
+		} break;
+
+		case 5: {
+			fl = IT_SUPER_NAILGUN;
+			if (pmove.ammo_nails >= 2)
+				am = 1;
+		} break;
+
+		case 6: {
+			fl = IT_GRENADE_LAUNCHER;
+			if (pmove.ammo_rockets >= 1)
+				am = 1;
+		} break;
+
+		case 7: {
+			fl = IT_ROCKET_LAUNCHER;
+			if (pmove.ammo_rockets >= 1)
+				am = 1;
+		} break;
+
+		case 8: {
+			fl = IT_LIGHTNING;
+			if (pmove.ammo_cells >= 1)
+				am = 1;
+		} break;
+
+		case 22: {
+			fl = IT_HOOK;
+			am = 1;
+		} break;
+	}
+
+	if (pmove.items & fl && am)
+	{
+		if (pmove.weapon != fl)
+			pmove.weaponframe = 0;
+
+		pmove.weapon = fl;
+		W_SetCurrentAmmo();
+	}
+
+	return true;
+}
+
+static void ImpulseCommands(void)
+{
+	int clear = false;
+
+	if (((pmove.impulse >= 1) && (pmove.impulse <= 8)) || (pmove.impulse == 22))
+		clear = W_ChangeWeapon(pmove.impulse);
+	else if (pmove.impulse == 10)
+		clear = CycleWeaponCommand();
+	else if (pmove.impulse == 12)
+		clear = CycleWeaponReverseCommand();
+
+	if (clear)
+		pmove.impulse = 0;
+}
+
+static void launch_spike(float off)
+{
+	prediction_event_fakeproj_t *newmis;
+
+	if (pmove.weapon == IT_SUPER_NAILGUN)
+	{
+		newmis = PM_AddEvent_FakeProj(IT_SUPER_NAILGUN);
+		PM_SoundEffect_Weapon(cl_sfx_sng, 1, 32);
+		off = 0;
+	}
+	else
+	{
+		newmis = PM_AddEvent_FakeProj(IT_NAILGUN);
+		PM_SoundEffect_Weapon(cl_sfx_ng, 1, 16);
+	}
+
+	if (newmis)
+	{
+		vec3_t forward, right;
+		AngleVectors(pmove.cmd.angles, forward, right, NULL);
+		VectorScale(forward, 1000, newmis->velocity);
+
+		VectorCopy(pmove.origin, newmis->origin);
+		newmis->origin[0] += (forward[0] * 8) + (right[0] * off);
+		newmis->origin[1] += (forward[1] * 8) + (right[1] * off);
+		newmis->origin[2] += 16 + forward[2] * 8;
+		VectorCopy(pmove.cmd.angles, newmis->angles);
+		newmis->angles[0] = -newmis->angles[0];
+	}
+}
+
+static void player_run(void)
+{
+	pmove.client_nextthink = 0;
+	pmove.client_thinkindex = 0;
+	pmove.weaponframe = 0;
+}
+
+static void anim_axe(void)
+{
+	pmove.client_nextthink = pmove.client_time + 0.1;
+	pmove.weaponframe++;
+	pmove.client_thinkindex++;
+	if (pmove.client_thinkindex > 4)
+		pmove.client_thinkindex = 0;
+}
+
+static void player_nail1(void)
+{
+	pmove.client_nextthink = pmove.client_time + 0.1;
+	pmove.client_thinkindex = 2;
+
+	if (!(pmove.cmd.buttons & 1) || pmove.impulse)
+	{
+		player_run();
+		return;
+	}
+
+	pmove.weaponframe = pmove.weaponframe + 1;
+	if (pmove.weaponframe >= 9)
+		pmove.weaponframe = 1;
+
+	pmove.current_ammo = pmove.ammo_nails -= 1;
+	pmove.attack_finished = pmove.client_time + 0.2;
+	launch_spike(4);
+}
+
+static void player_nail2(void)
+{
+	pmove.client_nextthink = pmove.client_time + 0.1;
+	pmove.client_thinkindex = 1;
+
+	if (!(pmove.cmd.buttons & 1) || pmove.impulse)
+	{
+		player_run();
+		return;
+	}
+
+	pmove.weaponframe = pmove.weaponframe + 1;
+	if (pmove.weaponframe >= 9)
+		pmove.weaponframe = 1;
+
+	pmove.current_ammo = pmove.ammo_nails -= 1;
+	pmove.attack_finished = pmove.client_time + 0.2;
+	launch_spike(-4);
+}
+
+static void anim_nailgun(void)
+{
+	if (pmove.client_thinkindex < 2)
+		player_nail1();
+	else
+		player_nail2();
+}
+
+static void player_light_fire(void)
+{
+	pmove.weaponframe = pmove.weaponframe + 1;
+	if (pmove.weaponframe >= 5)
+		pmove.weaponframe = 1;
+
+	pmove.attack_finished = pmove.client_time + 0.2;
+
+	pmove.current_ammo = pmove.ammo_cells -= 1;
+	if (pmove.waterlevel <= 1)
+	{
+		prediction_event_fakeproj_t *beam = PM_AddEvent_FakeProj(IT_LIGHTNING);
+		if (beam)
+		{
+			VectorCopy(pmove.origin, beam->origin);
+			beam->origin[2] += 16;
+
+			VectorCopy(pmove.cmd.angles, beam->angles);
+		}
+	}
+}
+
+static void player_light1(void)
+{
+	pmove.client_nextthink = pmove.client_time + 0.1;
+	pmove.client_thinkindex = 2;
+
+	if (!(pmove.cmd.buttons & 1) || pmove.impulse)
+	{
+		player_run();
+		return;
+	}
+
+	player_light_fire();
+}
+
+static void player_light2(void)
+{
+	pmove.client_nextthink = pmove.client_time + 0.1;
+	pmove.client_thinkindex = 1;
+
+	if (!(pmove.cmd.buttons & 1) || pmove.impulse)
+	{
+		player_run();
+		return;
+	}
+
+	player_light_fire();
+}
+
+static void anim_lightning(void)
+{
+	if (pmove.client_thinkindex < 2)
+		player_light1();
+	else
+		player_light2();
+}
+
+static void anim_rocket(void)
+{
+	pmove.client_nextthink = pmove.client_time + 0.1;
+	pmove.weaponframe = pmove.client_thinkindex;
+	pmove.client_thinkindex++;
+	if (pmove.client_thinkindex > 6)
+		pmove.client_thinkindex = 0;
+}
+
+static void anim_shotgun(void)
+{
+	pmove.client_nextthink = pmove.client_time + 0.1;
+	pmove.weaponframe = pmove.client_thinkindex;
+	pmove.client_thinkindex++;
+	if (pmove.client_thinkindex > 6)
+		pmove.client_thinkindex = 0;
+}
+
+static void execute_clientthink(void)
+{
+	if (pmove.client_thinkindex == 0)
+	{
+		player_run();
+		return;
+	}
+
+	switch (pmove.weapon)
+	{
+	case IT_AXE: {
+		anim_axe();
+	} break;
+	case IT_SHOTGUN: {
+		anim_shotgun();
+	} break;
+	case IT_SUPER_SHOTGUN: {
+		anim_shotgun();
+	} break;
+	case IT_NAILGUN: {
+		anim_nailgun();
+	} break;
+	case IT_SUPER_NAILGUN: {
+		anim_nailgun();
+	} break;
+	case IT_GRENADE_LAUNCHER: {
+		anim_rocket();
+	} break;
+	case IT_ROCKET_LAUNCHER: {
+		anim_rocket();
+	} break;
+	case IT_LIGHTNING: {
+		anim_lightning();
+	} break;
+	case IT_HOOK: {
+		anim_shotgun();
+	} break;
+	}
+}
+
+static void W_Attack(void)
+{
+	if (!W_CheckNoAmmo())
+		return;
+
+	switch (pmove.weapon)
+	{
+	case IT_AXE: {
+		int temp;
+		float r;
+
+		pmove.attack_finished = pmove.client_time + 0.5;
+		PM_SoundEffect_Weapon(cl_sfx_ax1, 1, 2);
+
+		// crude deterministic substitute for the server's random() swing choice
+		temp = (((int)(pmove.client_time * 931.75) << 11) + ((int)(pmove.client_time) >> 6)) % 1000;
+		r = abs(temp) / 1000.0;
+		if (r < 0.25)
+			pmove.weaponframe = 0;
+		else if (r < 0.5)
+			pmove.weaponframe = 4;
+		else if (r < 0.75)
+			pmove.weaponframe = 0;
+		else
+			pmove.weaponframe = 4;
+
+		pmove.client_thinkindex = 1;
+		anim_axe();
+	} break;
+	case IT_SHOTGUN: {
+		if (pmove.client_predflags & PRDFL_COILGUN)
+		{
+			if (pmove.client_predflags & PRDFL_MIDAIR)
+				pmove.attack_finished = pmove.client_time + 0.7;
+			else
+				pmove.attack_finished = pmove.client_time + 0.5;
+			PM_SoundEffect_Weapon(cl_sfx_coil, 1, 4);
+		}
+		else
+		{
+			pmove.current_ammo = pmove.ammo_shells -= 1;
+			pmove.attack_finished = pmove.client_time + 0.5;
+			PM_SoundEffect_Weapon(cl_sfx_sg, 1, 4);
+		}
+
+		pmove.client_thinkindex = 1;
+		anim_shotgun();
+	} break;
+	case IT_SUPER_SHOTGUN: {
+		pmove.attack_finished = pmove.client_time + 0.7;
+		PM_SoundEffect_Weapon(cl_sfx_ssg, 1, 8);
+		pmove.current_ammo = pmove.ammo_shells -= 1;
+		pmove.client_thinkindex = 1;
+		anim_shotgun();
+	} break;
+	case IT_NAILGUN: {
+		anim_nailgun();
+	} break;
+	case IT_SUPER_NAILGUN: {
+		anim_nailgun();
+	} break;
+	case IT_GRENADE_LAUNCHER: {
+		prediction_event_fakeproj_t *newmis;
+
+		pmove.attack_finished = pmove.client_time + 0.6;
+		pmove.current_ammo = pmove.ammo_rockets -= 1;
+		PM_SoundEffect_Weapon(cl_sfx_gl, 1, 64);
+
+		newmis = PM_AddEvent_FakeProj(IT_GRENADE_LAUNCHER);
+		if (newmis)
+		{
+			vec3_t forward, right, up;
+			AngleVectors(pmove.cmd.angles, forward, right, up);
+
+			newmis->velocity[0] = forward[0] * 600 + up[0] * 200;
+			newmis->velocity[1] = forward[1] * 600 + up[1] * 200;
+			newmis->velocity[2] = forward[2] * 600 + up[2] * 200;
+
+			VectorCopy(pmove.origin, newmis->origin);
+
+			vectoangles(newmis->velocity, newmis->angles);
+			VectorSet(newmis->avelocity, 300, 300, 300);
+		}
+
+		pmove.client_thinkindex = 1;
+		anim_rocket();
+	} break;
+	case IT_ROCKET_LAUNCHER: {
+		prediction_event_fakeproj_t *newmis;
+
+		pmove.attack_finished = pmove.client_time + 0.8;
+		pmove.current_ammo = pmove.ammo_rockets -= 1;
+		PM_SoundEffect_Weapon(cl_sfx_rl, 1, 128);
+
+		newmis = PM_AddEvent_FakeProj(IT_ROCKET_LAUNCHER);
+		if (newmis)
+		{
+			vec3_t forward;
+			AngleVectors(pmove.cmd.angles, forward, NULL, NULL);
+
+			if (pmove.client_predflags & PRDFL_MIDAIR)
+			{
+				VectorScale(forward, 2000, newmis->velocity);
+			}
+			else
+			{
+				VectorScale(forward, 1000, newmis->velocity);
+			}
+
+			VectorCopy(pmove.origin, newmis->origin);
+			newmis->origin[0] += forward[0] * 8;
+			newmis->origin[1] += forward[1] * 8;
+			newmis->origin[2] += 16 + forward[2] * 8;
+
+			VectorCopy(pmove.cmd.angles, newmis->angles);
+			newmis->angles[0] = -newmis->angles[0];
+		}
+
+		pmove.client_thinkindex = 1;
+		anim_rocket();
+	} break;
+	case IT_LIGHTNING: {
+		PM_SoundEffect_Weapon(cl_sfx_lg, 0, 256);
+		anim_lightning();
+	} break;
+	case IT_HOOK: {
+		pmove.attack_finished = pmove.client_time + 0.1;
+	} break;
+	}
+}
+
+void PM_PlayerWeapon(void)
+{
+	// run this regardless because it sets our model, don't want any ugly prediction errors
+	W_SetCurrentAmmo();
+
+	if (pmove.pm_type == PM_DEAD || pmove.pm_type == PM_NONE || pmove.pm_type == PM_LOCK)
+	{
+		pmove.impulse = 0;
+		pmove.attack_finished = pmove.client_time + 0.05;
+		pmove.effect_frame = 0;
+		W_SetCurrentAmmo();
+		return;
+	}
+
+	pmove.client_time += (float)pmove.cmd.msec / 1000;
+
+	if (pmove.cmd.impulse_pred)
+		pmove.impulse = pmove.cmd.impulse_pred;
+
+	if ((pmove.client_time > pmove.attack_finished) && (pmove.current_ammo == 0)
+		&& (pmove.weapon != IT_AXE) && (pmove.weapon != IT_HOOK))
+	{
+		pmove.weapon = W_BestWeapon();
+		W_SetCurrentAmmo();
+	}
+
+	if (pmove.client_nextthink && pmove.client_time >= pmove.client_nextthink)
+	{
+		float held_client_time = pmove.client_time;
+
+		pmove.client_time = pmove.client_nextthink;
+		pmove.client_nextthink = 0;
+		execute_clientthink();
+		pmove.client_time = held_client_time;
+	}
+
+	if (pmove.client_time >= pmove.attack_finished)
+	{
+		ImpulseCommands();
+
+		if (pmove.cmd.buttons & 1 && key_dest == key_game)
+		{
+			W_Attack();
+			W_SetCurrentAmmo();
+		}
+	}
+}
+
+#endif // MVD_PEXT1_WEAPONPREDICTION

--- a/src/snd_main.c
+++ b/src/snd_main.c
@@ -402,6 +402,9 @@ static void S_Restart_f (void)
 	S_Startup();
 
 	CL_InitTEnts();
+#ifdef MVD_PEXT1_WEAPONPREDICTION
+	CL_InitWepSounds();
+#endif
 	for (i=1; i < MAX_SOUNDS; i++) {
 
 		if (!cl.sound_name[i][0])


### PR DESCRIPTION
Client-side port of unezquake's "antilag 1" prediction prototype, intended as a stopgap until a CSQC-defined antilag replaces it. The unezquake implementation serves as the specification; logic was verified function-by-function to be behavior-equivalent.

## Protocol extensions

The three extension defines cannot live in qwprot's `protocol.h` (shared with mvdsv, server side not included here), so a new `ANTILAG` CMake option (default `ON`) supplies them from the compile command:

- **`MVD_PEXT1_WEAPONPREDICTION`** — the server appends the local player's weapon simulation state (weapon, ammo, attack timing, think state, ping, prediction flags) to `PF_WEAPONFRAME` updates, and the client re-runs QuakeC-style weapon logic (`pmove_weapon.c`) for every unacknowledged input frame on top of movement prediction. Predicted effects are queued and replayed slightly delayed so mispredictions can be corrected: weapon sounds, nails/grenades/rockets as locally simulated "fake projectiles", lightning beams, and the jump sound. The matching server-sent sounds/beam are suppressed while predicting, the view weapon model and animation follow the predicted state (including the `PRDFL_COILGUN` remap), and prediction errors decay smoothly instead of snapping.
- **`MVD_PEXT1_SIMPLEPROJECTILE`** — the server streams projectiles as lightweight stateless updates (`svc_packetsprojectiles`) that the client flies locally instead of lerping networked entities, merging them with its own predicted projectiles by owner and proximity so a predicted rocket seamlessly becomes the server's.
- **`FTE_PEXT_ACCURATETIMINGS`** — already wired but dormant in the codebase; the define activates it and a new `cl_pext_accuratetimings` cvar (default `1`) replaces the old `cl_pext_other` gating so it is on by default and individually controllable.

With `ANTILAG=OFF` the build is functionally identical to master; everything is `#ifdef`-gated.

## Runtime control

Negotiation: `cl_pext_weaponprediction`, `cl_pext_simpleprojectiles`, `cl_pext_accuratetimings` (all default `1`; extensions only activate on supporting servers). Behavior: `cl_nopred_weapon` (master kill switch, servers can also force off per player via `PRDFL_FORCEOFF`), `cl_predict_weaponsound` (bitmask), `cl_predict_projectiles`, `cl_predict_beam`, `cl_predict_jump`, `cl_predict_buffer` (effect delay in frames), `cl_predict_smoothview`, `cl_sproj_xerp`. All documented in the help JSON. A new `pext_list` command prints the extensions that survived negotiation, to verify what is actually active.

## Differences from the unezquake prototype

- Prediction-event lists are freed without leaking; dead code is not ported (predicted-explosion knockback subsystem, `pmove_playeffects`, never-set `last_frame`, the disabled `clc_ackframe` path and its bookkeeping, the commented-out legacy delta parser).
- Jump-sound prediction and smoothview are additionally gated on the negotiated extension, so vanilla-server behavior is untouched even in antilag builds.
- A `msg_badread` guard in the simple-projectile parser turns a truncated message into a `Host_Error` instead of an infinite loop, and projectile/prediction state (`cs_sprojectiles`, `PRDFL_*` flags) is reset on map change/reconnect.
- The weapon simulation lives in a new `pmove_weapon.c` rather than appended to `pmove.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
