### PR TITLE
Feature/colorize f version f system

### DIFF
--- a/src/fchecks.c
+++ b/src/fchecks.c
@@ -25,6 +25,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "fmod.h"
 #include "utils.h"
 
+// Compile-time platform color for f_version display
+#if defined(_WIN32)
+#define QW_PLATFORM_COLOR "&c4af"   // light blue  - Windows
+#elif defined(__linux__)
+#define QW_PLATFORM_COLOR "&cfa0"   // orange      - Linux
+#elif defined(__APPLE__)
+#define QW_PLATFORM_COLOR "&caaa"   // silver      - macOS
+#else
+#define QW_PLATFORM_COLOR "&c888"   // gray        - other
+#endif
+
 
 static float
 f_system_reply_time,
@@ -53,8 +64,8 @@ extern cvar_t cl_iDrive;
 static void FChecks_VersionResponse (void)
 {
 	// {} required for color codes to render in QW chat
-	// ice white (&ccef) for ezQuake, cyan (&c0ff) for version, gray (&c888) for platform
-	Cbuf_AddText(va("say {&ccefezQuake&r &c0ff%s&r &c888%s:%s&r}\n",
+	// ice white for ezQuake, cyan for version, platform color varies by OS, gray for renderer
+	Cbuf_AddText(va("say {&ccefezQuake&r &c0ff%s&r " QW_PLATFORM_COLOR "%s&r:&c888%s&r}\n",
 		VersionString(), QW_PLATFORM, QW_RENDERER));
 }
 
@@ -250,6 +261,18 @@ const char* FChecks_RulesetAdditionString(void)
 	return features;
 }
 
+// Color per ruleset reflects permissiveness: gray=open, yellow=competitive, orange=strict, red=tournament
+static const char *FChecks_RulesetColor(const char *ruleset)
+{
+	if (!strcmp(ruleset, "default"))     return "&caaa"; // gray        - no restrictions
+	if (!strcmp(ruleset, "smackdown"))   return "&cff0"; // yellow      - standard competitive
+	if (!strcmp(ruleset, "smackdrive"))  return "&caf0"; // lime        - smackdown + iDrive
+	if (!strcmp(ruleset, "thunderdome")) return "&cfa0"; // orange      - strict tournament
+	if (!strcmp(ruleset, "MTFL"))        return "&cf80"; // orange-red  - league rules
+	if (!strcmp(ruleset, "qcon"))        return "&cf44"; // red         - QuakeCon / strictest
+	return "&caaa";
+}
+
 static qbool FChecks_CheckFRulesetRequest (const char *s)
 {
 	// format of the reply:
@@ -280,8 +303,10 @@ static qbool FChecks_CheckFRulesetRequest (const char *s)
 			fServer = "server-na";
 		}
 
-		Cbuf_AddText(va("say \"%*s%21s %16s %s%s\"\n",
-			pad_len, emptystring, fServer, brief_version, ruleset, features));
+		// {} required for color codes; ruleset colored by strictness level
+		Cbuf_AddText(va("say \"{%*s%21s %16s %s%s&r%s}\"\n",
+			pad_len, emptystring, fServer, brief_version,
+			FChecks_RulesetColor(ruleset), ruleset, features));
 		f_ruleset_reply_time = cls.realtime;
 		return true;
 	}

--- a/src/fchecks.c
+++ b/src/fchecks.c
@@ -52,7 +52,10 @@ extern cvar_t cl_iDrive;
 
 static void FChecks_VersionResponse (void)
 {
-	Cbuf_AddText (va("say ezQuake %s " QW_PLATFORM ":" QW_RENDERER "\n", VersionString()));
+	// {} required for color codes to render in QW chat
+	// ice white (&ccef) for ezQuake, cyan (&c0ff) for version, gray (&c888) for platform
+	Cbuf_AddText(va("say {&ccefezQuake&r &c0ff%s&r &c888%s:%s&r}\n",
+		VersionString(), QW_PLATFORM, QW_RENDERER));
 }
 
 static char *FChecks_FServerResponse_Text(void)
