### PR TITLE
Make video-restart registrations idempotent

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1290,7 +1290,10 @@ void Cmd_AddCommand (char *cmd_name, xcommand_t function)
 	// fail if the command already exists
 	for (cmd = cmd_hash_array[key]; cmd; cmd=cmd->hash_next) {
 		if (!strcasecmp (cmd_name, cmd->name)) {
-			Com_Printf ("Cmd_AddCommand: %s already defined\n", cmd_name);
+			// Renderer restarts may register the same static command again.
+			if (cmd->function != function) {
+				Com_Printf ("Cmd_AddCommand: %s already defined\n", cmd_name);
+			}
 			return;
 		}
 	}

--- a/src/cvar.c
+++ b/src/cvar.c
@@ -380,6 +380,11 @@ void Cvar_Register(cvar_t *var)
 			return;
 		}
 
+		// Renderer restarts may register the same static cvar again.
+		if (old == var) {
+			return;
+		}
+
 		// warn if CVAR_SILENT is not set
 		if (!(old->flags & CVAR_SILENT)) {
 			Com_Printf("Can't register variable %s, already defined\n", var->name);


### PR DESCRIPTION
## Summary

Keep duplicate-registration diagnostics for real name collisions, but make
registration idempotent when a video restart registers the exact same static
cvar or command again.

## Root cause

`vid_restart` rebuilds renderer-related state and invokes initialization paths
that call `Cvar_Register()` and `Cmd_AddCommand()` again. The existing objects
remain registered, so a normal restart emits hundreds of messages such as:

```text
Can't register variable <name>, already defined
Cmd_AddCommand: <name> already defined
```

In the reproduced first-start path, one preset-triggered `vid_restart` emitted
291 duplicate-registration lines even though startup and gameplay completed
successfully.

## Change

- `Cvar_Register()` silently returns only when the existing cvar is the exact
  same object. Latched cvars retain their existing apply/reset path.
- `Cmd_AddCommand()` silently returns only when the existing command has the
  same name and function pointer.
- Different cvar objects and different command handlers with the same name keep
  the existing warnings.

This deliberately does not add a broad log suppression flag.

## Validation

- Reproduced on ezQuake 3.6.9 and nightly
  `20260616-101233_a86996a` with a preset-triggered `vid_restart`.
- Confirmed the 291 lines are registration diagnostics: they disappear after
  the first normal shutdown because the preset no longer requests the restart.
- Audited the conditions so only identity-equivalent registrations are silent;
  actual collisions continue through the previous warning paths.
- `git diff --check` passes.
- A local full build was not run because CMake is not installed on the test
  host; repository CI is expected to compile all supported targets.

The change does not alter cvar values, command handlers, rendering or gameplay.
