### PR TITLE
Change server snapshot size to screen resolution

### DIFF
--- a/src/cl_screenshot.c
+++ b/src/cl_screenshot.c
@@ -330,7 +330,7 @@ void SCR_RSShot_f(void)
 	
 	snprintf(filename, sizeof(filename), "%s/temp/__rsshot__", Sshot_SshotDirectory());
 
-	width = 800; height = 600;
+	width = glwidth; height = glheight;
 	base = (byte *)Q_malloc((width * height + glwidth * glheight) * 3);
 	pixels = base + glwidth * glheight * 3;
 
@@ -362,7 +362,6 @@ void SCR_RSShot_f(void)
 
 	remove(filename);
 }
-
 qbool SCR_TakingAutoScreenshot(void)
 {
 	return scr_autosshot_countdown > 0;


### PR DESCRIPTION
Users are reporting that details are poorly visible on a screenshot with an 800x600 resolution for 4k as example.