@@ -336,11 +339,8 @@ static qbool FChecks_SystemRequest (const char *s)
 
 		sys_string = (allow_f_system.integer) ? SYSINFO_GetString() : "disabled";
 
-		//if (sys_string != NULL && sys_string[0]) {
-		Cbuf_AddText("say ");
-		Cbuf_AddText(sys_string);
-		Cbuf_AddText("\n");
-		//}
+		// {} required for color codes to render in QW chat
+		Cbuf_AddText(va("say {%s}\n", sys_string));
 
 		f_system_reply_time = cls.realtime;
 		return true;

--- a/src/fmod.c
+++ b/src/fmod.c
@@ -655,5 +655,12 @@ char *FMod_Response_Text(void)
 
 void FMod_Response (void)
 {
-	Cbuf_AddText (va ("%s %s\n", cls.state == ca_disconnected ? "echo" : "say", FMod_Response_Text()));
+	const char *text = FMod_Response_Text();
+	const char *cmd  = cls.state == ca_disconnected ? "echo" : "say";
+
+	// {} required for color codes; green = clean, red = modified files detected
+	if (strcmp(text, "all models ok") == 0)
+		Cbuf_AddText(va("%s {&c0f0%s&r}\n", cmd, text));
+	else
+		Cbuf_AddText(va("%s {&cf00%s&r}\n", cmd, text));
 }

--- a/src/host.c
+++ b/src/host.c
@@ -65,15 +65,86 @@ extern void COM_StoreOriginalCmdline(int argc, char **argv);
 
 char f_system_string[1024] = "";
 
-char * SYSINFO_GetString(void)
-{
-	return f_system_string;
-}
-
 unsigned long long	SYSINFO_memory = 0;
 int					SYSINFO_MHz = 0;
 char				*SYSINFO_processor_description = NULL;
 char				*SYSINFO_3D_description        = NULL;
