### PR TITLE
Fix r_drawflat destroying alpha cutout on brush-model fence surfaces

### DIFF
--- a/src/glc_brushmodel.c
+++ b/src/glc_brushmodel.c
@@ -1514,7 +1514,6 @@ void GLC_ChainBrushModelSurfaces(model_t* clmodel, entity_t* ent)
 	qbool drawFlatFloors = clmodel->isworldmodel && (r_drawflat.integer == 2 || r_drawflat.integer == 1) && r_drawflat_mode.integer == 0;
 	qbool drawFlatWalls = clmodel->isworldmodel && (r_drawflat.integer == 3 || r_drawflat.integer == 1) && r_drawflat_mode.integer == 0;
 	extern msurface_t* skychain;
-	extern msurface_t* alphachain;
 
 	psurf = &clmodel->surfaces[clmodel->firstmodelsurface];
 	for (i = 0; i < clmodel->nummodelsurfaces; i++, psurf++) {
@@ -1543,7 +1542,13 @@ void GLC_ChainBrushModelSurfaces(model_t* clmodel, entity_t* ent)
 				GLC_EmitWaterPoly(psurf);
 			}
 			else if (psurf->flags & SURF_DRAWALPHA) {
-				CHAIN_SURF_B2F(psurf, alphachain);
+				// Chain onto the per-texture chain for the alpha pass; the global
+				// alphachain is never drawn for brush models.
+				CHAIN_SURF_B2F(psurf, psurf->texinfo->texture->texturechain);
+				clmodel->alphapass_todo = true;
+				clmodel->texturechains_have_lumas |= R_TextureAnimation(ent, psurf->texinfo->texture)->isLumaTexture;
+				clmodel->first_texture_chained = min(clmodel->first_texture_chained, psurf->texinfo->miptex);
+				clmodel->last_texture_chained = max(clmodel->last_texture_chained, psurf->texinfo->miptex);
 			}
 			else {
 				if (drawFlatFloors && isFloor) {

--- a/src/glm_brushmodel.c
+++ b/src/glm_brushmodel.c
@@ -161,11 +161,15 @@ void GLM_ChainBrushModelSurfaces(model_t* clmodel, entity_t* ent)
 			clmodel->last_texture_chained = max(clmodel->last_texture_chained, psurf->texinfo->miptex);
 		}
 		else {
-			if (drawFlatFloors && (psurf->flags & SURF_DRAWFLAT_FLOOR)) {
+			// Keep alpha-tested (fence) surfaces out of the drawflat chain, which is
+			// drawn without alpha test; the texture chain still applies the drawflat tint.
+			qbool alphaSurface = (psurf->flags & SURF_DRAWALPHA);
+
+			if (!alphaSurface && drawFlatFloors && (psurf->flags & SURF_DRAWFLAT_FLOOR)) {
 				chain_surfaces_simple_drawflat(&clmodel->drawflat_chain, psurf);
 				clmodel->drawflat_todo = true;
 			}
-			else if (drawFlatWalls && !(psurf->flags & SURF_DRAWFLAT_FLOOR)) {
+			else if (!alphaSurface && drawFlatWalls && !(psurf->flags & SURF_DRAWFLAT_FLOOR)) {
 				chain_surfaces_simple_drawflat(&clmodel->drawflat_chain, psurf);
 				clmodel->drawflat_todo = true;
 			}


### PR DESCRIPTION
With `r_drawflat 1`, fence/`{`-textured surfaces on inline brush-model entities (e.g. `func_illusionary` palm-tree leaves) rendered as solid flat-coloured rectangles instead of keeping their alpha-cutout silhouette.

Inline submodels inherit `isworldmodel` from the world model, so the renderers enabled the drawflat chains for them and routed their alpha-tested surfaces down paths that drop the alpha test:

- **GLM**: the surfaces went into `drawflat_chain`, drawn with the non-alpha-tested program. Fix: exclude `SURF_DRAWALPHA` surfaces from the drawflat chain (mirroring the world path); they fall through to the texture chain, which still applies the drawflat tint but keeps the silhouette.
- **GLC**: the surfaces were chained onto the global `alphachain`, which `GLC_DrawBrushModel` never draws, so they were missing entirely regardless of `r_drawflat`. Fix: chain them onto the per-texture `texturechain` and flag `alphapass_todo` so the existing alpha pass renders them.

`isworldmodel` inheritance is intentionally untouched — it is what makes the flat tint apply to brush entities at all.

Tested in both renderers: `r_drawflat 0` unchanged; `r_drawflat 1` gives single colour + lightmap with intact leaf silhouettes; GLC now draws the previously missing surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
