### PR TITLE
Skip QVM probe when PR1 is selected explicitly

### DIFF
--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -424,6 +424,12 @@ void PR2_UnLoadProgs(void)
 //===========================================================================
 void PR2_LoadProgs(void)
 {
+	if (sv_progtype.integer == VMI_NONE)
+	{
+		PR1_LoadProgs();
+		return;
+	}
+
 	sv_vm = VM_Create(VM_GAME, sv_progsname.string, PR2_GameSystemCalls, sv_progtype.value );
 
 	if ( sv_vm )


### PR DESCRIPTION
## Summary

When `sv_progtype` explicitly selects PR1 (`VMI_NONE`), load `qwprogs.dat`
directly instead of probing for a QVM first.

## Root cause

`PR2_LoadProgs()` always called `VM_Create()`, including when the selected VM
type was `VMI_NONE`. `VM_Create()` therefore tried the QVM path, printed a
failure, and only then allowed `PR2_LoadProgs()` to fall back to
`PR1_LoadProgs()`.

This made a successful PR1 startup look broken. For example, starting a local
legacy mod with `+sv_progtype 0` printed:

```text
Loading vm file x86qw_fortress.qvm...
Failed.
```

The engine then loaded `fortress/qwprogs.dat` and the mod worked normally.

## Change

Return through `PR1_LoadProgs()` before `VM_Create()` whenever
`sv_progtype.integer == VMI_NONE`. Native and QVM modes keep their existing
probe and fallback behavior.

## Validation

- Reproduced with ezQuake 3.6.9 and nightly
  `20260616-101233_a86996a` using PR1 gamecode from Final Arena, Pro-X,
  Team Fortress 2.9 and Total Destruction 2 2.22.
- All four mods loaded and accepted a player after the misleading QVM failure,
  confirming that PR1 was the selected and functioning path.
- Verified the patch is limited to the explicit `VMI_NONE` branch and passes
  `git diff --check`.
- A local full build was not run because CMake is not installed on the test
  host; repository CI is expected to compile all supported targets.

No gameplay or protocol behavior is changed.