+
+static char f_system_string_colored[512];
+
+static int SYSINFO_ContainsStr(const char *haystack, const char *needle)
+{
+	char h[256], n[64];
+	int i;
+	for (i = 0; haystack[i] && i < (int)sizeof(h)-1; i++)
+		h[i] = (haystack[i] >= 'A' && haystack[i] <= 'Z') ? haystack[i]+32 : haystack[i];
+	h[i] = '\0';
+	for (i = 0; needle[i] && i < (int)sizeof(n)-1; i++)
+		n[i] = (needle[i] >= 'A' && needle[i] <= 'Z') ? needle[i]+32 : needle[i];
+	n[i] = '\0';
+	return strstr(h, n) != NULL;
+}
+
+// Returns f_system string with vendor color codes for chat display.
+// CPU: Intel=blue(&c06f) AMD/Ryzen=red(&cf00)
+// GPU: NVIDIA/GeForce/RTX/GTX=green(&c0f0) AMD/Radeon=red(&cf00) Intel=blue(&c06f)
+char * SYSINFO_GetString(void)
+{
+	char cpu_colored[256] = {0};
+	char gpu_colored[256] = {0};
+	char mem_part[32] = {0};
+	const char *cpu = SYSINFO_processor_description ? SYSINFO_processor_description : "";
+	const char *gpu = SYSINFO_3D_description ? SYSINFO_3D_description : "";
+
+	if (cpu[0]) {
+		if (SYSINFO_ContainsStr(cpu, "Intel"))
+			snprintf(cpu_colored, sizeof(cpu_colored), "&c06f%s&r", cpu);
+		else if (SYSINFO_ContainsStr(cpu, "AMD") || SYSINFO_ContainsStr(cpu, "Ryzen"))
+			snprintf(cpu_colored, sizeof(cpu_colored), "&cf00%s&r", cpu);
+		else
+			strlcpy(cpu_colored, cpu, sizeof(cpu_colored));
+	}
+
+	if (gpu[0]) {
+		if (SYSINFO_ContainsStr(gpu, "NVIDIA") || SYSINFO_ContainsStr(gpu, "GeForce") ||
+		    SYSINFO_ContainsStr(gpu, "RTX") || SYSINFO_ContainsStr(gpu, "GTX"))
+			snprintf(gpu_colored, sizeof(gpu_colored), "&c0f0%s&r", gpu);
+		else if (SYSINFO_ContainsStr(gpu, "AMD") || SYSINFO_ContainsStr(gpu, "Radeon") ||
+		         SYSINFO_ContainsStr(gpu, "RX "))
+			snprintf(gpu_colored, sizeof(gpu_colored), "&cf00%s&r", gpu);
+		else if (SYSINFO_ContainsStr(gpu, "Intel"))
+			snprintf(gpu_colored, sizeof(gpu_colored), "&c06f%s&r", gpu);
+		else
+			strlcpy(gpu_colored, gpu, sizeof(gpu_colored));
+	}
+
+	{
+		char tmp[sizeof(f_system_string)];
+		char *comma;
+		strlcpy(tmp, f_system_string, sizeof(tmp));
+		comma = strchr(tmp, ',');
+		if (comma) *comma = '\0';
+		strlcpy(mem_part, tmp, sizeof(mem_part));
+	}
+
+	f_system_string_colored[0] = '\0';
+	strlcat(f_system_string_colored, mem_part, sizeof(f_system_string_colored));
+	if (cpu_colored[0]) {
+		strlcat(f_system_string_colored, ", ", sizeof(f_system_string_colored));
+		strlcat(f_system_string_colored, cpu_colored, sizeof(f_system_string_colored));
+		if (SYSINFO_MHz)
+			strlcat(f_system_string_colored, va(" (%dMHz)", SYSINFO_MHz), sizeof(f_system_string_colored));
+	}
+	if (gpu_colored[0]) {
+		strlcat(f_system_string_colored, ", ", sizeof(f_system_string_colored));
+		strlcat(f_system_string_colored, gpu_colored, sizeof(f_system_string_colored));
+	}
+
+	if (!f_system_string_colored[0])
+		return f_system_string;
+
+	return f_system_string_colored;
+}
 
 static void SYSINFO_Shutdown(void)
 {


### PR DESCRIPTION
# 🎨 fchecks/fmod: add color markup to f_version, f_system, f_modified and f_ruleset responses

This PR adds `{...}` color markup to four f-check chat responses, making it easier for players to quickly read and understand the information at a glance. All color codes use the existing QW `{...}` bracket syntax already supported by ezQuake. The plain `f_system_string` used for demo XML metadata is preserved unchanged.

---

## 📋 f_version

The response is now split into visually distinct segments so players can immediately identify the client, version, platform and renderer:

| Segment | Color | Code |
|---|---|---|
| `ezQuake` label | ice white | `&ccef` |
| version number | cyan | `&c0ff` |
| platform (Windows) | light blue | `&c4af` |
| platform (Linux) | orange | `&cfa0` |
| platform (macOS) | silver | `&caaa` |
| renderer | gray | `&c888` |

Platform color is resolved at **compile time** via a `QW_PLATFORM_COLOR` preprocessor macro, so there is no runtime branching.

**Before:**
```
ezQuake 3.6.9-102-ge346316a Win64:GL
```
**After:**
```
{&ccefezQuake&r &c0ff3.6.9-102-ge346316a&r &c4afWin64&r:&c888GL&r}
```

---

## 🖥️ f_system

CPU and GPU vendor names are now color-coded so players can quickly identify hardware at a glance without reading the full string:

| Vendor | Color | Code |
|---|---|---|
| Intel CPU or GPU | blue | `&c06f` |
| AMD / Ryzen CPU | red | `&cf00` |
| AMD / Radeon GPU | red | `&cf00` |
| NVIDIA / GeForce / RTX / GTX GPU | green | `&c0f0` |
| Unknown vendor | plain text | — |

A case-insensitive helper `SYSINFO_ContainsStr()` handles all capitalization variants (e.g. `AMD`, `Amd`, `amd`).

The colorized output is built in a **separate buffer** inside `SYSINFO_GetString()`. The original `f_system_string` remains plain text and continues to be used by `cl_demo.c` for demo XML metadata without any color code pollution.

**Example output:**
```
{16384MiB, &c06fIntel(R) Core(TM) i7-9700K CPU @ 3.60GHz&r (3601MHz), &c0f0NVIDIA GeForce RTX 2080&r}
```

---

## 🔍 f_modified

The response now uses color to make the result immediately obvious without players having to read the full message:

| Result | Color | Code | Meaning |
|---|---|---|---|
| `all models ok` | 🟢 green | `&c0f0` | Install is clean, no modifications detected |
| `modified: <files>` | 🔴 red | `&cf00` | One or more model/sound files were modified |

Works correctly in both connected (`say`) and disconnected (`echo`) states.

**Before:**
```c
Cbuf_AddText(va("%s %s\n", cmd, FMod_Response_Text()));
```
**After:**
```c
if (strcmp(text, "all models ok") == 0)
    Cbuf_AddText(va("%s {&c0f0%s&r}\n", cmd, text));
else
    Cbuf_AddText(va("%s {&cf00%s&r}\n", cmd, text));
```

---

## ⚖️ f_ruleset

The ruleset name is now colored to reflect its **permissiveness level**, giving players an immediate visual indication of what is and isn't allowed on the server — from most open (gray) to most restrictive (red):

| Ruleset | Color | Level | Notes |
|---|---|---|---|
| `default` | ⬜ gray `&caaa` | No restrictions | All features allowed |
| `smackdown` | 🟡 yellow `&cff0` | Standard competitive | Movement scripts, model check active |
| `smackdrive` | 🟢 lime `&caf0` | Smackdown + iDrive | Like smackdown but side-step aid allowed |
| `thunderdome` | 🟠 orange `&cfa0` | Strict tournament | Tighter restrictions than smackdown |
| `MTFL` | 🟠 orange-red `&cf80` | League rules | MTFL competition ruleset |
| `qcon` | 🔴 red `&cf44` | QuakeCon / strictest | Most restrictive tournament ruleset |

A small helper `FChecks_RulesetColor()` maps ruleset name → color code, keeping the logic in one place and easy to update if new rulesets are added.

**Before:**
```c
Cbuf_AddText(va("say \"%*s%21s %16s %s%s\"\n",
    pad_len, emptystring, fServer, brief_version, ruleset, features));
```
**After:**
```c
Cbuf_AddText(va("say \"{%*s%21s %16s %s%s&r%s}\"\n",
    pad_len, emptystring, fServer, brief_version,
    FChecks_RulesetColor(ruleset), ruleset, features));
```

---

## 📁 Files changed

| File | What changed |
|---|---|
| `src/host.c` | Added `SYSINFO_ContainsStr()` case-insensitive helper and rewrote `SYSINFO_GetString()` to return a colorized string with vendor detection |
| `src/fchecks.c` | Added `QW_PLATFORM_COLOR` compile-time macro, `FChecks_RulesetColor()` helper, updated `f_version`, `f_system` and `f_ruleset` response formatting |
| `src/fmod.c` | Updated `FMod_Response()` to use green/red color markup based on whether modifications are detected |

---

## ✅ Notes

- All changes use the `{...}` wrapper already supported by ezQuake for colored chat output
- No new cvars, no behavioral changes — purely cosmetic output improvements
- Backward compatible: servers and clients that do not support color codes will display the raw `&c` sequences, which is the same behavior as any other colored ezQuake output
- The `f_system_string` plain buffer is preserved for internal uses (demo XML metadata via `cl_demo.c`)
